### PR TITLE
html event abstraction, phase 4 - form_data

### DIFF
--- a/docs/collections/_development/developing-ui.md
+++ b/docs/collections/_development/developing-ui.md
@@ -107,6 +107,8 @@ To process sapevents in abap the component (page) must implement `ZIF_ABAPGIT_GU
   - `ii_event->query( )->get( 'XXX' )`
   - or `ii_event->query( )->to_abap( changing cs_container = ls_struc_with_fields )`
   - query string_map is immutable (attempt to `set` will raise an exception)
+  - accepts optional `iv_upper_cased` param to unify param names (default = `true`)
+- `ii_event->form_data()` - attempts to parse post_data assuming it is set of key value pairs. Returns a string map. Otherwise behaves as `query()` above. `iv_upper_cased = false` by default.
 
 Events can be processed on 2 levels - in page/component **or** in the router. On new event:
 - the GUI goes through event handlers stack - list of components that registered themselves as event handlers during rendering via `gui_services`

--- a/src/ui/core/zcl_abapgit_gui_event.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.testclasses.abap
@@ -95,7 +95,7 @@ CLASS ltcl_event IMPLEMENTATION.
       act = lo_map->size( )
       exp = 0 ).
 
-    APPEND 'a=b&b=c' to lt_postdata.
+    APPEND 'a=b&b=c' TO lt_postdata.
     CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
       EXPORTING
         iv_action   = 'XXX'

--- a/src/ui/core/zcl_abapgit_gui_event.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.testclasses.abap
@@ -7,6 +7,7 @@ CLASS ltcl_event DEFINITION
   PRIVATE SECTION.
 
     METHODS query FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS form_data FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -33,7 +34,12 @@ CLASS ltcl_event IMPLEMENTATION.
         iv_action = 'XXX'
         iv_getdata = 'a=b&b=c'.
 
-    lo_map = li_cut->query( ).
+    " Cross check just in case
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->form_data( )->size( )
+      exp = 0 ).
+
+    lo_map = li_cut->query( iv_upper_cased = abap_false ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->size( )
       exp = 2 ).
@@ -55,6 +61,11 @@ CLASS ltcl_event IMPLEMENTATION.
       act = lo_map->get( 'B' )
       exp = 'c' ).
 
+    " Check defaults
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->query( )->get( 'A' )
+      exp = 'b' ).
+
     TRY.
         lo_map->set(
           iv_key = 'x'
@@ -68,4 +79,70 @@ CLASS ltcl_event IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD form_data.
+
+    DATA li_cut TYPE REF TO zif_abapgit_gui_event.
+    DATA lo_map TYPE REF TO zcl_abapgit_string_map.
+    DATA lo_x TYPE REF TO zcx_abapgit_exception.
+    DATA lt_postdata TYPE cnht_post_data_tab.
+
+    CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
+      EXPORTING
+        iv_action = 'XXX'.
+
+    lo_map = li_cut->form_data( ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->size( )
+      exp = 0 ).
+
+    APPEND 'a=b&b=c' to lt_postdata.
+    CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
+      EXPORTING
+        iv_action   = 'XXX'
+        it_postdata = lt_postdata.
+
+    " Cross check just in case
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->query( )->size( )
+      exp = 0 ).
+
+    lo_map = li_cut->form_data( iv_upper_cased = abap_false ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->size( )
+      exp = 2 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->get( 'a' )
+      exp = 'b' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->get( 'b' )
+      exp = 'c' ).
+
+    lo_map = li_cut->form_data( iv_upper_cased = abap_true ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->size( )
+      exp = 2 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->get( 'A' )
+      exp = 'b' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->get( 'B' )
+      exp = 'c' ).
+
+    " Check defaults
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->form_data( )->get( 'a' )
+      exp = 'b' ).
+
+    TRY.
+        lo_map->set(
+          iv_key = 'x'
+          iv_val = 'y' ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception INTO lo_x.
+        cl_abap_unit_assert=>assert_char_cp(
+          act = lo_x->get_text( )
+          exp = '*immutable*' ).
+    ENDTRY.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/ui/core/zif_abapgit_gui_event.intf.abap
+++ b/src/ui/core/zif_abapgit_gui_event.intf.abap
@@ -14,4 +14,12 @@ INTERFACE zif_abapgit_gui_event
     RAISING
       zcx_abapgit_exception.
 
+  METHODS form_data
+    IMPORTING
+      iv_upper_cased TYPE abap_bool DEFAULT abap_false
+    RETURNING
+      VALUE(ro_string_map) TYPE REF TO zcl_abapgit_string_map
+    RAISING
+      zcx_abapgit_exception.
+
 ENDINTERFACE.

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -52,13 +52,6 @@ CLASS zcl_abapgit_gui_page_boverview DEFINITION
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
-    METHODS decode_merge
-      IMPORTING
-        !it_postdata    TYPE cnht_post_data_tab
-      RETURNING
-        VALUE(rs_merge) TYPE ty_merge
-      RAISING
-        zcx_abapgit_exception .
     METHODS build_menu
       RETURNING
         VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar .
@@ -243,25 +236,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD decode_merge.
-
-    DATA lt_fields TYPE tihttpnvp.
-    FIELD-SYMBOLS: <ls_field> LIKE LINE OF lt_fields.
-
-
-    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( it_postdata ).
-
-    READ TABLE lt_fields ASSIGNING <ls_field> WITH KEY name = 'source'.
-    ASSERT sy-subrc = 0.
-    rs_merge-source = <ls_field>-value.
-
-    READ TABLE lt_fields ASSIGNING <ls_field> WITH KEY name = 'target'.
-    ASSERT sy-subrc = 0.
-    rs_merge-target = <ls_field>-value.
-
-  ENDMETHOD.
-
-
   METHOD escape_branch.
 
     rv_string = iv_string.
@@ -420,7 +394,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
         refresh( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN c_actions-merge.
-        ls_merge = decode_merge( ii_event->mt_postdata ).
+        ls_merge-source = ii_event->form_data( )->get( 'source' ).
+        ls_merge-target = ii_event->form_data( )->get( 'target' ).
         CREATE OBJECT lo_merge
           EXPORTING
             io_repo   = mo_repo

--- a/src/ui/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/zcl_abapgit_html_action_utils.clas.abap
@@ -13,6 +13,7 @@ CLASS zcl_abapgit_html_action_utils DEFINITION
     CLASS-METHODS parse_fields
       IMPORTING
         !iv_string       TYPE clike
+        !iv_upper_cased  TYPE abap_bool DEFAULT abap_false
       RETURNING
         VALUE(rt_fields) TYPE tihttpnvp .
     CLASS-METHODS parse_fields_upper_case_name
@@ -261,13 +262,18 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
     ENDLOOP.
 
+    IF iv_upper_cased = abap_true.
+      field_keys_to_upper( CHANGING ct_fields = rt_fields ).
+    ENDIF.
+
   ENDMETHOD.
 
 
   METHOD parse_fields_upper_case_name.
 
-    rt_fields = parse_fields( iv_string ).
-    field_keys_to_upper( CHANGING ct_fields = rt_fields ).
+    rt_fields = parse_fields(
+      iv_string      = iv_string
+      iv_upper_cased = abap_true ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -16,6 +16,7 @@ CLASS zcl_abapgit_string_map DEFINITION
     CLASS-METHODS create
       RETURNING
         VALUE(ro_instance) TYPE REF TO zcl_abapgit_string_map.
+    METHODS constructor.
     METHODS get
       IMPORTING
         iv_key        TYPE string
@@ -53,6 +54,11 @@ CLASS zcl_abapgit_string_map DEFINITION
         !cs_container TYPE any
       RAISING
         zcx_abapgit_exception.
+    METHODS strict
+      IMPORTING
+        !iv_strict TYPE abap_bool DEFAULT abap_true
+      RETURNING
+        VALUE(ro_instance) TYPE REF to zcl_abapgit_string_map .
     METHODS freeze.
 
     DATA mt_entries TYPE tts_entries READ-ONLY.
@@ -60,6 +66,7 @@ CLASS zcl_abapgit_string_map DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA mv_read_only TYPE abap_bool.
+    DATA mv_is_strict TYPE abap_bool.
 
 ENDCLASS.
 
@@ -73,6 +80,11 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Cannot clear. This string map is immutable' ).
     ENDIF.
     CLEAR mt_entries.
+  ENDMETHOD.
+
+
+  METHOD constructor.
+    mv_is_strict = abap_true.
   ENDMETHOD.
 
 
@@ -151,6 +163,12 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD strict.
+    mv_is_strict = iv_strict.
+    ro_instance = me.
+  ENDMETHOD.
+
+
   METHOD to_abap.
 
     DATA lo_type TYPE REF TO cl_abap_typedescr.
@@ -172,6 +190,8 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
       IF sy-subrc = 0.
         " TODO check target type ?
         <lv_val> = <ls_entry>-v.
+      ELSEIF mv_is_strict = abap_false.
+        CONTINUE.
       ELSE.
         zcx_abapgit_exception=>raise( |Component { lv_field } not found in target| ).
       ENDIF.

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -58,7 +58,7 @@ CLASS zcl_abapgit_string_map DEFINITION
       IMPORTING
         !iv_strict TYPE abap_bool DEFAULT abap_true
       RETURNING
-        VALUE(ro_instance) TYPE REF to zcl_abapgit_string_map .
+        VALUE(ro_instance) TYPE REF TO zcl_abapgit_string_map .
     METHODS freeze.
 
     DATA mt_entries TYPE tts_entries READ-ONLY.

--- a/src/utils/zcl_abapgit_string_map.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.testclasses.abap
@@ -105,7 +105,7 @@ CLASS ltcl_sm_test IMPLEMENTATION.
 
     DATA ls_struc_act TYPE ty_struc.
     DATA ls_struc_exp TYPE ty_struc.
-    DATA lx TYPE REF TO cx_root.
+    DATA lo_x TYPE REF TO cx_root.
     DATA lo_cut TYPE REF TO zcl_abapgit_string_map.
     lo_cut = zcl_abapgit_string_map=>create( ).
 
@@ -129,10 +129,10 @@ CLASS ltcl_sm_test IMPLEMENTATION.
     TRY.
         lo_cut->to_abap( CHANGING cs_container = ls_struc_act ).
         cl_abap_unit_assert=>fail( ).
-      CATCH cx_root INTO lx.
+      CATCH cx_root INTO lo_x.
         cl_abap_unit_assert=>assert_equals(
           exp = 'Component Z not found in target'
-          act = lx->get_text( ) ).
+          act = lo_x->get_text( ) ).
     ENDTRY.
 
     lo_cut->strict( abap_false )->to_abap( CHANGING cs_container = ls_struc_act ).

--- a/src/utils/zcl_abapgit_string_map.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.testclasses.abap
@@ -4,8 +4,18 @@ CLASS ltcl_sm_test DEFINITION
   DURATION SHORT
   RISK LEVEL HARMLESS.
   PRIVATE SECTION.
+
+    TYPES:
+      BEGIN OF ty_struc,
+        a TYPE string,
+        b TYPE abap_bool,
+        c TYPE i,
+      END OF ty_struc.
+
     METHODS simple FOR TESTING RAISING zcx_abapgit_exception.
     METHODS freeze FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS strict FOR TESTING RAISING zcx_abapgit_exception.
+
 ENDCLASS.
 
 CLASS ltcl_sm_test IMPLEMENTATION.
@@ -88,6 +98,48 @@ CLASS ltcl_sm_test IMPLEMENTATION.
         cl_abap_unit_assert=>fail( ).
       CATCH zcx_abapgit_exception.
     ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD strict.
+
+    DATA ls_struc_act TYPE ty_struc.
+    DATA ls_struc_exp TYPE ty_struc.
+    DATA lx TYPE REF TO cx_root.
+    DATA lo_cut TYPE REF TO zcl_abapgit_string_map.
+    lo_cut = zcl_abapgit_string_map=>create( ).
+
+    lo_cut->set(
+      iv_key = 'a'
+      iv_val = 'avalue' ).
+    lo_cut->set(
+      iv_key = 'b'
+      iv_val = 'X' ).
+    lo_cut->set(
+      iv_key = 'c'
+      iv_val = '123' ).
+    lo_cut->set(
+      iv_key = 'z'
+      iv_val = 'xyz' ).
+
+    ls_struc_exp-a = 'avalue'.
+    ls_struc_exp-b = abap_true.
+    ls_struc_exp-c = 123.
+
+    TRY.
+        lo_cut->to_abap( CHANGING cs_container = ls_struc_act ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_root INTO lx.
+        cl_abap_unit_assert=>assert_equals(
+          exp = 'Component Z not found in target'
+          act = lx->get_text( ) ).
+    ENDTRY.
+
+    lo_cut->strict( abap_false )->to_abap( CHANGING cs_container = ls_struc_act ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = ls_struc_exp
+      act = ls_struc_act ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
to #3602

final part (at least for now).

`ii_event->form_data( )` attempts to parse post_data assuming it is key-value and returns a string_map. Optionally `iv_upper_cased`. The rest is the same as `query`.

Also refactored most of pages. Except `add_online` because waiting for #3960. Will adjust both of them after. And except of both settings pages - they are painful to refactor and maybe does not make sense if they will be switched to new form which will change the whole parsing completely.