### PR TITLE
ZCL_ABAPGIT_GIT_PORCELAIN: Add deepen_level parameter to pull methods

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -23,6 +23,7 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
       IMPORTING
         !iv_url          TYPE string
         !iv_branch_name  TYPE string
+        !iv_deepen_level TYPE i DEFAULT 1
       RETURNING
         VALUE(rs_result) TYPE ty_pull_result
       RAISING
@@ -31,6 +32,7 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
       IMPORTING
         !iv_url          TYPE string
         !iv_commit_hash  TYPE zif_abapgit_definitions=>ty_sha1
+        !iv_deepen_level TYPE i DEFAULT 1
       RETURNING
         VALUE(rs_result) TYPE ty_pull_result
       RAISING
@@ -424,6 +426,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
       EXPORTING
         iv_url          = iv_url
         iv_branch_name  = iv_branch_name
+        iv_deepen_level = iv_deepen_level
       IMPORTING
         et_objects      = rs_result-objects
         ev_branch       = rs_result-commit ).
@@ -438,11 +441,12 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
 
     zcl_abapgit_git_transport=>upload_pack_by_commit(
       EXPORTING
-        iv_url     = iv_url
-        iv_hash    = iv_commit_hash
+        iv_url          = iv_url
+        iv_hash         = iv_commit_hash
+        iv_deepen_level = iv_deepen_level
       IMPORTING
-        et_objects = rs_result-objects
-        ev_commit  = rs_result-commit ).
+        et_objects      = rs_result-objects
+        ev_commit       = rs_result-commit ).
 
     rs_result-files = pull( iv_commit  = rs_result-commit
                             it_objects = rs_result-objects ).


### PR DESCRIPTION
Related to #3040

Add `iv_deepen_level` to pull methods to be able to call `pull_by_branch` and `pull_by_commit` with adjusted deepen level.