### PR TITLE
Fix ZIF_ABAPGIT_OBJECT~EXISTS methods

### DIFF
--- a/src/objects/zcl_abapgit_object_cmpt.clas.abap
+++ b/src/objects/zcl_abapgit_object_cmpt.clas.abap
@@ -143,7 +143,14 @@ CLASS ZCL_ABAPGIT_OBJECT_CMPT IMPLEMENTATION.
             i_version    = 'A'
           RECEIVING
             r_flg_exists = rv_bool.
-
+        IF rv_bool = abap_false.
+          CALL METHOD ('CL_CMP_TEMPLATE')=>('S_TEMPLATE_EXISTS')
+            EXPORTING
+              i_name       = mv_name
+              i_version    = 'I'
+            RECEIVING
+              r_flg_exists = rv_bool.
+        ENDIF.
       CATCH cx_root.
         zcx_abapgit_exception=>raise( 'CMPT not supported' ).
     ENDTRY.

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -98,6 +98,20 @@ CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD read_baseinfo.
+
+    TRY.
+        rv_baseinfo_string = mo_files->read_string( 'baseinfo' ).
+
+      CATCH zcx_abapgit_exception.
+        " File not found. That's ok, as the object could have been created in a
+        " system where baseinfo wasn't supported.
+        RETURN.
+    ENDTRY.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_object~changed_by.
 
     DATA: lo_ddl   TYPE REF TO object,
@@ -257,7 +271,6 @@ CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
         CALL METHOD lo_ddl->('IF_DD_DDL_HANDLER~READ')
           EXPORTING
             name      = ms_item-obj_name
-            get_state = 'A'
           IMPORTING
             got_state = lv_state.
         rv_bool = boolc( NOT lv_state IS INITIAL ).
@@ -415,19 +428,4 @@ CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
                  ig_data = <lg_data> ).
 
   ENDMETHOD.
-
-
-  METHOD read_baseinfo.
-
-    TRY.
-        rv_baseinfo_string = mo_files->read_string( 'baseinfo' ).
-
-      CATCH zcx_abapgit_exception.
-        " File not found. That's ok, as the object could have been created in a
-        " system where baseinfo wasn't supported.
-        RETURN.
-    ENDTRY.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -299,11 +299,8 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
 
     DATA: lv_domname TYPE dd01l-domname.
 
-
     SELECT SINGLE domname FROM dd01l INTO lv_domname
-      WHERE domname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers = '0000'.
+      WHERE domname = ms_item-obj_name.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -224,12 +224,19 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
     DATA: lv_rollname TYPE dd04l-rollname.
 
     lv_rollname = ms_item-obj_name.
+
+    " Check nametab because it's fast
     CALL FUNCTION 'DD_GET_NAMETAB_HEADER'
       EXPORTING
         tabname   = lv_rollname
       EXCEPTIONS
         not_found = 1
         OTHERS    = 2.
+    IF sy-subrc <> 0.
+      " Check for inactive or modified versions
+      SELECT SINGLE rollname FROM dd04l INTO lv_rollname
+        WHERE rollname = lv_rollname.
+    ENDIF.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_enqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_enqu.clas.abap
@@ -87,11 +87,8 @@ CLASS ZCL_ABAPGIT_OBJECT_ENQU IMPLEMENTATION.
 
     DATA: lv_viewname TYPE dd25l-viewname.
 
-
     SELECT SINGLE viewname FROM dd25l INTO lv_viewname
-      WHERE viewname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers = '0000'.
+      WHERE viewname = ms_item-obj_name.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -187,8 +187,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
     DATA: lv_progname TYPE reposrc-progname.
 
     SELECT SINGLE progname FROM reposrc INTO lv_progname
-      WHERE progname = ms_item-obj_name
-      AND r3state = 'A'.
+      WHERE progname = ms_item-obj_name.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -94,10 +94,8 @@ CLASS ZCL_ABAPGIT_OBJECT_SHLP IMPLEMENTATION.
 
     DATA: lv_shlpname TYPE dd30l-shlpname.
 
-
     SELECT SINGLE shlpname FROM dd30l INTO lv_shlpname
-      WHERE shlpname = ms_item-obj_name
-      AND as4local = 'A'.                               "#EC CI_GENBUFF
+      WHERE shlpname = ms_item-obj_name.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -108,10 +108,8 @@ CLASS ZCL_ABAPGIT_OBJECT_TTYP IMPLEMENTATION.
 
     DATA: lv_typename TYPE dd40l-typename.
 
-
     SELECT SINGLE typename FROM dd40l INTO lv_typename
-      WHERE typename = ms_item-obj_name
-      AND as4local = 'A'.
+      WHERE typename = ms_item-obj_name.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_type.clas.abap
+++ b/src/objects/zcl_abapgit_object_type.clas.abap
@@ -77,6 +77,8 @@ CLASS ZCL_ABAPGIT_OBJECT_TYPE IMPLEMENTATION.
         AND ddlanguage = mv_language.
 
     lv_typdname = ms_item-obj_name.
+
+    " Active version
     CALL FUNCTION 'TYPD_GET_OBJECT'
       EXPORTING
         typdname          = lv_typdname
@@ -89,6 +91,22 @@ CLASS ZCL_ABAPGIT_OBJECT_TYPE IMPLEMENTATION.
         version_not_found = 1
         reps_not_exist    = 2
         OTHERS            = 3.
+    IF sy-subrc <> 0.
+      " Inactive version
+      CALL FUNCTION 'TYPD_GET_OBJECT'
+        EXPORTING
+          typdname          = lv_typdname
+          r3state           = 'I'
+        TABLES
+          psmodisrc         = lt_psmodisrc
+          psmodilog         = lt_psmodilog
+          psource           = et_source
+          ptrdir            = lt_ptrdir
+        EXCEPTIONS
+          version_not_found = 1
+          reps_not_exist    = 2
+          OTHERS            = 3.
+    ENDIF.
     IF sy-subrc <> 0.
       RAISE EXCEPTION TYPE zcx_abapgit_not_found.
     ENDIF.

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -159,11 +159,8 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
     DATA: lv_viewname TYPE dd25l-viewname,
           lv_ddl_view TYPE abap_bool.
 
-
     SELECT SINGLE viewname FROM dd25l INTO lv_viewname
-      WHERE viewname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers = '0000'.
+      WHERE viewname = ms_item-obj_name.
     rv_bool = boolc( sy-subrc = 0 ).
 
     IF rv_bool = abap_true.


### PR DESCRIPTION
`EXISTS` needs to check for any version of an object - active, inactive, or new. Fix object classes that check only for active version.

Closes https://github.com/abapGit/abapGit/issues/3964