### PR TITLE
ZCL_ABAPGIT_GIT_PORCELAIN=>FULL_TREE: Rename iv_branch to iv_parent

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -75,7 +75,7 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
     CLASS-METHODS full_tree
       IMPORTING
         !it_objects        TYPE zif_abapgit_definitions=>ty_objects_tt
-        !iv_branch         TYPE zif_abapgit_definitions=>ty_sha1
+        !iv_parent         TYPE zif_abapgit_definitions=>ty_sha1
       RETURNING
         VALUE(rt_expanded) TYPE zif_abapgit_definitions=>ty_expanded_tt
       RAISING
@@ -405,7 +405,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
     READ TABLE it_objects INTO ls_object
       WITH KEY type COMPONENTS
         type = zif_abapgit_definitions=>c_type-commit
-        sha1 = iv_branch.
+        sha1 = iv_parent.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( 'commit not found' ).
     ENDIF.
@@ -488,7 +488,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
 
 
     lt_expanded = full_tree( it_objects = it_old_objects
-                             iv_branch  = iv_parent ).
+                             iv_parent  = iv_parent ).
 
     lt_stage = io_stage->get_all( ).
     LOOP AT lt_stage ASSIGNING <ls_stage>.

--- a/src/zcl_abapgit_merge.clas.abap
+++ b/src/zcl_abapgit_merge.clas.abap
@@ -433,13 +433,13 @@ CLASS ZCL_ABAPGIT_MERGE IMPLEMENTATION.
 
     ms_merge-stree = zcl_abapgit_git_porcelain=>full_tree(
       it_objects = mt_objects
-      iv_branch  = ms_merge-source-sha1 ).
+      iv_parent  = ms_merge-source-sha1 ).
     ms_merge-ttree = zcl_abapgit_git_porcelain=>full_tree(
       it_objects = mt_objects
-      iv_branch  = ms_merge-target-sha1 ).
+      iv_parent  = ms_merge-target-sha1 ).
     ms_merge-ctree = zcl_abapgit_git_porcelain=>full_tree(
       it_objects = mt_objects
-      iv_branch  = ms_merge-common-commit ).
+      iv_parent  = ms_merge-common-commit ).
 
     calculate_result( ).
 


### PR DESCRIPTION
Related #3040

Method `full_tree` is to be used for commit hashes too. As the import parameters type is already of type ty_sha1 and the functionality can be used without a change for commit hashes there is no need to implement a commit hash-related method.

**Change Log:**
- Renamed `iv_branch` of `full_tree` to `iv_parent`
- Updated related caller