### PR TITLE
ZCL_ABAPGIT_SERVICES_GIT: Add method checkout_commit_build_list to build the popup selection table for commits

### DIFF
--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -106,7 +106,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_commit>    TYPE zif_abapgit_definitions=>ty_commit,
                    <ls_value_tab> TYPE ty_commit_value_tab.
 
-    CLEAR: et_commits.
+    CLEAR: et_commits, et_value_tab.
 
     ls_pull_result = zcl_abapgit_git_commit=>get_by_branch( iv_branch_name  = iv_branch_name
                                                             iv_repo_url     = iv_url

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -4,6 +4,7 @@ CLASS zcl_abapgit_services_git DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+
     CLASS-METHODS pull
       IMPORTING
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -29,6 +30,7 @@ CLASS zcl_abapgit_services_git DEFINITION
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
       RAISING
         zcx_abapgit_exception.
+
     CLASS-METHODS delete_tag
       IMPORTING
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -51,7 +53,6 @@ CLASS zcl_abapgit_services_git DEFINITION
         !io_stage  TYPE REF TO zcl_abapgit_stage
       RAISING
         zcx_abapgit_exception.
-
   PROTECTED SECTION.
     TYPES: BEGIN OF ty_commit_value_tab,
              sha1     TYPE zif_abapgit_definitions=>ty_sha1,
@@ -67,7 +68,6 @@ CLASS zcl_abapgit_services_git DEFINITION
         VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
         zcx_abapgit_exception .
-
   PRIVATE SECTION.
     CLASS-METHODS checkout_commit_build_list
       IMPORTING
@@ -238,11 +238,11 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
   METHOD create_branch.
 
-    DATA: lv_name               TYPE string,
-          lv_cancel             TYPE abap_bool,
-          lo_repo               TYPE REF TO zcl_abapgit_repo_online,
-          lv_msg                TYPE string,
-          li_popups             TYPE REF TO zif_abapgit_popups,
+    DATA: lv_name   TYPE string,
+          lv_cancel TYPE abap_bool,
+          lo_repo   TYPE REF TO zcl_abapgit_repo_online,
+          lv_msg    TYPE string,
+          li_popups TYPE REF TO zif_abapgit_popups,
           lv_source_branch_name TYPE string.
 
 

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -97,9 +97,9 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
   METHOD checkout_commit_build_list.
 
     DATA: lv_unix_time   TYPE zcl_abapgit_time=>ty_unixtime,
-          lv_date        TYPE sydatum,
+          lv_date        TYPE sy-datum,
           lv_date_string TYPE c LENGTH 12,
-          lv_time        TYPE syuzeit,
+          lv_time        TYPE sy-uzeit,
           lv_time_string TYPE c LENGTH 10,
           ls_pull_result TYPE zcl_abapgit_git_commit=>ty_pull_result.
 
@@ -108,11 +108,9 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
     CLEAR: et_commits.
 
-    ls_pull_result = zcl_abapgit_git_commit=>get_by_branch(
-      EXPORTING
-        iv_branch_name  = iv_branch_name
-        iv_repo_url     = iv_url
-        iv_deepen_level = 99 ).
+    ls_pull_result = zcl_abapgit_git_commit=>get_by_branch( iv_branch_name  = iv_branch_name
+                                                            iv_repo_url     = iv_url
+                                                            iv_deepen_level = 99 ).
 
     et_commits = ls_pull_result-commits.
     DELETE et_commits WHERE sha1 = ls_pull_result-commit.


### PR DESCRIPTION
Related to #3040

Add new method `checkout_commit_build_list` to `ZCL_ABAPGIT_SERVICES_GIT` to build up the selection table for the checkout commit popup.