### PR TITLE
Rename repo related pages

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_addofflin.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addofflin.clas.abap
@@ -219,7 +219,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDOFFLIN IMPLEMENTATION.
         IF mo_validation_log->is_empty( ) = abap_true.
           mo_form_data->to_abap( CHANGING cs_container = ls_repo_params ).
           lo_new_offline_repo = zcl_abapgit_services_repo=>new_offline( ls_repo_params ).
-          CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_view_repo
+          CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
             EXPORTING
               iv_key = lo_new_offline_repo->get_key( ).
           rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -282,7 +282,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
         IF mo_validation_log->is_empty( ) = abap_true.
           mo_form_data->to_abap( CHANGING cs_container = ls_repo_params ).
           lo_new_online_repo = zcl_abapgit_services_repo=>new_online( ls_repo_params ).
-          CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_view_repo
+          CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
             EXPORTING
               iv_key = lo_new_online_repo->get_key( ).
           rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -25,7 +25,7 @@ CLASS zcl_abapgit_gui_page_main DEFINITION
         abapgit_home TYPE string VALUE 'abapgit_home',
       END OF c_actions.
 
-    DATA: mo_repo_overview TYPE REF TO zcl_abapgit_gui_repo_over,
+    DATA: mo_repo_overview TYPE REF TO zcl_abapgit_gui_page_repo_over,
           mv_repo_key      TYPE zif_abapgit_persistence=>ty_value.
 
     METHODS build_main_menu
@@ -74,7 +74,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
     gui_services( )->get_hotkeys_ctl( )->register_hotkeys( me ).
 
     IF mo_repo_overview IS INITIAL.
-      CREATE OBJECT mo_repo_overview TYPE zcl_abapgit_gui_repo_over.
+      CREATE OBJECT mo_repo_overview.
     ENDIF.
 
     ri_html->add( mo_repo_overview->zif_abapgit_gui_renderable~render( ) ).
@@ -103,7 +103,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
         ENDTRY.
 
         mv_repo_key = lv_key.
-        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_view_repo
+        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
           EXPORTING
             iv_key = lv_key.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -1,4 +1,4 @@
-CLASS zcl_abapgit_gui_repo_over DEFINITION
+CLASS zcl_abapgit_gui_page_repo_over DEFINITION
   PUBLIC
   INHERITING FROM zcl_abapgit_gui_component
   FINAL
@@ -7,24 +7,24 @@ CLASS zcl_abapgit_gui_repo_over DEFINITION
   PUBLIC SECTION.
 
     INTERFACES zif_abapgit_gui_renderable .
-    DATA: mv_order_by         TYPE string READ-ONLY.
+
+    DATA mv_order_by TYPE string READ-ONLY .
 
     METHODS constructor
-      RAISING zcx_abapgit_exception.
+      RAISING
+        zcx_abapgit_exception .
     METHODS set_order_by
       IMPORTING
-        iv_order_by TYPE string.
+        !iv_order_by TYPE string .
     METHODS set_order_direction
       IMPORTING
-        iv_order_descending TYPE abap_bool.
-
+        !iv_order_descending TYPE abap_bool .
     METHODS set_filter
       IMPORTING
-        it_postdata TYPE cnht_post_data_tab.
-
+        !it_postdata TYPE cnht_post_data_tab .
     METHODS has_favorites
-      RETURNING VALUE(rv_has_favorites) TYPE abap_bool.
-
+      RETURNING
+        VALUE(rv_has_favorites) TYPE abap_bool .
   PROTECTED SECTION.
 
 
@@ -115,7 +115,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_REPO_OVER IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
 
 
   METHOD apply_filter.

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>ZCL_ABAPGIT_GUI_REPO_OVER</CLSNAME>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_REPO_OVER</CLSNAME>
     <LANGU>E</LANGU>
     <DESCRIPT>GUI - DB page</DESCRIPT>
     <STATE>1</STATE>

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1,10 +1,12 @@
-CLASS zcl_abapgit_gui_page_view_repo DEFINITION
+CLASS zcl_abapgit_gui_page_repo_view DEFINITION
   PUBLIC
-  FINAL
   INHERITING FROM zcl_abapgit_gui_page
-  CREATE PUBLIC.
+  FINAL
+  CREATE PUBLIC .
 
   PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_gui_hotkeys .
 
     CONSTANTS:
       BEGIN OF c_actions,
@@ -17,10 +19,7 @@ CLASS zcl_abapgit_gui_page_view_repo DEFINITION
         display_more             TYPE string VALUE 'display_more' ##NO_TEXT,
         repo_switch_origin_to_pr TYPE string VALUE 'repo_switch_origin_to_pr',
         repo_reset_origin        TYPE string VALUE 'repo_reset_origin',
-      END OF c_actions.
-
-
-    INTERFACES: zif_abapgit_gui_hotkeys.
+      END OF c_actions .
 
     METHODS constructor
       IMPORTING
@@ -28,8 +27,8 @@ CLASS zcl_abapgit_gui_page_view_repo DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-    METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION.
-
+    METHODS zif_abapgit_gui_event_handler~on_event
+        REDEFINITION .
   PROTECTED SECTION.
     METHODS render_content REDEFINITION.
   PRIVATE SECTION.
@@ -185,7 +184,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -1176,7 +1175,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO IMPLEMENTATION.
 
     CASE ii_event->mv_action.
       WHEN zif_abapgit_definitions=>c_action-go_repo. " Switch to another repo
-        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_view_repo
+        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
           EXPORTING
             iv_key = |{ ii_event->query( iv_upper_cased = abap_true )->get( 'KEY' ) }|.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO</CLSNAME>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW</CLSNAME>
     <LANGU>E</LANGU>
     <DESCRIPT>GUI - View Repo</DESCRIPT>
     <STATE>1</STATE>

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -234,7 +234,7 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         lt_repo_list = zcl_abapgit_repo_srv=>get_instance( )->list( ).
 
         IF lv_last_repo_key IS NOT INITIAL.
-          CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_view_repo
+          CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
             EXPORTING
               iv_key = lv_last_repo_key.
         ELSEIF lt_repo_list IS NOT INITIAL.
@@ -651,7 +651,7 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
           WHEN lc_page-repo_view.
             rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
           WHEN lc_page-main_view.
-            CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_view_repo
+            CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
               EXPORTING
                 iv_key = lo_repo->get_key( ).
             rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.


### PR DESCRIPTION
while there are no major UI PRs I'd like to renme a couple of classes if no objection

- zcl_abapgit_gui_page_view_repo
- zcl_abapgit_gui_page_repo_sett
- zcl_abapgit_gui_repo_over

Now are

- zcl_abapgit_gui_page_repo_view
- zcl_abapgit_gui_page_repo_sett
- zcl_abapgit_gui_page_repo_over

P.S. zcl_abapgit_gui_page_repo_over is formally not a page currently, but I think to merge it with page_main which currently does part of repo_over (after recent refactoring of 1st page)
