### PR TITLE
html event abstraction, phase 5 - case insensitive query and form_data

### DIFF
--- a/src/ui/core/zcl_abapgit_gui_event.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.testclasses.abap
@@ -6,18 +6,20 @@ CLASS ltcl_event DEFINITION
 
   PRIVATE SECTION.
 
+    METHODS query_wrong_data FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS form_wrong_data FOR TESTING RAISING zcx_abapgit_exception.
     METHODS query FOR TESTING RAISING zcx_abapgit_exception.
     METHODS form_data FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS immutability FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
 CLASS ltcl_event IMPLEMENTATION.
 
-  METHOD query.
+  METHOD query_wrong_data.
 
     DATA li_cut TYPE REF TO zif_abapgit_gui_event.
     DATA lo_map TYPE REF TO zcl_abapgit_string_map.
-    DATA lo_x TYPE REF TO zcx_abapgit_exception.
 
     CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
       EXPORTING
@@ -29,6 +31,30 @@ CLASS ltcl_event IMPLEMENTATION.
       act = lo_map->size( )
       exp = 0 ).
 
+  ENDMETHOD.
+
+  METHOD form_wrong_data.
+
+    DATA li_cut TYPE REF TO zif_abapgit_gui_event.
+    DATA lo_map TYPE REF TO zcl_abapgit_string_map.
+
+    CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
+      EXPORTING
+        iv_action = 'XXX'.
+
+    lo_map = li_cut->form_data( ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_map->size( )
+      exp = 0 ).
+
+  ENDMETHOD.
+
+  METHOD query.
+
+    DATA li_cut TYPE REF TO zif_abapgit_gui_event.
+    DATA lo_map TYPE REF TO zcl_abapgit_string_map.
+    DATA lo_x TYPE REF TO zcx_abapgit_exception.
+
     CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
       EXPORTING
         iv_action = 'XXX'
@@ -39,10 +65,11 @@ CLASS ltcl_event IMPLEMENTATION.
       act = li_cut->form_data( )->size( )
       exp = 0 ).
 
-    lo_map = li_cut->query( iv_upper_cased = abap_false ).
+    lo_map = li_cut->query( ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->size( )
       exp = 2 ).
+
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->get( 'a' )
       exp = 'b' ).
@@ -50,32 +77,13 @@ CLASS ltcl_event IMPLEMENTATION.
       act = lo_map->get( 'b' )
       exp = 'c' ).
 
-    lo_map = li_cut->query( iv_upper_cased = abap_true ).
-    cl_abap_unit_assert=>assert_equals(
-      act = lo_map->size( )
-      exp = 2 ).
+    " Case insensitivity
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->get( 'A' )
       exp = 'b' ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->get( 'B' )
       exp = 'c' ).
-
-    " Check defaults
-    cl_abap_unit_assert=>assert_equals(
-      act = li_cut->query( )->get( 'A' )
-      exp = 'b' ).
-
-    TRY.
-        lo_map->set(
-          iv_key = 'x'
-          iv_val = 'y' ).
-        cl_abap_unit_assert=>fail( ).
-      CATCH zcx_abapgit_exception INTO lo_x.
-        cl_abap_unit_assert=>assert_char_cp(
-          act = lo_x->get_text( )
-          exp = '*immutable*' ).
-    ENDTRY.
 
   ENDMETHOD.
 
@@ -85,15 +93,6 @@ CLASS ltcl_event IMPLEMENTATION.
     DATA lo_map TYPE REF TO zcl_abapgit_string_map.
     DATA lo_x TYPE REF TO zcx_abapgit_exception.
     DATA lt_postdata TYPE cnht_post_data_tab.
-
-    CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
-      EXPORTING
-        iv_action = 'XXX'.
-
-    lo_map = li_cut->form_data( ).
-    cl_abap_unit_assert=>assert_equals(
-      act = lo_map->size( )
-      exp = 0 ).
 
     APPEND 'a=b&b=c' TO lt_postdata.
     CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
@@ -106,10 +105,11 @@ CLASS ltcl_event IMPLEMENTATION.
       act = li_cut->query( )->size( )
       exp = 0 ).
 
-    lo_map = li_cut->form_data( iv_upper_cased = abap_false ).
+    lo_map = li_cut->form_data( ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->size( )
       exp = 2 ).
+
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->get( 'a' )
       exp = 'b' ).
@@ -117,7 +117,7 @@ CLASS ltcl_event IMPLEMENTATION.
       act = lo_map->get( 'b' )
       exp = 'c' ).
 
-    lo_map = li_cut->form_data( iv_upper_cased = abap_true ).
+    " Case insensitivity
     cl_abap_unit_assert=>assert_equals(
       act = lo_map->size( )
       exp = 2 ).
@@ -128,13 +128,31 @@ CLASS ltcl_event IMPLEMENTATION.
       act = lo_map->get( 'B' )
       exp = 'c' ).
 
-    " Check defaults
-    cl_abap_unit_assert=>assert_equals(
-      act = li_cut->form_data( )->get( 'a' )
-      exp = 'b' ).
+  ENDMETHOD.
+
+  METHOD immutability.
+
+    DATA li_cut TYPE REF TO zif_abapgit_gui_event.
+    DATA lo_x TYPE REF TO zcx_abapgit_exception.
+
+    CREATE OBJECT li_cut TYPE zcl_abapgit_gui_event
+      EXPORTING
+        iv_getdata = 'a=b&b=c'
+        iv_action  = 'XXX'.
 
     TRY.
-        lo_map->set(
+        li_cut->form_data( )->set(
+          iv_key = 'x'
+          iv_val = 'y' ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception INTO lo_x.
+        cl_abap_unit_assert=>assert_char_cp(
+          act = lo_x->get_text( )
+          exp = '*immutable*' ).
+    ENDTRY.
+
+    TRY.
+        li_cut->query( )->set(
           iv_key = 'x'
           iv_val = 'y' ).
         cl_abap_unit_assert=>fail( ).
@@ -145,4 +163,5 @@ CLASS ltcl_event IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/core/zif_abapgit_gui_event.intf.abap
+++ b/src/ui/core/zif_abapgit_gui_event.intf.abap
@@ -7,16 +7,12 @@ INTERFACE zif_abapgit_gui_event
   DATA mi_gui_services TYPE REF TO zif_abapgit_gui_services READ-ONLY.
 
   METHODS query
-    IMPORTING
-      iv_upper_cased TYPE abap_bool DEFAULT abap_true
     RETURNING
       VALUE(ro_string_map) TYPE REF TO zcl_abapgit_string_map
     RAISING
       zcx_abapgit_exception.
 
   METHODS form_data
-    IMPORTING
-      iv_upper_cased TYPE abap_bool DEFAULT abap_false
     RETURNING
       VALUE(ro_string_map) TYPE REF TO zcl_abapgit_string_map
     RAISING

--- a/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
@@ -56,7 +56,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_EDIT IMPLEMENTATION.
 
     DATA lo_map TYPE REF TO zcl_abapgit_string_map.
 
-    lo_map = ii_event->form_data( iv_upper_cased = abap_true ).
+    lo_map = ii_event->form_data( ).
     rs_content-type     = lo_map->get( 'TYPE' ).
     rs_content-value    = lo_map->get( 'VALUE' ).
     rs_content-data_str = lo_map->get( 'XMLDATA' ).

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -181,7 +181,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
     DATA lo_map TYPE REF TO zcl_abapgit_string_map.
 
-    lo_map = ii_event->form_data( iv_upper_cased = abap_true ).
+    lo_map = ii_event->form_data( ).
     lo_map->to_abap( CHANGING cs_container = rs_commit ).
     REPLACE ALL OCCURRENCES
       OF zif_abapgit_definitions=>c_crlf

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -94,7 +94,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN c_actions-select.
 
-        lv_key = ii_event->query( iv_upper_cased = abap_true )->get( 'KEY' ).
+        lv_key = ii_event->query( )->get( 'KEY' ).
         zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( lv_key ).
 
         TRY.
@@ -134,7 +134,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
 
       WHEN zif_abapgit_definitions=>c_action-repo_settings.
 
-        lv_key = ii_event->query( iv_upper_cased = abap_true )->get( 'KEY' ).
+        lv_key = ii_event->query( )->get( 'KEY' ).
         CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_sett
           EXPORTING
             io_repo = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).

--- a/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
@@ -120,7 +120,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
     FIELD-SYMBOLS:
       <ls_conflict>      TYPE zif_abapgit_definitions=>ty_merge_conflict.
 
-    lv_merge_content = ii_event->form_data( iv_upper_cased = abap_true )->get( 'MERGE_CONTENT' ).
+    lv_merge_content = ii_event->form_data( )->get( 'MERGE_CONTENT' ).
 
     REPLACE ALL OCCURRENCES
       OF zif_abapgit_definitions=>c_crlf IN lv_merge_content WITH zif_abapgit_definitions=>c_newline.

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1177,7 +1177,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-go_repo. " Switch to another repo
         CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view
           EXPORTING
-            iv_key = |{ ii_event->query( iv_upper_cased = abap_true )->get( 'KEY' ) }|.
+            iv_key = |{ ii_event->query( )->get( 'KEY' ) }|.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.
 
       WHEN c_actions-toggle_hide_files. " Toggle file diplay

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -609,7 +609,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
       zcl_abapgit_path=>split_file_location(
         EXPORTING
-          iv_fullpath = <ls_item>-k
+          iv_fullpath = to_lower( <ls_item>-k ) " filename is lower cased
         IMPORTING
           ev_path     = ls_file-path
           ev_filename = ls_file-filename ).

--- a/src/utils/zcl_abapgit_string_map.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.testclasses.abap
@@ -15,6 +15,7 @@ CLASS ltcl_sm_test DEFINITION
     METHODS simple FOR TESTING RAISING zcx_abapgit_exception.
     METHODS freeze FOR TESTING RAISING zcx_abapgit_exception.
     METHODS strict FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS case_insensitive FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -142,5 +143,36 @@ CLASS ltcl_sm_test IMPLEMENTATION.
       act = ls_struc_act ).
 
   ENDMETHOD.
+
+  METHOD case_insensitive.
+
+    DATA lo_cut TYPE REF TO zcl_abapgit_string_map.
+    lo_cut = zcl_abapgit_string_map=>create( iv_case_insensitive = abap_true ).
+
+    lo_cut->set(
+      iv_key = 'A'
+      iv_val = 'avalue' ).
+    lo_cut->set(
+      iv_key = 'b'
+      iv_val = 'bvalue' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'avalue'
+      act = lo_cut->get( 'A' ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'avalue'
+      act = lo_cut->get( 'a' ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'bvalue'
+      act = lo_cut->get( 'B' ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'bvalue'
+      act = lo_cut->get( 'b' ) ).
+
+  ENDMETHOD.
+
 
 ENDCLASS.


### PR DESCRIPTION
to #3602 

query and form_data is now case insensitive, reworked UTs also. Looks like should work everywhere. Just one hard fix in stage_page where filenames are lowercased. 

event class is cleaner now without cluttered upper/lower maps, usage is also cleaner. @mbtools thanks for the idea !

I think this is the last PR for this refactoring