### PR TITLE
Bugfixes in html_form and Finetune add pages to new event

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_addofflin.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addofflin.clas.abap
@@ -38,13 +38,6 @@ CLASS zcl_abapgit_gui_page_addofflin DEFINITION
     DATA mo_form_data TYPE REF TO zcl_abapgit_string_map .
     DATA mo_form TYPE REF TO zcl_abapgit_html_form .
 
-    METHODS parse_form
-      IMPORTING
-        !it_form_fields     TYPE tihttpnvp
-      RETURNING
-        VALUE(ro_form_data) TYPE REF TO zcl_abapgit_string_map
-      RAISING
-        zcx_abapgit_exception .
     METHODS validate_form
       IMPORTING
         !io_form_data            TYPE REF TO zcl_abapgit_string_map
@@ -129,24 +122,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDOFFLIN IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD parse_form.
-
-    DATA ls_field LIKE LINE OF it_form_fields.
-
-    CREATE OBJECT ro_form_data.
-
-    " temporary, TODO refactor later, after gui_event class is ready, move to on_event
-    LOOP AT it_form_fields INTO ls_field.
-      ro_form_data->set(
-        iv_key = ls_field-name
-        iv_val = ls_field-value ).
-    ENDLOOP.
-
-    ro_form_data = mo_form->validate_normalize_form_data( ro_form_data ).
-
-  ENDMETHOD.
-
-
   METHOD validate_form.
 
     DATA lx_err TYPE REF TO zcx_abapgit_exception.
@@ -182,7 +157,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDOFFLIN IMPLEMENTATION.
           lo_new_offline_repo TYPE REF TO zcl_abapgit_repo_offline.
 
     " import data from html before re-render
-    mo_form_data = parse_form( zcl_abapgit_html_action_utils=>parse_post_form_data( ii_event->mt_postdata ) ).
+    mo_form_data = mo_form->normalize_form_data( ii_event->form_data( ) ).
 
     CASE ii_event->mv_action.
       WHEN c_event-go_back.
@@ -193,7 +168,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDOFFLIN IMPLEMENTATION.
         mo_form_data->set(
           iv_key = c_id-package
           iv_val = zcl_abapgit_services_basis=>create_package(
-            iv_prefill_package = |{ mo_form_data->get( 'package' ) }| ) ).
+            iv_prefill_package = |{ mo_form_data->get( c_id-package ) }| ) ).
         IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
           mo_validation_log = validate_form( mo_form_data ).
           rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -46,14 +46,6 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
     DATA mo_form_data TYPE REF TO zcl_abapgit_string_map.
     DATA mo_form TYPE REF TO zcl_abapgit_html_form.
 
-    METHODS parse_form
-      IMPORTING
-        it_form_fields TYPE tihttpnvp
-      RETURNING
-        VALUE(ro_form_data) TYPE REF TO zcl_abapgit_string_map
-      RAISING
-        zcx_abapgit_exception.
-
     METHODS validate_form
       IMPORTING
         io_form_data             TYPE REF TO zcl_abapgit_string_map
@@ -156,24 +148,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD parse_form.
-
-    DATA ls_field LIKE LINE OF it_form_fields.
-
-    CREATE OBJECT ro_form_data.
-
-    " temporary, TODO refactor later, after gui_event class is ready, move to on_event
-    LOOP AT it_form_fields INTO ls_field.
-      ro_form_data->set(
-        iv_key = ls_field-name
-        iv_val = ls_field-value ).
-    ENDLOOP.
-
-    ro_form_data = mo_form->validate_normalize_form_data( ro_form_data ).
-
-  ENDMETHOD.
-
-
   METHOD validate_form.
 
     DATA lx_err TYPE REF TO zcx_abapgit_exception.
@@ -220,7 +194,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
           lo_new_online_repo TYPE REF TO zcl_abapgit_repo_online.
 
     " import data from html before re-render
-    mo_form_data = parse_form( zcl_abapgit_html_action_utils=>parse_post_form_data( ii_event->mt_postdata ) ).
+    mo_form_data = mo_form->normalize_form_data( ii_event->form_data( ) ).
 
     CASE ii_event->mv_action.
       WHEN c_event-go_back.
@@ -231,7 +205,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
         mo_form_data->set(
           iv_key = c_id-package
           iv_val = zcl_abapgit_services_basis=>create_package(
-            iv_prefill_package = |{ mo_form_data->get( 'package' ) }| ) ).
+            iv_prefill_package = |{ mo_form_data->get( c_id-package ) }| ) ).
         IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
           mo_validation_log = validate_form( mo_form_data ).
           rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -406,7 +406,7 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
         IF lv_error IS NOT INITIAL.
           ii_html->add( |<small>{ lv_error }</small>| ).
         ENDIF.
-        IF lv_value IS NOT INITIAL.
+        IF lv_value = abap_true OR lv_value = 'on'. " boolc return ` ` which is not initial -> bug after 1st validation
           lv_checked = ' checked'.
         ENDIF.
         ii_html->add( |<input type="checkbox" name="{ is_field-name }" id="{ is_field-name }"{ lv_checked }>| ).

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -64,7 +64,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_hint       TYPE string OPTIONAL
       RETURNING
         VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
-    METHODS validate_normalize_form_data
+    METHODS normalize_form_data
       IMPORTING
         !io_form_data       TYPE REF TO zcl_abapgit_string_map
       RETURNING
@@ -193,6 +193,36 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
       GET TIME STAMP FIELD lv_ts.
       ro_form->mv_form_id = |form_{ lv_ts }|.
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD normalize_form_data.
+
+    DATA lv_value TYPE string.
+    FIELD-SYMBOLS <ls_field> LIKE LINE OF mt_fields.
+
+    CREATE OBJECT ro_form_data.
+
+    LOOP AT mt_fields ASSIGNING <ls_field>.
+      CLEAR lv_value.
+      lv_value = io_form_data->get( <ls_field>-name ).
+
+      IF <ls_field>-type = c_field_type-checkbox.
+        ro_form_data->set(
+          iv_key = <ls_field>-name
+          iv_val = boolc( lv_value = 'on' ) ).
+      ELSEIF <ls_field>-type = c_field_type-text AND <ls_field>-upper_case = abap_true.
+        ro_form_data->set(
+          iv_key = <ls_field>-name
+          iv_val = to_upper( lv_value ) ).
+      ELSE.
+        ro_form_data->set(
+          iv_key = <ls_field>-name
+          iv_val = lv_value ).
+      ENDIF.
+
+    ENDLOOP.
 
   ENDMETHOD.
 
@@ -469,54 +499,19 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD validate_normalize_form_data.
-
-    DATA ls_field LIKE LINE OF mt_fields.
-    FIELD-SYMBOLS <ls_entry> LIKE LINE OF io_form_data->mt_entries.
-
-    CREATE OBJECT ro_form_data.
-
-    LOOP AT io_form_data->mt_entries ASSIGNING <ls_entry>.
-      READ TABLE mt_fields INTO ls_field WITH KEY by_name COMPONENTS name = <ls_entry>-k.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |Unexpected form field [{ <ls_entry>-k }]| ).
-      ENDIF.
-
-      IF ls_field-type = c_field_type-checkbox.
-        ro_form_data->set(
-          iv_key = <ls_entry>-k
-          iv_val = boolc( <ls_entry>-v = 'on' ) ).
-      ELSEIF ls_field-type = c_field_type-text AND ls_field-upper_case = abap_true.
-        ro_form_data->set(
-          iv_key = <ls_entry>-k
-          iv_val = to_upper( <ls_entry>-v ) ).
-      ELSE.
-        ro_form_data->set(
-          iv_key = <ls_entry>-k
-          iv_val = <ls_entry>-v ).
-      ENDIF.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
   METHOD validate_required_fields.
 
-    DATA ls_field LIKE LINE OF mt_fields.
-    FIELD-SYMBOLS <ls_entry> LIKE LINE OF io_form_data->mt_entries.
+    DATA lv_value TYPE string.
+    FIELD-SYMBOLS <ls_field> LIKE LINE OF mt_fields.
 
     CREATE OBJECT ro_validation_log.
 
-    LOOP AT io_form_data->mt_entries ASSIGNING <ls_entry>.
-      READ TABLE mt_fields INTO ls_field WITH KEY by_name COMPONENTS name = <ls_entry>-k.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |Unexpected form field [{ <ls_entry>-k }]| ).
-      ENDIF.
-
-      IF ls_field-required IS NOT INITIAL AND <ls_entry>-v IS INITIAL.
+    LOOP AT mt_fields ASSIGNING <ls_field>.
+      lv_value = io_form_data->get( <ls_field>-name ).
+      IF <ls_field>-required IS NOT INITIAL AND lv_value IS INITIAL.
         ro_validation_log->set(
-          iv_key = ls_field-name
-          iv_val = |{ ls_field-label } cannot be empty| ).
+          iv_key = <ls_field>-name
+          iv_val = |{ <ls_field>-label } cannot be empty| ).
       ENDIF.
     ENDLOOP.
 

--- a/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
@@ -1,0 +1,130 @@
+CLASS ltcl_test_form DEFINITION
+  FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT
+  FINAL.
+
+  PRIVATE SECTION.
+
+    METHODS validate FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS normalize FOR TESTING RAISING zcx_abapgit_exception.
+
+ENDCLASS.
+
+CLASS ltcl_test_form IMPLEMENTATION.
+
+  METHOD validate.
+
+    DATA lo_cut TYPE REF TO zcl_abapgit_html_form.
+    DATA lo_form_data TYPE REF TO zcl_abapgit_string_map.
+    DATA lo_log TYPE REF TO zcl_abapgit_string_map.
+
+    lo_cut       = zcl_abapgit_html_form=>create( ).
+    lo_form_data = zcl_abapgit_string_map=>create( ).
+
+    lo_cut->text(
+      iv_name        = 'field1'
+      iv_required    = abap_true
+      iv_label       = 'Field name 1'
+    )->text(
+      iv_name        = 'field2'
+      iv_label       = 'Field name 2' ).
+
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field1' )
+      exp = '*cannot be empty' ).
+
+    lo_form_data->set(
+      iv_key = 'field1'
+      iv_val = '' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field1' )
+      exp = '*cannot be empty' ).
+
+    lo_form_data->set(
+      iv_key = 'field1'
+      iv_val = 'xyz' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 0 ).
+
+  ENDMETHOD.
+
+  METHOD normalize.
+
+    DATA lo_cut TYPE REF TO zcl_abapgit_html_form.
+    DATA lo_form_data TYPE REF TO zcl_abapgit_string_map.
+    DATA lo_normalized_act TYPE REF TO zcl_abapgit_string_map.
+    DATA lo_normalized_exp TYPE REF TO zcl_abapgit_string_map.
+
+    lo_cut            = zcl_abapgit_html_form=>create( ).
+    lo_form_data      = zcl_abapgit_string_map=>create( ).
+    lo_normalized_exp = zcl_abapgit_string_map=>create( ).
+
+    lo_cut->text(
+      iv_name        = 'field1'
+      iv_label       = 'Field name 1' ).
+    lo_cut->text(
+      iv_name        = 'field2'
+      iv_upper_case  = abap_true
+      iv_label       = 'Field name 2' ).
+    lo_cut->text(
+      iv_name        = 'field3'
+      iv_label       = 'Field name 3' ).
+    lo_cut->checkbox(
+      iv_name        = 'chk1'
+      iv_label       = 'Checkbox1' ).
+    lo_cut->checkbox(
+      iv_name        = 'chk2'
+      iv_label       = 'Checkbox2' ).
+
+    lo_form_data->set(
+      iv_key = 'field1'
+      iv_val = 'val1' ).
+    lo_form_data->set(
+      iv_key = 'field2'
+      iv_val = 'val2' ).
+    " Intentinally field3 is not specificed
+    lo_form_data->set(
+      iv_key = 'chk1'
+      iv_val = '' ).
+    lo_form_data->set(
+      iv_key = 'chk2'
+      iv_val = 'on' ).
+    lo_form_data->set(
+      iv_key = 'chk3'
+      iv_val = 'on' ). " Extra field - filtered by normalizing
+
+    lo_normalized_exp->set(
+      iv_key = 'field1'
+      iv_val = 'val1' ).
+    lo_normalized_exp->set(
+      iv_key = 'field2'
+      iv_val = 'VAL2' ).
+    lo_normalized_exp->set(
+      iv_key = 'field3'
+      iv_val = '' ). " But it is present in normalized
+    lo_normalized_exp->set(
+      iv_key = 'chk1'
+      iv_val = ` ` ). " hmmm
+    lo_normalized_exp->set(
+      iv_key = 'chk2'
+      iv_val = 'X' ).
+
+    lo_normalized_act = lo_cut->normalize_form_data( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_normalized_act->mt_entries
+      exp = lo_normalized_exp->mt_entries ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
@@ -67,7 +67,7 @@ CLASS ltcl_test_form IMPLEMENTATION.
     DATA lo_normalized_exp TYPE REF TO zcl_abapgit_string_map.
 
     lo_cut            = zcl_abapgit_html_form=>create( ).
-    lo_form_data      = zcl_abapgit_string_map=>create( ).
+    lo_form_data      = zcl_abapgit_string_map=>create( iv_case_insensitive = abap_true ).
     lo_normalized_exp = zcl_abapgit_string_map=>create( ).
 
     lo_cut->text(

--- a/src/ui/zcl_abapgit_html_form.clas.xml
+++ b/src/ui/zcl_abapgit_html_form.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
after #4007, ~~**don't review yet as it contains changes from both PRs**~~

So main purpose is to remove unnecessary parse_form from the add pages which was a very straight forward fix. But !
It appeared that validation and normalization of html_form are done incorrectly - it loops through incoming data instead of fields definition which lead to incorrect processing if input fields are missing. so fixed, and covered with UTs.
On the way I had  to remove the check on extra input fields that were missing in the definition. But I think it is ok, actually it is a good default validation logic.