### PR TITLE
Add pull_by_commit

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -9,7 +9,6 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
       BEGIN OF ty_pull_result,
         files   TYPE zif_abapgit_definitions=>ty_files_tt,
         objects TYPE zif_abapgit_definitions=>ty_objects_tt,
-        branch  TYPE zif_abapgit_definitions=>ty_sha1,
         commit  TYPE zif_abapgit_definitions=>ty_sha1,
       END OF ty_pull_result .
     TYPES:
@@ -117,8 +116,6 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
       RETURNING
         VALUE(rt_folders) TYPE ty_folders_tt .
     CLASS-METHODS pull
-      IMPORTING
-        !iv_hash   TYPE zif_abapgit_definitions=>ty_sha1
       CHANGING
         !cs_result TYPE ty_pull_result
       RAISING
@@ -426,11 +423,9 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
         iv_branch_name  = iv_branch_name
       IMPORTING
         et_objects      = rs_result-objects
-        ev_branch       = rs_result-branch ).
+        ev_branch       = rs_result-commit ).
 
     pull(
-      EXPORTING
-        iv_hash   = rs_result-branch
       CHANGING
         cs_result = rs_result ).
 
@@ -448,8 +443,6 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
         ev_commit  = rs_result-commit ).
 
     pull(
-      EXPORTING
-        iv_hash   = rs_result-commit
       CHANGING
         cs_result = rs_result ).
 
@@ -464,7 +457,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
     READ TABLE cs_result-objects INTO ls_object
       WITH KEY type COMPONENTS
         type = zif_abapgit_definitions=>c_type-commit
-        sha1 = iv_hash.
+        sha1 = cs_result-commit.
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( 'Commit/Branch not found.' ).

--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -425,9 +425,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
         et_objects      = rs_result-objects
         ev_branch       = rs_result-commit ).
 
-    pull(
-      CHANGING
-        cs_result = rs_result ).
+    pull( CHANGING cs_result = rs_result ).
 
   ENDMETHOD.
 
@@ -442,9 +440,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
         et_objects = rs_result-objects
         ev_commit  = rs_result-commit ).
 
-    pull(
-      CHANGING
-        cs_result = rs_result ).
+    pull( CHANGING cs_result = rs_result ).
 
   ENDMETHOD.
 

--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -407,7 +407,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
         type = zif_abapgit_definitions=>c_type-commit
         sha1 = iv_branch.
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'commit not found.' ).
+      zcx_abapgit_exception=>raise( 'commit not found' ).
     ENDIF.
     ls_commit = zcl_abapgit_git_pack=>decode_commit( ls_object-data ).
 
@@ -441,11 +441,11 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
 
     zcl_abapgit_git_transport=>upload_pack_by_commit(
       EXPORTING
-        iv_url          = iv_url
-        iv_hash         = iv_commit_hash
+        iv_url     = iv_url
+        iv_hash    = iv_commit_hash
       IMPORTING
-        et_objects      = rs_result-objects
-        ev_commit       = rs_result-commit ).
+        et_objects = rs_result-objects
+        ev_commit  = rs_result-commit ).
 
     pull(
       EXPORTING

--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -30,7 +30,7 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
     CLASS-METHODS pull_by_commit
       IMPORTING
         !iv_url          TYPE string
-        !iv_commit_hash  TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
+        !iv_commit_hash  TYPE zif_abapgit_definitions=>ty_sha1
       RETURNING
         VALUE(rs_result) TYPE ty_pull_result
       RAISING

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -104,7 +104,7 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
     li_progress->show( iv_current = 1
                        iv_text    = 'Fetch remote files' ).
 
-    ls_pull = zcl_abapgit_git_porcelain=>pull(
+    ls_pull = zcl_abapgit_git_porcelain=>pull_by_branch(
       iv_url         = get_url( )
       iv_branch_name = get_branch_name( ) ).
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -110,7 +110,7 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
     set_files_remote( ls_pull-files ).
     set_objects( ls_pull-objects ).
-    mv_branch = ls_pull-branch.
+    mv_branch = ls_pull-commit.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Related to #3040

This PR implements `pull_by_commit`, renames `pull` to `pull_by_branch` and adds a private method `pull` to merge redundant code of the 2 public methods.