### PR TITLE
Improvements for uninstall

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -501,9 +501,9 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
         RAISE EXCEPTION lx_error.
     ENDTRY.
 
+    lv_count = 1.
     DO 3 TIMES.
       LOOP AT lt_tadir ASSIGNING <ls_tadir>.
-        lv_count = lv_count + 1.
         li_progress->show( iv_current = lv_count
                            iv_text    = |Delete { <ls_tadir>-obj_name }| ).
 
@@ -517,6 +517,7 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
               is_item    = ls_item ).
 
             DELETE lt_tadir.
+            lv_count = lv_count + 1.
 
             " make sure to save object deletions
             COMMIT WORK.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -475,6 +475,7 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           lt_tadir    LIKE it_tadir,
           lt_items    TYPE zif_abapgit_definitions=>ty_items_tt,
           lx_error    TYPE REF TO zcx_abapgit_exception,
+          lv_count    TYPE i,
           lv_text     TYPE string.
 
     FIELD-SYMBOLS: <ls_tadir> LIKE LINE OF it_tadir.
@@ -495,27 +496,42 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
         check_objects_locked( iv_language = zif_abapgit_definitions=>c_english
                               it_items    = lt_items ).
 
-        LOOP AT lt_tadir ASSIGNING <ls_tadir>.
-          li_progress->show( iv_current = sy-tabix
-                             iv_text    = |Delete { <ls_tadir>-obj_name }| ).
-
-          CLEAR ls_item.
-          ls_item-obj_type = <ls_tadir>-object.
-          ls_item-obj_name = <ls_tadir>-obj_name.
-          delete_obj(
-            iv_package = <ls_tadir>-devclass
-            is_item    = ls_item ).
-
-* make sure to save object deletions
-          COMMIT WORK.
-        ENDLOOP.
-
       CATCH zcx_abapgit_exception INTO lx_error.
         zcl_abapgit_default_transport=>get_instance( )->reset( ).
         RAISE EXCEPTION lx_error.
     ENDTRY.
 
+    DO 3 TIMES.
+      LOOP AT lt_tadir ASSIGNING <ls_tadir>.
+        lv_count = lv_count + 1.
+        li_progress->show( iv_current = lv_count
+                           iv_text    = |Delete { <ls_tadir>-obj_name }| ).
+
+        CLEAR ls_item.
+        ls_item-obj_type = <ls_tadir>-object.
+        ls_item-obj_name = <ls_tadir>-obj_name.
+
+        TRY.
+            delete_obj(
+              iv_package = <ls_tadir>-devclass
+              is_item    = ls_item ).
+
+            DELETE lt_tadir.
+
+            " make sure to save object deletions
+            COMMIT WORK.
+          CATCH zcx_abapgit_exception INTO lx_error ##NO_HANDLER.
+            " ignore errors inside the loops and raise it later
+        ENDTRY.
+
+      ENDLOOP.
+    ENDDO.
+
     zcl_abapgit_default_transport=>get_instance( )->reset( ).
+
+    IF lx_error IS BOUND AND lines( lt_tadir ) > 0.
+      RAISE EXCEPTION lx_error.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_dependencies.clas.abap
+++ b/src/zcl_abapgit_dependencies.clas.abap
@@ -137,7 +137,15 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
             <ls_tadir>-korrnum = '180000'.
           ENDIF.
         WHEN 'IDOC'.
-          <ls_tadir>-korrnum = '160000'.
+          <ls_tadir>-korrnum = '200000'.
+        WHEN 'WDCA'.
+          <ls_tadir>-korrnum = '174000'.
+        WHEN 'WDYA'.
+          <ls_tadir>-korrnum = '173000'.
+        WHEN 'WDCC'.
+          <ls_tadir>-korrnum = '172000'.
+        WHEN 'WDYN'.
+          <ls_tadir>-korrnum = '171000'.
         WHEN 'IEXT'.
           <ls_tadir>-korrnum = '150000'.
         WHEN OTHERS.

--- a/src/zcl_abapgit_dependencies.clas.abap
+++ b/src/zcl_abapgit_dependencies.clas.abap
@@ -73,6 +73,7 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_tadir> LIKE LINE OF ct_tadir.
 
     " misuse field KORRNUM to fix deletion sequence
+    " higher value means later deletion
 
     LOOP AT ct_tadir ASSIGNING <ls_tadir>.
       CASE <ls_tadir>-object.
@@ -86,18 +87,9 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
           <ls_tadir>-korrnum = '810000'.
         WHEN 'DTEL'.
           <ls_tadir>-korrnum = '800000'.
-        WHEN 'DCLS'.
-          " AUTH and SUSO after DCLS
-          <ls_tadir>-korrnum = '705000'.
-        WHEN 'SUSO'.
-          " SUSO after DCLS
-          <ls_tadir>-korrnum = '710000'.
-        WHEN 'AUTH'.
-          " AUTH after DCLS
-          <ls_tadir>-korrnum = '715000'.
-        WHEN 'DDLS'.
-          " DDLS after DCLS but before other DDIC
-          <ls_tadir>-korrnum = '720000'.
+        WHEN 'SHLP'.
+          " SHLP after TABL
+          <ls_tadir>-korrnum = '760000'.
         WHEN 'TTYP' OR 'TABL' OR 'VIEW'.
           SELECT SINGLE tabclass FROM dd02l
             INTO lv_tabclass
@@ -110,6 +102,18 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
           ELSE.
             <ls_tadir>-korrnum = '750000'.
           ENDIF.
+        WHEN 'DDLS'.
+          " DDLS after DCLS but before other DDIC
+          <ls_tadir>-korrnum = '720000'.
+        WHEN 'AUTH'.
+          " AUTH after DCLS
+          <ls_tadir>-korrnum = '715000'.
+        WHEN 'SUSO'.
+          " SUSO after DCLS
+          <ls_tadir>-korrnum = '710000'.
+        WHEN 'DCLS'.
+          " AUTH and SUSO after DCLS
+          <ls_tadir>-korrnum = '705000'.
         WHEN 'IASP'.
           <ls_tadir>-korrnum = '552000'.
         WHEN 'IARP'.
@@ -130,10 +134,10 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
           IF sy-subrc = 0.
             <ls_tadir>-korrnum = '200000'.
           ELSE.
-            <ls_tadir>-korrnum = '100000'.
+            <ls_tadir>-korrnum = '180000'.
           ENDIF.
         WHEN 'IDOC'.
-          <ls_tadir>-korrnum = '200000'.
+          <ls_tadir>-korrnum = '160000'.
         WHEN 'IEXT'.
           <ls_tadir>-korrnum = '150000'.
         WHEN OTHERS.


### PR DESCRIPTION
Uninstall now catches exceptions and tries up to 3 times to remove an object. Exceptions are only raised if after 3 tries some objects still remain. 

Tested with https://github.com/larshp/abapPGP

Closes https://github.com/abapGit/abapGit/issues/379 and https://github.com/abapGit/abapGit/issues/3949, and probably #3228

PS: In certain cases with cyclic dependencies it won't be possible to automatically delete.