### PR TITLE
ZCL_ABAPGIT_SERVICES_GIT: Add new method checkout_commit to let the user check out commits

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -391,6 +391,9 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-git_reset.                     " GIT Reset
         zcl_abapgit_services_git=>reset( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+      WHEN zif_abapgit_definitions=>c_action-git_checkout_commit.           " GIT Checkout commit
+        zcl_abapgit_services_git=>checkout_commit( lv_key ).
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-git_branch_create.             " GIT Create new branch
         zcl_abapgit_services_git=>create_branch( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -115,7 +115,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
     checkout_commit_build_list(
       EXPORTING
-        iv_branch_name = lo_repo->get_branch_name( )
+        iv_branch_name = lo_repo->get_selected_branch( )
         iv_url         = lo_repo->get_url( )
       IMPORTING
         et_value_tab   = lt_value_tab
@@ -124,7 +124,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
     ls_selected_commit = checkout_commit_build_popup( it_commits   = lt_commits
                                                       it_value_tab = lt_value_tab ).
 
-    lo_repo->set_sha1( ls_selected_commit-sha1 ).
+    lo_repo->select_commit( ls_selected_commit-sha1 ).
     COMMIT WORK AND WAIT.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -101,8 +101,6 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
   METHOD checkout_commit.
 
     DATA: lo_repo            TYPE REF TO zcl_abapgit_repo_online,
-          lx_error           TYPE REF TO zcx_abapgit_exception,
-          lv_more_loadable   TYPE abap_bool,
           lt_value_tab       TYPE ty_commit_value_tab_tt,
           lt_commits         TYPE zif_abapgit_definitions=>ty_commit_tt,
           ls_selected_commit TYPE zif_abapgit_definitions=>ty_commit.

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -123,10 +123,8 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
         et_value_tab   = lt_value_tab
         et_commits     = lt_commits ).
 
-    ls_selected_commit = checkout_commit_build_popup(
-      EXPORTING
-        it_commits   = lt_commits
-        it_value_tab = lt_value_tab ).
+    ls_selected_commit = checkout_commit_build_popup( it_commits   = lt_commits
+                                                      it_value_tab = lt_value_tab ).
 
     lo_repo->set_sha1( ls_selected_commit-sha1 ).
     COMMIT WORK AND WAIT.

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -190,7 +190,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
     APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
     <ls_column>-name   = 'SHA1'.
     <ls_column>-text   = 'Hash'.
-    <ls_column>-length = 7.
+    <ls_column>-length = 8.
     APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
     <ls_column>-name = 'MESSAGE'.
     <ls_column>-text = 'Message'.

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -4,7 +4,6 @@ CLASS zcl_abapgit_services_git DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-
     CLASS-METHODS pull
       IMPORTING
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -30,7 +29,6 @@ CLASS zcl_abapgit_services_git DEFINITION
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
       RAISING
         zcx_abapgit_exception.
-
     CLASS-METHODS delete_tag
       IMPORTING
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -53,6 +51,12 @@ CLASS zcl_abapgit_services_git DEFINITION
         !io_stage  TYPE REF TO zcl_abapgit_stage
       RAISING
         zcx_abapgit_exception.
+    CLASS-METHODS checkout_commit
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception.
+
   PROTECTED SECTION.
     TYPES: BEGIN OF ty_commit_value_tab,
              sha1     TYPE zif_abapgit_definitions=>ty_sha1,
@@ -68,6 +72,7 @@ CLASS zcl_abapgit_services_git DEFINITION
         VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
         zcx_abapgit_exception .
+
   PRIVATE SECTION.
     CLASS-METHODS checkout_commit_build_list
       IMPORTING
@@ -92,6 +97,42 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_services_git IMPLEMENTATION.
+
+  METHOD checkout_commit.
+
+    DATA: lo_repo            TYPE REF TO zcl_abapgit_repo_online,
+          lx_error           TYPE REF TO zcx_abapgit_exception,
+          lv_more_loadable   TYPE abap_bool,
+          lt_value_tab       TYPE ty_commit_value_tab_tt,
+          lt_commits         TYPE zif_abapgit_definitions=>ty_commit_tt,
+          ls_selected_commit TYPE zif_abapgit_definitions=>ty_commit.
+
+    FIELD-SYMBOLS: <ls_field_desc> TYPE rsvbfidesc.
+
+    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+
+    IF lo_repo->get_local_settings( )-write_protected = abap_true.
+      zcx_abapgit_exception=>raise( 'Cannot checkout. Local code is write-protected by repo config.' ).
+    ENDIF.
+
+    checkout_commit_build_list(
+      EXPORTING
+        iv_branch_name = lo_repo->get_branch_name( )
+        iv_url         = lo_repo->get_url( )
+      IMPORTING
+        et_value_tab   = lt_value_tab
+        et_commits     = lt_commits ).
+
+    ls_selected_commit = checkout_commit_build_popup(
+      EXPORTING
+        it_commits   = lt_commits
+        it_value_tab = lt_value_tab ).
+
+    lo_repo->set_sha1( ls_selected_commit-sha1 ).
+    COMMIT WORK AND WAIT.
+
+  ENDMETHOD.
+
 
   METHOD checkout_commit_build_list.
 
@@ -235,11 +276,11 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
   METHOD create_branch.
 
-    DATA: lv_name   TYPE string,
-          lv_cancel TYPE abap_bool,
-          lo_repo   TYPE REF TO zcl_abapgit_repo_online,
-          lv_msg    TYPE string,
-          li_popups TYPE REF TO zif_abapgit_popups,
+    DATA: lv_name               TYPE string,
+          lv_cancel             TYPE abap_bool,
+          lo_repo               TYPE REF TO zcl_abapgit_repo_online,
+          lv_msg                TYPE string,
+          li_popups             TYPE REF TO zif_abapgit_popups,
           lv_source_branch_name TYPE string.
 
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -216,6 +216,7 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
 
   METHOD set_sha1.
+    reset_remote( ).
     mv_branch = iv_sha1.
   ENDMETHOD.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -498,6 +498,7 @@ INTERFACE zif_abapgit_definitions
       ie_devtools                   TYPE string VALUE 'ie_devtools',
       git_pull                      TYPE string VALUE 'git_pull',
       git_reset                     TYPE string VALUE 'git_reset',
+      git_checkout_commit           TYPE string VALUE 'git_checkout_commit',
       git_branch_create             TYPE string VALUE 'git_branch_create',
       git_branch_switch             TYPE string VALUE 'git_branch_switch',
       git_branch_delete             TYPE string VALUE 'git_branch_delete',


### PR DESCRIPTION
Related to #3040

Adds a new method checkout_commit to ZCL_ABAPGIT_SERVICES_GIT that makes it possible to select commits from a popup and set the repo commit status after the selection. Added caller in GUI_ROUTER and some pretty printer changes too. Had to extend the hash column to be able to show the 7 first instead of just the 6 first hash characters.