### PR TITLE
Fix arrow direction for sort order

### DIFF
--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -594,9 +594,9 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       IF <ls_col>-tech_name = iv_order_by
       AND iv_order_by IS NOT INITIAL.
         IF iv_order_descending = abap_true.
-          lv_tmp = lv_tmp && | &#x25B4;|. " arrow up
-        ELSE.
           lv_tmp = lv_tmp && | &#x25BE;|. " arrow down
+        ELSE.
+          lv_tmp = lv_tmp && | &#x25B4;|. " arrow up
         ENDIF.
       ENDIF.
 


### PR DESCRIPTION
These are currently the wrong way around. At least I couldn't find any other application that uses arrow up for descending.

![image](https://user-images.githubusercontent.com/5270359/97112362-268c1000-16e4-11eb-9e2e-06fc12f2b90a.png)

![image](https://user-images.githubusercontent.com/5270359/97112371-33a8ff00-16e4-11eb-96a2-ed0ceef9b3fd.png)

![image](https://user-images.githubusercontent.com/5270359/97112388-4e7b7380-16e4-11eb-87d8-710920e46f53.png)
