### PR TITLE
CLAS: Avoid unnecessary serialize of testclasses include

### DIFF
--- a/src/objects/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_serializer.clas.abap
@@ -311,6 +311,7 @@ CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
         model_only   = 3
         OTHERS       = 4.
     IF sy-subrc <> 0 OR ls_vseoclass-with_unit_tests = abap_false.
+      mv_skip_testclass = abap_true.
       RETURN.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_serializer.clas.abap
@@ -297,6 +297,15 @@ CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
 
   METHOD serialize_testclasses.
 
+    DATA lv_with_unit_test TYPE abap_bool.
+
+    " Unit tests are only functional if the corresponding flag is set
+    " Therefore, if the flag is not set, there's no need to serialize this include
+    SELECT SINGLE with_unit_tests FROM seoclassdf INTO lv_with_unit_test WHERE clsname = is_clskey-clsname.
+    IF sy-subrc <> 0 OR lv_with_unit_test = abap_false.
+      RETURN.
+    ENDIF.
+
     rt_source = read_include( is_clskey = is_clskey
                               iv_type = seop_ext_class_testclasses ).
 

--- a/src/objects/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_serializer.clas.abap
@@ -301,7 +301,8 @@ CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
 
     " Unit tests are only functional if the corresponding flag is set
     " Therefore, if the flag is not set, there's no need to serialize this include
-    SELECT SINGLE with_unit_tests FROM seoclassdf INTO lv_with_unit_test WHERE clsname = is_clskey-clsname.
+    SELECT SINGLE with_unit_tests FROM seoclassdf INTO lv_with_unit_test
+        WHERE clsname = is_clskey-clsname AND version = '1'.
     IF sy-subrc <> 0 OR lv_with_unit_test = abap_false.
       RETURN.
     ENDIF.

--- a/src/objects/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_serializer.clas.abap
@@ -297,13 +297,20 @@ CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
 
   METHOD serialize_testclasses.
 
-    DATA lv_with_unit_test TYPE abap_bool.
+    DATA ls_vseoclass TYPE vseoclass.
 
-    " Unit tests are only functional if the corresponding flag is set
-    " Therefore, if the flag is not set, there's no need to serialize this include
-    SELECT SINGLE with_unit_tests FROM seoclassdf INTO lv_with_unit_test
-        WHERE clsname = is_clskey-clsname AND version = '1'.
-    IF sy-subrc <> 0 OR lv_with_unit_test = abap_false.
+    CALL FUNCTION 'SEO_CLIF_GET'
+      EXPORTING
+        cifkey       = is_clskey
+        version      = seoc_version_active
+      IMPORTING
+        class        = ls_vseoclass
+      EXCEPTIONS
+        not_existing = 1
+        deleted      = 2
+        model_only   = 3
+        OTHERS       = 4.
+    IF sy-subrc <> 0 OR ls_vseoclass-with_unit_tests = abap_false.
       RETURN.
     ENDIF.
 


### PR DESCRIPTION
Unit tests are only functional if the corresponding flag is set (`seoclassdf-with_unit_tests`). Therefore, if the flag is not set, there's no need to serialize this include.