### PR TITLE
ZCL_ABAPGIT_REPO_ONLINE: Change methods fetch_remote and push to be able to retrieve and push objects also by commit hash

### DIFF
--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -515,7 +515,6 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
     lo_repo->select_commit( space ).
     lo_repo->select_branch( ls_branch-name ).
-    
     COMMIT WORK AND WAIT.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -476,6 +476,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
       RETURN.
     ENDIF.
 
+    lo_repo->set_sha1( space ).
     lo_repo->set_branch_name( ls_branch-name ).
 
     COMMIT WORK AND WAIT.

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -392,8 +392,9 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
 * assumption: PUSH is done on top of the currently selected branch
 
-    DATA: ls_push TYPE zcl_abapgit_git_porcelain=>ty_push_result,
-          lv_text TYPE string.
+    DATA: ls_push   TYPE zcl_abapgit_git_porcelain=>ty_push_result,
+          lv_text   TYPE string,
+          lv_parent TYPE zif_abapgit_definitions=>ty_sha1.
 
 
     IF ms_data-branch_name CP zif_abapgit_definitions=>c_git_branch-tags.
@@ -410,12 +411,18 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     handle_stage_ignore( io_stage ).
 
+    IF get_sha1( ) IS INITIAL.
+      lv_parent = get_sha1_remote( ).
+    ELSE.
+      lv_parent = get_sha1( ).
+    ENDIF.
+
     ls_push = zcl_abapgit_git_porcelain=>push(
       is_comment     = is_comment
       io_stage       = io_stage
       iv_branch_name = get_branch_name( )
       iv_url         = get_url( )
-      iv_parent      = get_sha1_remote( )
+      iv_parent      = lv_parent
       it_old_objects = get_objects( ) ).
 
     set_objects( ls_push-new_objects ).

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -114,9 +114,13 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
     li_progress->show( iv_current = 1
                        iv_text    = 'Fetch remote files' ).
 
-    ls_pull = zcl_abapgit_git_porcelain=>pull_by_branch(
-      iv_url         = get_url( )
-      iv_branch_name = get_branch_name( ) ).
+    IF get_sha1( ) IS INITIAL.
+      ls_pull = zcl_abapgit_git_porcelain=>pull_by_branch( iv_url         = get_url( )
+                                                           iv_branch_name = get_branch_name( ) ).
+    ELSE.
+      ls_pull = zcl_abapgit_git_porcelain=>pull_by_commit( iv_url         = get_url( )
+                                                           iv_commit_hash = get_sha1( ) ).
+    ENDIF.
 
     set_files_remote( ls_pull-files ).
     set_objects( ls_pull-objects ).


### PR DESCRIPTION
Related to #3040

Objects can now be retrieved and pushed/staged by commit hash and not only the branch hash, whereas the commit hash is only set if the user doesn't use the branch hash as top commit.

The method fetch_remote is being changed to be able to retrieve remote objects if a repo commit has been set. If only the branch name is supplied we have to get the remote objects from the top (root/branch) commit.

The method push is being changed to be able to push local objects if a repo commit has been set. If only the branch hash is supplied we have to push the objects with binding to the top (root/branch) commit.

Additionally this is also needed to test the changes in this PR: In case the branch is being switched the commit hash has to be reset.