### PR TITLE
news feature #1450

### DIFF
--- a/src/zcl_abapgit_news.clas.abap
+++ b/src/zcl_abapgit_news.clas.abap
@@ -47,6 +47,11 @@ CLASS zcl_abapgit_news DEFINITION
     DATA mv_lastseen_version TYPE string .
     DATA mv_latest_version TYPE string .
 
+    CLASS-METHODS is_relevant
+      IMPORTING
+        !iv_url            TYPE string
+      RETURNING
+        VALUE(rv_relevant) TYPE abap_bool .
     METHODS latest_version
       RETURNING
         VALUE(rv_version) TYPE string .
@@ -156,8 +161,7 @@ CLASS ZCL_ABAPGIT_NEWS IMPLEMENTATION.
     lo_repo_online ?= io_repo.
     lv_url          = lo_repo_online->get_url( ).
 
-    " News announcement temporary restricted to abapGit only
-    IF lv_url NS '/abapGit.git'. " TODO refactor
+    IF is_relevant( lv_url ) = abap_false.
       RETURN.
     ENDIF.
 
@@ -172,7 +176,6 @@ CLASS ZCL_ABAPGIT_NEWS IMPLEMENTATION.
 
     READ TABLE lt_remote ASSIGNING <ls_file>
       WITH KEY path = lc_log_path filename = lc_log_filename.
-
     IF sy-subrc = 0.
       CREATE OBJECT ro_instance
         EXPORTING
@@ -218,6 +221,16 @@ CLASS ZCL_ABAPGIT_NEWS IMPLEMENTATION.
       iv_a = mv_latest_version
       iv_b = mv_current_version ) > 0 ).
   ENDMETHOD.                    "has_updates
+
+
+  METHOD is_relevant.
+
+    " News announcement restricted to abapGit only
+    IF iv_url CS '/abapGit' OR iv_url CS '/abapGit.git'.
+      rv_relevant = abap_true.
+    ENDIF.
+
+  ENDMETHOD.
 
 
   METHOD latest_version.

--- a/src/zcl_abapgit_news.clas.testclasses.abap
+++ b/src/zcl_abapgit_news.clas.testclasses.abap
@@ -1,5 +1,60 @@
 *"* use this source file for your ABAP unit test classes
 
+CLASS ltcl_relevant DEFINITION DEFERRED.
+CLASS zcl_abapgit_news DEFINITION LOCAL FRIENDS ltcl_relevant.
+
+CLASS ltcl_relevant DEFINITION FINAL FOR TESTING RISK LEVEL HARMLESS DURATION SHORT.
+
+  PRIVATE SECTION.
+
+    METHODS:
+      test01 FOR TESTING,
+      test02 FOR TESTING,
+      test03 FOR TESTING.
+
+ENDCLASS.
+
+CLASS ltcl_relevant IMPLEMENTATION.
+
+  METHOD test01.
+
+    DATA: lv_relevant TYPE abap_bool.
+
+    lv_relevant = zcl_abapgit_news=>is_relevant( 'https://github.com/larshp/abapGit.git' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_relevant
+      exp = abap_true ).
+
+  ENDMETHOD.
+
+  METHOD test02.
+
+    DATA: lv_relevant TYPE abap_bool.
+
+    lv_relevant = zcl_abapgit_news=>is_relevant( 'https://github.com/larshp/abapGit' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_relevant
+      exp = abap_true ).
+
+  ENDMETHOD.
+
+  METHOD test03.
+
+    DATA: lv_relevant TYPE abap_bool.
+
+    lv_relevant = zcl_abapgit_news=>is_relevant( 'https://github.com/larshp/something' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_relevant
+      exp = abap_false ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
 CLASS ltcl_news DEFINITION DEFERRED.
 CLASS zcl_abapgit_news DEFINITION LOCAL FRIENDS ltcl_news.
 


### PR DESCRIPTION
news feature #1450

now works for both "/abapGit" and "/abapGit.git" urls