### PR TITLE
Refactor password dialog

### DIFF
--- a/src/http/zcl_abapgit_http_digest.clas.abap
+++ b/src/http/zcl_abapgit_http_digest.clas.abap
@@ -28,28 +28,29 @@ CLASS zcl_abapgit_http_digest DEFINITION
 
     CLASS-DATA: gv_nc TYPE n LENGTH 8.
 
-    CLASS-METHODS md5
-      IMPORTING
-        iv_data        TYPE string
-      RETURNING
-        VALUE(rv_hash) TYPE string
-      RAISING
-        zcx_abapgit_exception.
-    METHODS hash
-      IMPORTING
-        iv_qop             TYPE string
-        iv_nonce           TYPE string
-        iv_uri             TYPE string
-        iv_method          TYPE string
-        iv_cnonse          TYPE string
-      RETURNING
-        VALUE(rv_response) TYPE string
-      RAISING
-        zcx_abapgit_exception.
-    METHODS parse
-      IMPORTING
-        ii_client  TYPE REF TO if_http_client
-        !iv_digest TYPE string.
+    CLASS-METHODS:
+      md5
+        IMPORTING
+                  iv_data        TYPE string
+        RETURNING
+                  VALUE(rv_hash) TYPE string
+        RAISING   zcx_abapgit_exception.
+
+    METHODS:
+      hash
+        IMPORTING
+                  iv_qop             TYPE string
+                  iv_nonce           TYPE string
+                  iv_uri             TYPE string
+                  iv_method          TYPE string
+                  iv_cnonse          TYPE string
+        RETURNING
+                  VALUE(rv_response) TYPE string
+        RAISING   zcx_abapgit_exception,
+      parse
+        IMPORTING
+          ii_client TYPE REF TO if_http_client
+          !iv_digest TYPE string.
 
 ENDCLASS.
 

--- a/src/http/zcl_abapgit_proxy_auth.clas.abap
+++ b/src/http/zcl_abapgit_proxy_auth.clas.abap
@@ -8,40 +8,29 @@ CLASS zcl_abapgit_proxy_auth DEFINITION
       run
         IMPORTING ii_client TYPE REF TO if_http_client
         RAISING   zcx_abapgit_exception.
-
   PRIVATE SECTION.
     CLASS-DATA: gv_username TYPE string,
                 gv_password TYPE string.
-
-    CLASS-METHODS: enter RAISING zcx_abapgit_exception.
-
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_PROXY_AUTH IMPLEMENTATION.
-
-
-  METHOD enter.
-
-    zcl_abapgit_password_dialog=>popup(
-      EXPORTING
-        iv_repo_url = 'Proxy Authentication'
-      CHANGING
-        cv_user     = gv_username
-        cv_pass     = gv_password ).
-
-    IF gv_username IS INITIAL OR gv_password IS INITIAL.
-      zcx_abapgit_exception=>raise( 'Proxy auth failed' ).
-    ENDIF.
-
-  ENDMETHOD.
+CLASS zcl_abapgit_proxy_auth IMPLEMENTATION.
 
 
   METHOD run.
 
+    DATA lv_auth TYPE string.
+
     IF gv_username IS INITIAL OR gv_password IS INITIAL.
-      enter( ).
+      lv_auth = zcl_abapgit_login_manager=>get( zcl_abapgit_login_manager=>gc_proxy ).
+
+      IF lv_auth IS INITIAL.
+        " If proxy authorization is not set, redirect to "Login Page"
+        zcl_abapgit_login_manager=>login( zcl_abapgit_login_manager=>gc_proxy ).
+      ELSE.
+        SPLIT lv_auth AT ':' INTO gv_username gv_password.
+      ENDIF.
     ENDIF.
 
     ii_client->authenticate(

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -295,7 +295,7 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
       CATCH zcx_abapgit_cancel ##NO_HANDLER.
         " Do nothing = gc_event_state-no_more_act
       CATCH zcx_abapgit_exception INTO lx_exception.
-        IF lx_exception->is_login_error( ) = abap_true.
+        IF lx_exception->is_login( ) = abap_true.
           handle_login( lx_exception ).
         ELSE.
           handle_error( lx_exception ).

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -40,13 +40,13 @@ CLASS zcl_abapgit_gui DEFINITION
       RAISING
         zcx_abapgit_exception .
     METHODS on_event
-        FOR EVENT sapevent OF zif_abapgit_html_viewer
+          FOR EVENT sapevent OF zif_abapgit_html_viewer
       IMPORTING
-        !action
-        !frame
-        !getdata
-        !postdata
-        !query_table .
+          !action
+          !frame
+          !getdata
+          !postdata
+          !query_table .
     METHODS constructor
       IMPORTING
         !io_component         TYPE REF TO object OPTIONAL

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -55,6 +55,7 @@ span.separator {
 .pad-sides    { padding-left: 0.3em; padding-right: 0.3em; }
 .margin-v5    { margin-top: 0.5em; margin-bottom: 0.5em; }
 .margin-v1    { margin-top: 1em; margin-bottom: 1em; }
+.margin-30px  { margin-top: 30px !important; margin-bottom: 30px !important; }
 .indent5em    { padding-left: 0.5em; }
 .pad4px       { padding: 4px; }
 .w100         { width: 100%; }
@@ -70,8 +71,8 @@ span.separator {
 .wmax600px    { max-width: 600px }
 .auto-center  { /* use with max-width */
   width: 100%;
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 /* PANELS */
@@ -1091,7 +1092,8 @@ settings_tab tr:first-child td { border-top: 0px; }
 .dialog input[type="checkbox"] + label {
   display: inline-block;
 }
-.dialog input[type="text"] {
+.dialog input[type="text"], 
+.dialog input[type="password"] {
   width: 100%;
   box-sizing : border-box;
   height: 2.5em;

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -67,6 +67,10 @@ div.panel.error {
   color: #d41919;
   background-color: #fad6d6;
 }
+div.panel.warning {
+  color: #efb301;
+  background-color: lightyellow;
+}
 #debug-output { color: var(--theme-debug-color); }
 div.dummydiv { background-color: var(--theme-container-background-color); }
 

--- a/src/ui/zabapgit_css_theme_default.w3mi.xml
+++ b/src/ui/zabapgit_css_theme_default.w3mi.xml
@@ -9,13 +9,13 @@
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_CSS_THEME_DEFAULT</OBJID>
      <NAME>fileextension</NAME>
-     <VALUE>.CSS</VALUE>
+     <VALUE>.css</VALUE>
     </WWWPARAMS>
     <WWWPARAMS>
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_CSS_THEME_DEFAULT</OBJID>
      <NAME>filename</NAME>
-     <VALUE>~wwwtmp.CSS</VALUE>
+     <VALUE>default_theme.css</VALUE>
     </WWWPARAMS>
     <WWWPARAMS>
      <RELID>MI</RELID>

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -72,9 +72,10 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ri_html)       TYPE REF TO zif_abapgit_html .
     CLASS-METHODS render_warning_banner
       IMPORTING
-        !iv_text       TYPE string
+        !iv_text        TYPE string
+        !iv_extra_style TYPE string OPTIONAL
       RETURNING
-        VALUE(ri_html) TYPE REF TO zif_abapgit_html .
+        VALUE(ri_html)  TYPE REF TO zif_abapgit_html .
     CLASS-METHODS render_infopanel
       IMPORTING
         !iv_div_id     TYPE string
@@ -681,18 +682,8 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
                       iv_class = |url| ).
 
       IF iv_show_commit = abap_true.
-
-        TRY.
-            render_repo_top_commit_hash( ii_html        = ri_html
-                                         io_repo_online = lo_repo_online ).
-          CATCH zcx_abapgit_exception INTO lx_error.
-            " In case of missing or wrong credentials, show message in status bar
-            lv_hint = lx_error->get_text( ).
-            IF lv_hint CS 'credentials'.
-              MESSAGE lv_hint TYPE 'S' DISPLAY LIKE 'E'.
-            ENDIF.
-        ENDTRY.
-
+        render_repo_top_commit_hash( ii_html        = ri_html
+                                     io_repo_online = lo_repo_online ).
       ENDIF.
 
     ENDIF.
@@ -802,8 +793,15 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
   METHOD render_warning_banner.
 
+    DATA lv_class TYPE string VALUE 'panel warning center'.
+
+    IF iv_extra_style IS NOT INITIAL.
+      lv_class = lv_class && ` ` && iv_extra_style.
+    ENDIF.
+
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-    ri_html->add( '<div class="dummydiv warning">' ).
+
+    ri_html->add( |<div class="{ lv_class }">| ).
     ri_html->add( |{ ri_html->icon( 'exclamation-triangle/yellow' ) } { iv_text }| ).
     ri_html->add( '</div>' ).
 

--- a/src/ui/zcl_abapgit_gui_page_login.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_login.clas.abap
@@ -64,6 +64,8 @@ CLASS zcl_abapgit_gui_page_login DEFINITION
       RAISING
         zcx_abapgit_exception .
     METHODS get_form_schema
+      IMPORTING
+        iv_username    TYPE string
       RETURNING
         VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form .
 ENDCLASS.
@@ -81,12 +83,12 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
     mv_count  = iv_count.
     mv_digest = iv_digest.
     mo_page   = io_page.
+    mv_default_user = zcl_abapgit_login_manager=>get_default_user( mv_url ).
 
     CREATE OBJECT mo_validation_log.
     CREATE OBJECT mo_form_data.
-    mo_form = get_form_schema( ).
+    mo_form = get_form_schema( mv_default_user ).
 
-    mv_default_user = zcl_abapgit_login_manager=>get_default_user( mv_url ).
     mo_form_data->set( iv_key = c_id-user
                        iv_val = mv_default_user ).
 
@@ -129,12 +131,7 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
 
     DATA lv_title TYPE sy-title.
 
-    IF iv_url = zcl_abapgit_login_manager=>gc_proxy.
-      rv_host = 'Proxy'.
-    ELSE.
-      rv_host = zcl_abapgit_url=>host( iv_url ).
-      SPLIT rv_host AT '//' INTO lv_title rv_host.
-    ENDIF.
+    rv_host = zcl_abapgit_login_manager=>get_host( iv_url ).
 
     lv_title = |Login: { rv_host }|.
     EXPORT title = lv_title TO MEMORY ID zif_abapgit_definitions=>gc_memoryid_title.
@@ -149,12 +146,12 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
     ro_form->text(
       iv_name        = c_id-user
       iv_required    = abap_true
-      iv_autofocus   = boolc( mv_default_user IS INITIAL )
+      iv_autofocus   = boolc( iv_username IS INITIAL )
       iv_label       = 'User Name'
     )->text(
       iv_name        = c_id-password
       iv_required    = abap_true
-      iv_autofocus   = boolc( mv_default_user IS NOT INITIAL )
+      iv_autofocus   = boolc( iv_username IS NOT INITIAL )
       iv_password    = abap_true
       iv_label       = 'Password or Token'
     )->command(

--- a/src/ui/zcl_abapgit_gui_page_login.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_login.clas.abap
@@ -1,0 +1,243 @@
+CLASS zcl_abapgit_gui_page_login DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_component
+  FINAL
+  CREATE PRIVATE .
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_gui_event_handler .
+    INTERFACES zif_abapgit_gui_renderable .
+
+    CLASS-METHODS create
+      IMPORTING
+        !iv_url        TYPE string
+        !iv_count      TYPE i
+        !iv_digest     TYPE string
+        !io_page       TYPE REF TO zif_abapgit_gui_renderable
+      RETURNING
+        VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
+      RAISING
+        zcx_abapgit_exception .
+    METHODS constructor
+      IMPORTING
+        !iv_url    TYPE string
+        !iv_count  TYPE i
+        !iv_digest TYPE string
+        !io_page   TYPE REF TO zif_abapgit_gui_renderable OPTIONAL
+      RAISING
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      BEGIN OF c_id,
+        url      TYPE string VALUE 'url',
+        user     TYPE string VALUE 'user',
+        password TYPE string VALUE 'password',
+      END OF c_id .
+    CONSTANTS:
+      BEGIN OF c_event,
+        go_back TYPE string VALUE 'go_back',
+        login   TYPE string VALUE 'login',
+      END OF c_event .
+    DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map .
+    DATA mo_form_data TYPE REF TO zcl_abapgit_string_map .
+    DATA mo_form TYPE REF TO zcl_abapgit_html_form .
+    DATA mv_url TYPE string .
+    DATA mv_count TYPE i .
+    DATA mv_digest TYPE string.
+    DATA mo_page TYPE REF TO zif_abapgit_gui_renderable .
+    DATA mv_default_user TYPE string .
+
+    CLASS-METHODS export_title
+      IMPORTING
+        !iv_url        TYPE string
+      RETURNING
+        VALUE(rv_host) TYPE string
+      RAISING
+        zcx_abapgit_exception .
+    METHODS validate_form
+      IMPORTING
+        !io_form_data            TYPE REF TO zcl_abapgit_string_map
+      RETURNING
+        VALUE(ro_validation_log) TYPE REF TO zcl_abapgit_string_map
+      RAISING
+        zcx_abapgit_exception .
+    METHODS get_form_schema
+      RETURNING
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form .
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( ).
+
+    mv_url          = iv_url.
+    mv_count        = iv_count.
+    mv_digest       = iv_digest.
+    mo_page         = io_page.
+    mv_default_user = zcl_abapgit_persistence_user=>get_instance( )->get_repo_login( iv_url ).
+
+    CREATE OBJECT mo_validation_log.
+    CREATE OBJECT mo_form_data.
+    mo_form = get_form_schema( ).
+
+    mo_form_data->set( iv_key = c_id-user
+                       iv_val = mv_default_user ).
+
+  ENDMETHOD.
+
+
+  METHOD create.
+
+    DATA:
+      lo_component TYPE REF TO zcl_abapgit_gui_page_login,
+      lo_repo      TYPE REF TO zcl_abapgit_repo,
+      lv_host      TYPE string,
+      lv_name      TYPE string.
+
+    CREATE OBJECT lo_component
+      EXPORTING
+        iv_url    = iv_url
+        iv_count  = iv_count
+        iv_digest = iv_digest
+        io_page   = io_page.
+
+    lv_host = export_title( iv_url ).
+
+    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get_repo_from_url( iv_url ).
+    IF lo_repo IS BOUND.
+      lv_name = |({ zcl_abapgit_html=>icon( 'cloud-upload-alt/grey' )
+                } { lo_repo->get_name( ) })|.
+    ENDIF.
+
+    ri_page = zcl_abapgit_gui_page_hoc=>create(
+      iv_page_title      = |Login to <b>{ lv_host }</b> { lv_name }|
+      ii_child_component = lo_component ).
+
+  ENDMETHOD.
+
+
+  METHOD export_title.
+
+    DATA lv_title TYPE sy-title.
+
+    rv_host = to_lower( zcl_abapgit_url=>host( iv_url ) ).
+    SPLIT rv_host AT '//' INTO lv_title rv_host.
+
+    lv_title = |Login: { rv_host }|.
+    EXPORT title = lv_title TO MEMORY ID zif_abapgit_definitions=>gc_memoryid_title.
+
+  ENDMETHOD.
+
+
+  METHOD get_form_schema.
+
+    ro_form = zcl_abapgit_html_form=>create( iv_form_id = 'login-form' ).
+
+    ro_form->text(
+      iv_name        = c_id-user
+      iv_required    = abap_true
+      iv_autofocus   = boolc( mv_default_user IS INITIAL )
+      iv_label       = 'User Name'
+    )->text(
+      iv_name        = c_id-password
+      iv_required    = abap_true
+      iv_autofocus   = boolc( mv_default_user IS NOT INITIAL )
+      iv_password    = abap_true
+      iv_label       = 'Password/Token'
+    )->command(
+      iv_label       = 'Login'
+      iv_is_main     = abap_true
+      iv_action      = c_event-login
+    )->command(
+      iv_label       = 'Cancel'
+      iv_action      = c_event-go_back ).
+
+  ENDMETHOD.
+
+
+  METHOD validate_form.
+
+    ro_validation_log = mo_form->validate_required_fields( io_form_data ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_event_handler~on_event.
+
+    DATA lv_user TYPE string.
+
+    " import data from html before re-render
+    mo_form_data = mo_form->normalize_form_data( ii_event->form_data( ) ).
+
+    CASE ii_event->mv_action.
+      WHEN c_event-go_back.
+        zcl_abapgit_http=>reset_login( mv_url ).
+
+        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_main.
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.
+      WHEN c_event-login.
+        mo_validation_log = validate_form( mo_form_data ).
+
+        IF mo_validation_log->is_empty( ) = abap_true.
+          lv_user = mo_form_data->get( c_id-user ).
+
+          " Save new default user for repo
+          IF lv_user <> mv_default_user.
+            mv_default_user = lv_user.
+            zcl_abapgit_persistence_user=>get_instance( )->set_repo_login(
+              iv_url   = mv_url
+              iv_login = mv_default_user ).
+          ENDIF.
+
+          " Pass username and password to login manager
+          zcl_abapgit_login_manager=>set(
+            iv_uri      = mv_url
+            iv_username = lv_user
+            iv_password = mo_form_data->get( c_id-password )
+            iv_digest   = mv_digest ).
+
+          rs_handled-page  = mo_page.
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.
+        ELSE.
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render. " Display errors
+        ENDIF.
+    ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_renderable~render.
+
+    DATA lv_msg TYPE string.
+
+    gui_services( )->register_event_handler( me ).
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    IF mv_count = 1.
+      lv_msg = 'You have to login to access this repository'.
+      ri_html->add( zcl_abapgit_gui_chunk_lib=>render_warning_banner(
+                      iv_text        = lv_msg
+                      iv_extra_style = 'wmax600px auto-center margin-v1' ) ).
+    ELSEIF mv_count > 1.
+      lv_msg = 'Sorry, username or password are not correct. Try again!'.
+      ri_html->add( zcl_abapgit_gui_chunk_lib=>render_error(
+                      iv_error       = lv_msg
+                      iv_extra_style = 'wmax600px auto-center margin-v1' ) ).
+    ENDIF.
+
+    ri_html->add( mo_form->render(
+      iv_form_class     = 'dialog wmax600px auto-center margin-30px'
+      io_values         = mo_form_data
+      io_validation_log = mo_validation_log ) ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_login.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_login.clas.abap
@@ -32,21 +32,20 @@ CLASS zcl_abapgit_gui_page_login DEFINITION
 
     CONSTANTS:
       BEGIN OF c_id,
-        url      TYPE string VALUE 'url',
         user     TYPE string VALUE 'user',
         password TYPE string VALUE 'password',
       END OF c_id .
     CONSTANTS:
       BEGIN OF c_event,
-        go_back TYPE string VALUE 'go_back',
         login   TYPE string VALUE 'login',
+        go_back TYPE string VALUE 'go_back',
       END OF c_event .
     DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map .
     DATA mo_form_data TYPE REF TO zcl_abapgit_string_map .
     DATA mo_form TYPE REF TO zcl_abapgit_html_form .
     DATA mv_url TYPE string .
     DATA mv_count TYPE i .
-    DATA mv_digest TYPE string.
+    DATA mv_digest TYPE string .
     DATA mo_page TYPE REF TO zif_abapgit_gui_renderable .
     DATA mv_default_user TYPE string .
 
@@ -78,16 +77,16 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
 
     super->constructor( ).
 
-    mv_url          = iv_url.
-    mv_count        = iv_count.
-    mv_digest       = iv_digest.
-    mo_page         = io_page.
-    mv_default_user = zcl_abapgit_persistence_user=>get_instance( )->get_repo_login( iv_url ).
+    mv_url    = iv_url.
+    mv_count  = iv_count.
+    mv_digest = iv_digest.
+    mo_page   = io_page.
 
     CREATE OBJECT mo_validation_log.
     CREATE OBJECT mo_form_data.
     mo_form = get_form_schema( ).
 
+    mv_default_user = zcl_abapgit_login_manager=>get_default_user( mv_url ).
     mo_form_data->set( iv_key = c_id-user
                        iv_val = mv_default_user ).
 
@@ -111,10 +110,12 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
 
     lv_host = export_title( iv_url ).
 
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get_repo_from_url( iv_url ).
-    IF lo_repo IS BOUND.
-      lv_name = |({ zcl_abapgit_html=>icon( 'cloud-upload-alt/grey' )
-                } { lo_repo->get_name( ) })|.
+    IF iv_url <> zcl_abapgit_login_manager=>gc_proxy.
+      lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get_repo_from_url( iv_url ).
+      IF lo_repo IS BOUND.
+        lv_name = |({ zcl_abapgit_html=>icon( 'cloud-upload-alt/grey' )
+                  } { lo_repo->get_name( ) })|.
+      ENDIF.
     ENDIF.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
@@ -128,8 +129,12 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
 
     DATA lv_title TYPE sy-title.
 
-    rv_host = to_lower( zcl_abapgit_url=>host( iv_url ) ).
-    SPLIT rv_host AT '//' INTO lv_title rv_host.
+    IF iv_url = zcl_abapgit_login_manager=>gc_proxy.
+      rv_host = 'Proxy'.
+    ELSE.
+      rv_host = zcl_abapgit_url=>host( iv_url ).
+      SPLIT rv_host AT '//' INTO lv_title rv_host.
+    ENDIF.
 
     lv_title = |Login: { rv_host }|.
     EXPORT title = lv_title TO MEMORY ID zif_abapgit_definitions=>gc_memoryid_title.
@@ -151,7 +156,7 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
       iv_required    = abap_true
       iv_autofocus   = boolc( mv_default_user IS NOT INITIAL )
       iv_password    = abap_true
-      iv_label       = 'Password/Token'
+      iv_label       = 'Password or Token'
     )->command(
       iv_label       = 'Login'
       iv_is_main     = abap_true
@@ -172,14 +177,14 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
 
-    DATA lv_user TYPE string.
+    DATA lv_username TYPE string.
 
     " import data from html before re-render
     mo_form_data = mo_form->normalize_form_data( ii_event->form_data( ) ).
 
     CASE ii_event->mv_action.
       WHEN c_event-go_back.
-        zcl_abapgit_http=>reset_login( mv_url ).
+        zcl_abapgit_login_manager=>reset_count( mv_url ).
 
         CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_main.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.
@@ -187,20 +192,17 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
         mo_validation_log = validate_form( mo_form_data ).
 
         IF mo_validation_log->is_empty( ) = abap_true.
-          lv_user = mo_form_data->get( c_id-user ).
+          lv_username = mo_form_data->get( c_id-user ).
 
           " Save new default user for repo
-          IF lv_user <> mv_default_user.
-            mv_default_user = lv_user.
-            zcl_abapgit_persistence_user=>get_instance( )->set_repo_login(
-              iv_url   = mv_url
-              iv_login = mv_default_user ).
-          ENDIF.
+          zcl_abapgit_login_manager=>set_default_user(
+            iv_uri      = mv_url
+            iv_username = lv_username ).
 
           " Pass username and password to login manager
           zcl_abapgit_login_manager=>set(
             iv_uri      = mv_url
-            iv_username = lv_user
+            iv_username = lv_username
             iv_password = mo_form_data->get( c_id-password )
             iv_digest   = mv_digest ).
 
@@ -223,7 +225,12 @@ CLASS zcl_abapgit_gui_page_login IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     IF mv_count = 1.
-      lv_msg = 'You have to login to access this repository'.
+      IF mv_url = zcl_abapgit_login_manager=>gc_proxy.
+        lv_msg = 'You have to login to your proxy, first'.
+      ELSE.
+        lv_msg = 'You have to login to access this repository'.
+      ENDIF.
+
       ri_html->add( zcl_abapgit_gui_chunk_lib=>render_warning_banner(
                       iv_text        = lv_msg
                       iv_extra_style = 'wmax600px auto-center margin-v1' ) ).

--- a/src/ui/zcl_abapgit_gui_page_login.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_login.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_LOGIN</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapgit GUI login page</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -184,7 +184,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -853,6 +853,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
         ri_html->add( '</div>' ).
         ri_html->add( '</div>' ).
       CATCH zcx_abapgit_exception INTO lx_error.
+        IF lx_error->is_login_error( ) = abap_true.
+          RAISE EXCEPTION lx_error.
+        ENDIF.
+
         " Reset 'last shown repo' so next start will go to repo overview
         " and allow troubleshooting of issue
         zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( || ).

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -853,7 +853,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
         ri_html->add( '</div>' ).
         ri_html->add( '</div>' ).
       CATCH zcx_abapgit_exception INTO lx_error.
-        IF lx_error->is_login_error( ) = abap_true.
+        IF lx_error->is_login( ) = abap_true.
           RAISE EXCEPTION lx_error.
         ENDIF.
 

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -34,6 +34,8 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_upper_case  TYPE abap_bool DEFAULT abap_false
         !iv_placeholder TYPE string OPTIONAL
         !iv_side_action TYPE string OPTIONAL
+        !iv_password    TYPE abap_bool DEFAULT abap_false
+        !iv_autofocus   TYPE abap_bool DEFAULT abap_false
       RETURNING
         VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form .
     METHODS checkbox
@@ -98,6 +100,8 @@ CLASS zcl_abapgit_html_form DEFINITION
         placeholder   TYPE string,
         required      TYPE string,
         upper_case    TYPE abap_bool,
+        password      TYPE abap_bool,
+        autofocus     TYPE abap_bool,
         item_class    TYPE string,
         error         TYPE string,
         default_value TYPE string,
@@ -142,7 +146,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
+CLASS zcl_abapgit_html_form IMPLEMENTATION.
 
 
   METHOD checkbox.
@@ -356,6 +360,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     DATA lv_opt_id TYPE string.
     DATA lv_error TYPE string.
     DATA lv_value TYPE string.
+    DATA lv_type TYPE string.
+    DATA lv_focus TYPE string.
     DATA lv_checked TYPE string.
     DATA lv_item_class TYPE string.
     FIELD-SYMBOLS <ls_opt> LIKE LINE OF is_field-subitems.
@@ -391,8 +397,20 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
           ii_html->add( '<div class="input-container">' ). " Ugly :(
         ENDIF.
 
-        ii_html->add( |<input type="text" name="{ is_field-name }" id="{
-          is_field-name }"{ is_field-placeholder } value="{ lv_value }"{ is_field-dblclick }>| ).
+        IF is_field-password = abap_true.
+          lv_type = 'password'.
+        ELSE.
+          lv_type = 'text'.
+        ENDIF.
+
+        IF is_field-autofocus = abap_true.
+          lv_focus = ' autofocus'.
+        ELSE.
+          lv_focus = ''.
+        ENDIF.
+
+        ii_html->add( |<input type="{ lv_type }" name="{ is_field-name }" id="{
+          is_field-name }"{ is_field-placeholder } value="{ lv_value }"{ is_field-dblclick }{ lv_focus }>| ).
 
         IF is_field-side_action IS NOT INITIAL.
           ii_html->add( '</div>' ).
@@ -470,6 +488,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     ls_field-name       = iv_name.
     ls_field-label      = iv_label.
     ls_field-upper_case = iv_upper_case.
+    ls_field-password   = iv_password.
+    ls_field-autofocus = iv_autofocus.
 
     IF iv_hint IS NOT INITIAL.
       ls_field-hint    = | title="{ iv_hint }"|.

--- a/src/utils/zcl_abapgit_login_manager.clas.abap
+++ b/src/utils/zcl_abapgit_login_manager.clas.abap
@@ -136,7 +136,7 @@ CLASS zcl_abapgit_login_manager IMPLEMENTATION.
   METHOD get_default_user.
 
     " No default user for proxy
-    IF iv_uri = zcl_abapgit_login_manager=>gc_proxy.
+    IF iv_uri = gc_proxy.
       RETURN.
     ENDIF.
 
@@ -266,7 +266,7 @@ CLASS zcl_abapgit_login_manager IMPLEMENTATION.
   METHOD set_default_user.
 
     " No default user for proxy
-    IF iv_uri = zcl_abapgit_login_manager=>gc_proxy.
+    IF iv_uri = gc_proxy.
       RETURN.
     ENDIF.
 

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -73,7 +73,20 @@ FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt
 ENDFORM.                    "branch_popup
 
 FORM output.
-  DATA: lt_ucomm TYPE TABLE OF sy-ucomm.
+
+  DATA:
+    lt_ucomm TYPE TABLE OF sy-ucomm,
+    lv_title TYPE sy-title.
+
+  " Check if gui title should be set differently
+  " Used by login page (see ZCL_ABAPGIT_GUI_PAGE_LOGIN)
+  IMPORT title = lv_title FROM MEMORY ID zif_abapgit_definitions=>gc_memoryid_title.
+  IF sy-subrc = 0.
+    SET TITLEBAR '%_T' WITH lv_title.
+    FREE MEMORY ID zif_abapgit_definitions=>gc_memoryid_title.
+  ELSE.
+    SET TITLEBAR '%_T' WITH 'abapGit'.
+  ENDIF.
 
   PERFORM set_pf_status IN PROGRAM rsdbrunt IF FOUND.
 

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -76,7 +76,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
+CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
 
   METHOD add.
@@ -330,6 +330,26 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
           eo_repo       = eo_repo
           ev_reason     = ev_reason ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_repo_srv~get_repo_from_url.
+
+    DATA:
+      lt_repo        TYPE zif_abapgit_definitions=>ty_repo_ref_tt,
+      lo_repo        TYPE REF TO zcl_abapgit_repo,
+      lo_repo_online TYPE REF TO zcl_abapgit_repo_online.
+
+    lt_repo = list( ).
+
+    LOOP AT lt_repo INTO lo_repo.
+      CHECK lo_repo->is_offline( ) = abap_false.
+      lo_repo_online ?= lo_repo.
+      CHECK to_upper( lo_repo_online->get_url( ) ) = to_upper( iv_url ).
+      ro_repo ?= lo_repo.
+      RETURN.
+    ENDLOOP.
 
   ENDMETHOD.
 

--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -27,6 +27,9 @@ CLASS zcx_abapgit_exception DEFINITION
     DATA msgv3 TYPE symsgv READ-ONLY .
     DATA msgv4 TYPE symsgv READ-ONLY .
     DATA mt_callstack TYPE abap_callstack READ-ONLY .
+    DATA url TYPE string READ-ONLY .
+    DATA count TYPE i READ-ONLY.
+    DATA digest TYPE string READ-ONLY.
 
     "! Raise exception with text
     "! @parameter iv_text | Text
@@ -72,7 +75,20 @@ CLASS zcx_abapgit_exception DEFINITION
         !msgv1    TYPE symsgv OPTIONAL
         !msgv2    TYPE symsgv OPTIONAL
         !msgv3    TYPE symsgv OPTIONAL
-        !msgv4    TYPE symsgv OPTIONAL .
+        !msgv4    TYPE symsgv OPTIONAL
+        !url      TYPE string OPTIONAL
+        !count    TYPE i OPTIONAL
+        !digest   TYPE string OPTIONAL.
+    CLASS-METHODS raise_login_error
+      IMPORTING
+        !iv_url    TYPE string
+        !iv_count  TYPE i
+        !iv_digest TYPE string
+      RAISING
+        zcx_abapgit_exception .
+    METHODS is_login_error
+      RETURNING
+        VALUE(rv_result) TYPE abap_bool .
 
     METHODS get_source_position
         REDEFINITION .
@@ -110,7 +126,7 @@ ENDCLASS.
 
 
 
-CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
+CLASS zcx_abapgit_exception IMPLEMENTATION.
 
 
   METHOD constructor ##ADT_SUPPRESS_GENERATION.
@@ -121,6 +137,9 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
     me->msgv2 = msgv2.
     me->msgv3 = msgv3.
     me->msgv4 = msgv4.
+    me->url = url.
+    me->count = count.
+    me->digest = digest.
 
     CLEAR me->textid.
     IF textid IS INITIAL.
@@ -206,6 +225,11 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
 
     ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD is_login_error.
+    rv_result = boolc( url <> '' AND count > 0 ).
   ENDMETHOD.
 
 
@@ -300,6 +324,17 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
     split_text_to_symsg( lv_text ).
 
     raise_t100( ix_previous = ix_previous ).
+
+  ENDMETHOD.
+
+
+  METHOD raise_login_error.
+
+    RAISE EXCEPTION TYPE zcx_abapgit_exception
+      EXPORTING
+        url    = iv_url
+        count  = iv_count
+        digest = iv_digest.
 
   ENDMETHOD.
 

--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -28,8 +28,8 @@ CLASS zcx_abapgit_exception DEFINITION
     DATA msgv4 TYPE symsgv READ-ONLY .
     DATA mt_callstack TYPE abap_callstack READ-ONLY .
     DATA url TYPE string READ-ONLY .
-    DATA count TYPE i READ-ONLY.
-    DATA digest TYPE string READ-ONLY.
+    DATA count TYPE i READ-ONLY .
+    DATA digest TYPE string READ-ONLY .
 
     "! Raise exception with text
     "! @parameter iv_text | Text
@@ -78,15 +78,15 @@ CLASS zcx_abapgit_exception DEFINITION
         !msgv4    TYPE symsgv OPTIONAL
         !url      TYPE string OPTIONAL
         !count    TYPE i OPTIONAL
-        !digest   TYPE string OPTIONAL.
-    CLASS-METHODS raise_login_error
+        !digest   TYPE string OPTIONAL .
+    CLASS-METHODS raise_login
       IMPORTING
         !iv_url    TYPE string
         !iv_count  TYPE i
         !iv_digest TYPE string
       RAISING
         zcx_abapgit_exception .
-    METHODS is_login_error
+    METHODS is_login
       RETURNING
         VALUE(rv_result) TYPE abap_bool .
 
@@ -228,7 +228,7 @@ CLASS zcx_abapgit_exception IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD is_login_error.
+  METHOD is_login.
     rv_result = boolc( url <> '' AND count > 0 ).
   ENDMETHOD.
 
@@ -328,7 +328,7 @@ CLASS zcx_abapgit_exception IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD raise_login_error.
+  METHOD raise_login.
 
     RAISE EXCEPTION TYPE zcx_abapgit_exception
       EXPORTING

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -539,6 +539,7 @@ INTERFACE zif_abapgit_definitions
   CONSTANTS gc_yes TYPE ty_yes_no VALUE 'Y'.
   CONSTANTS gc_no TYPE ty_yes_no VALUE 'N'.
   CONSTANTS gc_partial TYPE ty_yes_no_partial VALUE 'P'.
+  CONSTANTS gc_memoryid_title TYPE c LENGTH 60 VALUE 'ZABAPGIT_TITLE'.
 
   TYPES:
     ty_method TYPE c LENGTH 1 .

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -1,6 +1,7 @@
 INTERFACE zif_abapgit_repo_srv
   PUBLIC .
 
+
   METHODS delete
     IMPORTING
       !io_repo TYPE REF TO zcl_abapgit_repo
@@ -69,6 +70,13 @@ INTERFACE zif_abapgit_repo_srv
     EXPORTING
       VALUE(eo_repo) TYPE REF TO zcl_abapgit_repo
       !ev_reason     TYPE string
+    RAISING
+      zcx_abapgit_exception .
+  METHODS get_repo_from_url
+    IMPORTING
+      !iv_url        TYPE string
+    RETURNING
+      VALUE(ro_repo) TYPE REF TO zcl_abapgit_repo
     RAISING
       zcx_abapgit_exception .
 ENDINTERFACE.


### PR DESCRIPTION
This is a replacement of the classic GUI popup dialog with an HTML form for entering username and password.

To best understand how it works, first look at `zcl_abapgit_http->create_by_url`. Instead of the password popup, it now jumps to the "Login Manager" and triggers a special exception in `zcl_abapgit_login_manager->login`. This exception is passed through to the general event handler in `zcl_abapgit_gui->handle_action`. Here it detects the special exception (`is_login`) and redirects to the new "Login Page" passing along the essential login details (URL, count, digest). 

The "Login Page" prompts for username and password via an HTML form. When the user clicks on "Login" or presses "Enter", username and password are set in the "Login Manager" (Digest authentification is now handled the same way). The "Login Page" then redirects back to the original page that triggered the login. 

We end up back in `zcl_abapgit_http->create_by_url` which can now load the credentials from the "Login Manager" (either username/password or the completed digest). If this results in a successful authentication (HTTP 200), the process continues as usual. If the username/password were incorrect, it will trigger the login process again. After 3 unsuccessful login attempts, the page will show the usual HTTP 401 error message. The login can be triggered again by refreshing the page. 

https://github.com/abapGit/abapGit/issues/783 contains a couple of screenshots.

I was able to verify basic authentication, but don't have any scenario with a proxy or requiring digest authentication. Please test thoroughly. 

Not included:
- Removal of old password popup

PS: The new solution integrates all login-related logic into `zcl_abapgit_login_manager` including the handing of digest and default users. This separates UI, HTTP, and Login nicely and is much cleaner than before. 