### PR TITLE
Fix handling of T100 exceptions

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -512,8 +512,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
       CATCH zcx_abapgit_exception INTO lx_error.
         zcl_abapgit_default_transport=>get_instance( )->reset( ).
-        lv_text = lx_error->get_text( ).
-        zcx_abapgit_exception=>raise( lv_text ).
+        RAISE EXCEPTION lx_error.
     ENDTRY.
 
     zcl_abapgit_default_transport=>get_instance( )->reset( ).

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -222,7 +222,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
 
   METHOD adjust_namespaces.

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -336,7 +336,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
     ENDIF.
 
     ri_html->add( |<div class="{ lv_class }">| ).
-    ri_html->add( |{ ri_html->icon( 'exclamation-circle/red' ) } Error: { lv_error }| ).
+    ri_html->add( |{ ri_html->icon( 'exclamation-circle/red' ) } { lv_error }| ).
     ri_html->add( '</div>' ).
 
   ENDMETHOD.
@@ -374,7 +374,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
       IN lv_longtext WITH |<h3>$1</h3>|.
 
     ri_html->add( |<div id="message" class="message-panel">| ).
-    ri_html->add( |{ lv_error_text }| ).
+    ri_html->add( |{ ri_html->icon( 'exclamation-circle/red' ) } { lv_error_text }| ).
     ri_html->add( |<div class="float-right">| ).
 
     ri_html->add_a(

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -355,23 +355,23 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     lv_error_text = ix_error->get_text( ).
-    lv_longtext = ix_error->get_longtext( abap_true ).
+    lv_longtext = ix_error->if_message~get_longtext( abap_true ).
 
-    REPLACE FIRST OCCURRENCE OF REGEX |(<br>{ zcl_abapgit_message_helper=>gc_section_text-cause }<br>)|
-            IN lv_longtext
-            WITH |<h3>$1</h3>|.
+    REPLACE FIRST OCCURRENCE OF REGEX
+      |({ zcl_abapgit_message_helper=>gc_section_text-cause }{ cl_abap_char_utilities=>newline })|
+      IN lv_longtext WITH |<h3>$1</h3>|.
 
-    REPLACE FIRST OCCURRENCE OF REGEX |(<br>{ zcl_abapgit_message_helper=>gc_section_text-system_response }<br>)|
-            IN lv_longtext
-            WITH |<h3>$1</h3>|.
+    REPLACE FIRST OCCURRENCE OF REGEX
+      |({ zcl_abapgit_message_helper=>gc_section_text-system_response }{ cl_abap_char_utilities=>newline })|
+      IN lv_longtext WITH |<h3>$1</h3>|.
 
-    REPLACE FIRST OCCURRENCE OF REGEX |(<br>{ zcl_abapgit_message_helper=>gc_section_text-what_to_do }<br>)|
-            IN lv_longtext
-            WITH |<h3>$1</h3>|.
+    REPLACE FIRST OCCURRENCE OF REGEX
+      |({ zcl_abapgit_message_helper=>gc_section_text-what_to_do }{ cl_abap_char_utilities=>newline })|
+      IN lv_longtext WITH |<h3>$1</h3>|.
 
-    REPLACE FIRST OCCURRENCE OF REGEX |(<br>{ zcl_abapgit_message_helper=>gc_section_text-sys_admin }<br>)|
-            IN lv_longtext
-            WITH |<h3>$1</h3>|.
+    REPLACE FIRST OCCURRENCE OF REGEX
+      |({ zcl_abapgit_message_helper=>gc_section_text-sys_admin }{ cl_abap_char_utilities=>newline })|
+      IN lv_longtext WITH |<h3>$1</h3>|.
 
     ri_html->add( |<div id="message" class="message-panel">| ).
     ri_html->add( |{ lv_error_text }| ).

--- a/src/zcl_abapgit_message_helper.clas.testclasses.abap
+++ b/src/zcl_abapgit_message_helper.clas.testclasses.abap
@@ -1,36 +1,39 @@
 CLASS ltcl_get_t100_longtext DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 
   PUBLIC SECTION.
-    INTERFACES if_t100_message.
     METHODS test01 FOR TESTING.
 
 ENDCLASS.
 
 CLASS ltcl_get_t100_longtext IMPLEMENTATION.
 
-  METHOD if_message~get_longtext.
-    RETURN.
-  ENDMETHOD.
-
-  METHOD if_message~get_text.
-    RETURN.
-  ENDMETHOD.
-
   METHOD test01.
 
-    DATA lo_cut TYPE REF TO zcl_abapgit_message_helper.
-    DATA lv_result TYPE string.
+    DATA: lx_err    TYPE REF TO zcx_abapgit_exception,
+          lv_dummy  TYPE string,
+          lv_result TYPE string.
 
-    if_t100_message~t100key-msgid = '00'.
-    if_t100_message~t100key-msgno = '058'.
-    if_t100_message~t100key-attr1 = 'ATTR'.
+    TRY.
+        MESSAGE e058(00) WITH 'Value_1' 'Value_2' 'Value_3' 'Value_4' INTO lv_dummy.
+        zcx_abapgit_exception=>raise_t100( ).
+      CATCH zcx_abapgit_exception INTO lx_err.
+        lv_result = lx_err->get_longtext( ).
+    ENDTRY.
 
-    CREATE OBJECT lo_cut
-      EXPORTING
-        ii_t100_message = me.
-
-    lv_result = lo_cut->get_t100_longtext( ).
     cl_abap_unit_assert=>assert_not_initial( lv_result ).
+
+    IF lv_result NS 'Value_1'.
+      cl_abap_unit_assert=>fail( ).
+    ENDIF.
+    IF lv_result NS 'Value_2'.
+      cl_abap_unit_assert=>fail( ).
+    ENDIF.
+    IF lv_result NS 'Value_3'.
+      cl_abap_unit_assert=>fail( ).
+    ENDIF.
+    IF lv_result NS 'Value_4'.
+      cl_abap_unit_assert=>fail( ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -118,7 +118,7 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD IF_MESSAGE~GET_LONGTEXT.
+  METHOD if_message~get_longtext.
 
     " You should remember that we have to call ZCL_ABAPGIT_MESSAGE_HELPER
     " dynamically, because the compiled abapGit report puts the definition
@@ -133,7 +133,7 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
 
       CREATE OBJECT lo_message_helper TYPE ('ZCL_ABAPGIT_MESSAGE_HELPER')
         EXPORTING
-          ii_t100_message = me.
+          io_exception = me.
 
       CALL METHOD lo_message_helper->('GET_T100_LONGTEXT')
         RECEIVING


### PR DESCRIPTION
Fixes the following issues with handing exceptions based on T100 messages (i.e. when using `zcx_abapgit_exception=>raise_t100( )`):
- Dump TABLE_INVALID_INDEX due to incorrect clearing of empty sections in longtext
- Missing replacement of message variables due to incorrect  `me` reference 
- Missing interface when getting longtext
- Wrong length of rv_target due to change from `exporting ev_target type c` to `returning rv_target type char01`
- A T100 message that was raise during object deletion lost the T100 info and showed up as 00/001 without longtext
- Wrong regex when trying to format longtext

Before:
![image](https://user-images.githubusercontent.com/59966492/94214135-c1f05200-fea6-11ea-8685-086750847e35.png)
Generic error 00/001 and no longtext on hover

After:
![image](https://user-images.githubusercontent.com/59966492/94214202-e5b39800-fea6-11ea-8944-706f5fa8cbba.png)
Correct error number TR/022 and nicely formatted longtext on hover

Caused in part by #3204 and #3658
Closes #3906
