### PR TITLE
ZCL_ABAPGIT_REPO_ONLINE: Change push method to be able to push objects by repo commit hash

### DIFF
--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -388,8 +388,9 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
 * assumption: PUSH is done on top of the currently selected branch
 
-    DATA: ls_push TYPE zcl_abapgit_git_porcelain=>ty_push_result,
-          lv_text TYPE string.
+    DATA: lv_parent TYPE zif_abapgit_definitions=>ty_sha1,
+          ls_push   TYPE zcl_abapgit_git_porcelain=>ty_push_result,
+          lv_text   TYPE string.
 
 
     IF ms_data-branch_name CP zif_abapgit_definitions=>c_git_branch-tags.
@@ -406,12 +407,18 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     handle_stage_ignore( io_stage ).
 
+    IF get_sha1( ) IS INITIAL.
+      lv_parent = get_sha1_remote( ).
+    ELSE.
+      lv_parent = get_sha1( ).
+    ENDIF.
+
     ls_push = zcl_abapgit_git_porcelain=>push(
       is_comment     = is_comment
       io_stage       = io_stage
       iv_branch_name = get_branch_name( )
       iv_url         = get_url( )
-      iv_parent      = get_sha1_remote( )
+      iv_parent      = lv_parent
       it_old_objects = get_objects( ) ).
 
     set_objects( ls_push-new_objects ).


### PR DESCRIPTION
Related to #3040

The method push is being changed to be able to push local objects if a repo commit has been set. If only the branch hash is supplied we have to push the objects with binding to the top (root/branch) commit.

See also PR #4077: Objects can now be retrieved and pushed/staged by commit hash and not only the branch hash, whereas the commit hash is only set if the user doesn't use the branch hash as top commit.