### PR TITLE
ZCL_ABAPGIT_REPO_ONLINE: Add getter and setter for branch

### DIFF
--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -29,9 +29,19 @@ CLASS zcl_abapgit_repo_online DEFINITION
         !iv_branch_name TYPE zif_abapgit_persistence=>ty_repo-branch_name
       RAISING
         zcx_abapgit_exception .
+    METHODS get_sha1
+      RETURNING
+        VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
     METHODS get_sha1_remote
       RETURNING
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
+    METHODS set_sha1
+      IMPORTING
+        iv_sha1 TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
     METHODS get_objects
@@ -87,7 +97,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
+CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
 
   METHOD fetch_remote.
@@ -168,9 +178,19 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_sha1.
+    rv_sha1 = mv_branch.
+  ENDMETHOD.
+
+
   METHOD get_sha1_remote.
     fetch_remote( ).
     rv_sha1 = mv_branch.
+  ENDMETHOD.
+
+
+  METHOD set_sha1.
+    mv_branch = iv_sha1.
   ENDMETHOD.
 
 


### PR DESCRIPTION
Related to #3040

We have to be able to get or set the current repo hash based on checked out commits: The user can choose a commit from a popup and then in the background the repo commit (`mv_branch`) is set to this selected commit hash. AG resets the repo based on the checked out commit hash after that.

@larshp I'll plan to rename `mv_branch` to `mv_sha1`. Is this ok with you or do you prefer another name (e. g. `mv_commit`) or a different approach?