### PR TITLE
ZABAPGIT_FORMS: Remove obsolete form package_popup and related callback handler

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -697,39 +697,6 @@ CLASS ZCL_ABAPGIT_POPUPS IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_popups~package_popup_callback.
-
-    DATA: ls_package_data TYPE scompkdtln,
-          lv_create       TYPE abap_bool.
-
-    FIELD-SYMBOLS: <ls_fpackage> LIKE LINE OF ct_fields.
-
-    CLEAR cs_error.
-
-    IF iv_code = 'COD1'.
-      cv_show_popup = abap_true.
-
-      READ TABLE ct_fields ASSIGNING <ls_fpackage> WITH KEY fieldname = 'DEVCLASS'.
-      ASSERT sy-subrc = 0.
-      ls_package_data-devclass = <ls_fpackage>-value.
-
-      zif_abapgit_popups~popup_to_create_package(
-        IMPORTING
-          es_package_data = ls_package_data
-          ev_create       = lv_create ).
-      IF lv_create = abap_false.
-        RETURN.
-      ENDIF.
-
-      zcl_abapgit_factory=>get_sap_package( ls_package_data-devclass )->create( ls_package_data ).
-      COMMIT WORK.
-
-      <ls_fpackage>-value = ls_package_data-devclass.
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_popups~popup_folder_logic.
 
     DATA: lt_fields       TYPE TABLE OF sval.

--- a/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
@@ -40,10 +40,6 @@ CLASS ltcl_abapgit_popups_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~package_popup_callback.
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~popup_folder_logic.
 
   ENDMETHOD.

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -135,15 +135,6 @@ INTERFACE zif_abapgit_popups
       !cv_show_popup TYPE char01
     RAISING
       zcx_abapgit_exception .
-  METHODS package_popup_callback
-    IMPORTING
-      !iv_code       TYPE clike
-    CHANGING
-      !ct_fields     TYPE zif_abapgit_definitions=>ty_sval_tt
-      !cs_error      TYPE svale
-      !cv_show_popup TYPE char01
-    RAISING
-      zcx_abapgit_exception .
   METHODS popup_transport_request
     IMPORTING
       !is_transport_type  TYPE zif_abapgit_definitions=>ty_transport_type

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -59,6 +59,46 @@ FORM exit RAISING zcx_abapgit_exception.
   ENDCASE.
 ENDFORM.
 
+*&---------------------------------------------------------------------*	
+*&      Form  branch_popup	
+*&---------------------------------------------------------------------*	
+*       text	
+*----------------------------------------------------------------------*	
+*      -->TT_FIELDS      text	
+*      -->PV_CODE        text	
+*      -->CS_ERROR       text	
+*      -->CV_SHOW_POPUP  text	
+*      -->RAISING        text	
+*      -->zcx_abapgit_exception  text	
+*      -->##CALLED       text	
+*      -->##NEEDED       text	
+*----------------------------------------------------------------------*	
+FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt	
+                  USING    pv_code TYPE clike	
+                  CHANGING cs_error TYPE svale	
+                           cv_show_popup TYPE c	
+                  RAISING zcx_abapgit_exception ##called ##needed.	
+* called dynamically from function module POPUP_GET_VALUES_USER_BUTTONS	
+
+  DATA: lx_error  TYPE REF TO zcx_abapgit_exception,	
+        li_popups TYPE REF TO zif_abapgit_popups.	
+
+  TRY.	
+      li_popups = zcl_abapgit_ui_factory=>get_popups( ).	
+      li_popups->branch_popup_callback(	
+        EXPORTING	
+          iv_code       = pv_code	
+        CHANGING	
+          ct_fields     = tt_fields[]	
+          cs_error      = cs_error	
+          cv_show_popup = cv_show_popup ).	
+
+    CATCH zcx_abapgit_exception INTO lx_error.	
+      MESSAGE lx_error TYPE 'S' DISPLAY LIKE 'E'.	
+  ENDTRY.	
+
+ENDFORM.                    "branch_popup
+
 FORM password_popup
       USING
         pv_repo_url TYPE string

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -32,6 +32,46 @@ FORM open_gui RAISING zcx_abapgit_exception.
 
 ENDFORM.
 
+*&---------------------------------------------------------------------*
+*&      Form  branch_popup
+*&---------------------------------------------------------------------*
+*       text
+*----------------------------------------------------------------------*
+*      -->TT_FIELDS      text
+*      -->PV_CODE        text
+*      -->CS_ERROR       text
+*      -->CV_SHOW_POPUP  text
+*      -->RAISING        text
+*      -->zcx_abapgit_exception  text
+*      -->##CALLED       text
+*      -->##NEEDED       text
+*----------------------------------------------------------------------*
+FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt
+                  USING    pv_code TYPE clike
+                  CHANGING cs_error TYPE svale
+                           cv_show_popup TYPE c
+                  RAISING zcx_abapgit_exception ##called ##needed.
+* called dynamically from function module POPUP_GET_VALUES_USER_BUTTONS
+
+  DATA: lx_error  TYPE REF TO zcx_abapgit_exception,
+        li_popups TYPE REF TO zif_abapgit_popups.
+
+  TRY.
+      li_popups = zcl_abapgit_ui_factory=>get_popups( ).
+      li_popups->branch_popup_callback(
+        EXPORTING
+          iv_code       = pv_code
+        CHANGING
+          ct_fields     = tt_fields[]
+          cs_error      = cs_error
+          cv_show_popup = cv_show_popup ).
+
+    CATCH zcx_abapgit_exception INTO lx_error.
+      MESSAGE lx_error TYPE 'S' DISPLAY LIKE 'E'.
+  ENDTRY.
+
+ENDFORM.                    "branch_popup
+
 FORM output.
   DATA: lt_ucomm TYPE TABLE OF sy-ucomm.
 
@@ -59,46 +99,6 @@ FORM exit RAISING zcx_abapgit_exception.
   ENDCASE.
 ENDFORM.
 
-*&---------------------------------------------------------------------*	
-*&      Form  branch_popup	
-*&---------------------------------------------------------------------*	
-*       text	
-*----------------------------------------------------------------------*	
-*      -->TT_FIELDS      text	
-*      -->PV_CODE        text	
-*      -->CS_ERROR       text	
-*      -->CV_SHOW_POPUP  text	
-*      -->RAISING        text	
-*      -->zcx_abapgit_exception  text	
-*      -->##CALLED       text	
-*      -->##NEEDED       text	
-*----------------------------------------------------------------------*	
-FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt	
-                  USING    pv_code TYPE clike	
-                  CHANGING cs_error TYPE svale	
-                           cv_show_popup TYPE c	
-                  RAISING zcx_abapgit_exception ##called ##needed.	
-* called dynamically from function module POPUP_GET_VALUES_USER_BUTTONS	
-
-  DATA: lx_error  TYPE REF TO zcx_abapgit_exception,	
-        li_popups TYPE REF TO zif_abapgit_popups.	
-
-  TRY.	
-      li_popups = zcl_abapgit_ui_factory=>get_popups( ).	
-      li_popups->branch_popup_callback(	
-        EXPORTING	
-          iv_code       = pv_code	
-        CHANGING	
-          ct_fields     = tt_fields[]	
-          cs_error      = cs_error	
-          cv_show_popup = cv_show_popup ).	
-
-    CATCH zcx_abapgit_exception INTO lx_error.	
-      MESSAGE lx_error TYPE 'S' DISPLAY LIKE 'E'.	
-  ENDTRY.	
-
-ENDFORM.                    "branch_popup
-
 FORM password_popup
       USING
         pv_repo_url TYPE string
@@ -108,10 +108,10 @@ FORM password_popup
 
   lcl_password_dialog=>popup(
     EXPORTING
-      iv_repo_url = pv_repo_url
+      iv_repo_url     = pv_repo_url
     CHANGING
-      cv_user     = cv_user
-      cv_pass     = cv_pass ).
+      cv_user         = cv_user
+      cv_pass         = cv_pass ).
 
 ENDFORM.
 

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -32,72 +32,6 @@ FORM open_gui RAISING zcx_abapgit_exception.
 
 ENDFORM.
 
-*&---------------------------------------------------------------------*
-*&      Form  branch_popup
-*&---------------------------------------------------------------------*
-*       text
-*----------------------------------------------------------------------*
-*      -->TT_FIELDS      text
-*      -->PV_CODE        text
-*      -->CS_ERROR       text
-*      -->CV_SHOW_POPUP  text
-*      -->RAISING        text
-*      -->zcx_abapgit_exception  text
-*      -->##CALLED       text
-*      -->##NEEDED       text
-*----------------------------------------------------------------------*
-FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt
-                  USING    pv_code TYPE clike
-                  CHANGING cs_error TYPE svale
-                           cv_show_popup TYPE c
-                  RAISING zcx_abapgit_exception ##called ##needed.
-* called dynamically from function module POPUP_GET_VALUES_USER_BUTTONS
-
-  DATA: lx_error  TYPE REF TO zcx_abapgit_exception,
-        li_popups TYPE REF TO zif_abapgit_popups.
-
-  TRY.
-      li_popups = zcl_abapgit_ui_factory=>get_popups( ).
-      li_popups->branch_popup_callback(
-        EXPORTING
-          iv_code       = pv_code
-        CHANGING
-          ct_fields     = tt_fields[]
-          cs_error      = cs_error
-          cv_show_popup = cv_show_popup ).
-
-    CATCH zcx_abapgit_exception INTO lx_error.
-      MESSAGE lx_error TYPE 'S' DISPLAY LIKE 'E'.
-  ENDTRY.
-
-ENDFORM.                    "branch_popup
-
-FORM package_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt
-                   USING    pv_code TYPE clike
-                   CHANGING cs_error TYPE svale
-                            cv_show_popup TYPE c
-                   RAISING  zcx_abapgit_exception ##called ##needed.
-* called dynamically from function module POPUP_GET_VALUES_USER_BUTTONS
-
-  DATA: lx_error  TYPE REF TO zcx_abapgit_exception,
-        li_popups TYPE REF TO zif_abapgit_popups.
-
-  TRY.
-      li_popups = zcl_abapgit_ui_factory=>get_popups( ).
-      li_popups->package_popup_callback(
-        EXPORTING
-          iv_code       = pv_code
-        CHANGING
-          ct_fields     = tt_fields[]
-          cs_error      = cs_error
-          cv_show_popup = cv_show_popup ).
-
-    CATCH zcx_abapgit_exception INTO lx_error.
-      MESSAGE lx_error TYPE 'S' DISPLAY LIKE 'E'.
-  ENDTRY.
-
-ENDFORM.                    "package_popup
-
 FORM output.
   DATA: lt_ucomm TYPE TABLE OF sy-ucomm.
 
@@ -134,10 +68,10 @@ FORM password_popup
 
   lcl_password_dialog=>popup(
     EXPORTING
-      iv_repo_url     = pv_repo_url
+      iv_repo_url = pv_repo_url
     CHANGING
-      cv_user         = cv_user
-      cv_pass         = cv_pass ).
+      cv_user     = cv_user
+      cv_pass     = cv_pass ).
 
 ENDFORM.
 


### PR DESCRIPTION
Form package_popup in ZABAPGIT_FORMS and its related callback handler aren't being used anymore and can thus be removed.