### PR TITLE
Fix state calculation for deleted objects

### DIFF
--- a/src/zcl_abapgit_file_status.clas.abap
+++ b/src/zcl_abapgit_file_status.clas.abap
@@ -66,7 +66,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
+CLASS zcl_abapgit_file_status IMPLEMENTATION.
 
 
   METHOD build_existing.
@@ -206,6 +206,7 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
 
     FIELD-SYMBOLS: <ls_remote> LIKE LINE OF it_remote,
                    <ls_result> LIKE LINE OF rt_results,
+                   <ls_state>  LIKE LINE OF it_cur_state,
                    <ls_local>  LIKE LINE OF it_local.
 
 
@@ -237,6 +238,21 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
           WITH KEY filename = <ls_local>-file-filename.
         IF sy-subrc = 0 AND <ls_local>-file-sha1 = <ls_remote>-sha1.
           <ls_result>-packmove = abap_true.
+          CLEAR <ls_remote>-sha1. " Mark as processed
+        ELSEIF sy-subrc = 4.
+          " Check if file existed before and was deleted remotely
+          READ TABLE lt_state_idx ASSIGNING <ls_state>
+            WITH KEY path = <ls_local>-file-path filename = <ls_local>-file-filename
+            BINARY SEARCH.
+          IF sy-subrc = 0.
+            IF <ls_local>-file-sha1 = <ls_state>-sha1.
+              <ls_result>-lstate = zif_abapgit_definitions=>c_state-unchanged.
+            ELSE.
+              <ls_result>-lstate = zif_abapgit_definitions=>c_state-modified.
+            ENDIF.
+            <ls_result>-rstate = zif_abapgit_definitions=>c_state-deleted.
+            CLEAR <ls_remote>-sha1. " Mark as processed
+          ENDIF.
         ENDIF.
       ENDIF.
       <ls_result>-inactive = <ls_local>-item-inactive.
@@ -263,7 +279,7 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
           lv_sub_fetched = abap_true.
           SORT lt_sub_packages BY table_line. "Optimize Read Access
         ENDIF.
-* make sure the package is under the repo main package
+        " Make sure the package is under the repo main package
         READ TABLE lt_sub_packages TRANSPORTING NO FIELDS
           WITH KEY table_line = ls_item-devclass
           BINARY SEARCH.
@@ -292,6 +308,14 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
         WITH KEY file-filename = <ls_remote>-filename.
       IF sy-subrc = 0 AND <ls_local>-file-sha1 = <ls_remote>-sha1.
         <ls_result>-packmove = abap_true.
+      ELSEIF sy-subrc = 4.
+        " Check if file existed before and was deleted locally
+        READ TABLE lt_state_idx ASSIGNING <ls_state>
+          WITH KEY path = <ls_remote>-path filename = <ls_remote>-filename
+          BINARY SEARCH.
+        IF sy-subrc = 0.
+          <ls_result>-lstate = zif_abapgit_definitions=>c_state-deleted.
+        ENDIF.
       ENDIF.
     ENDLOOP.
 

--- a/src/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/zcl_abapgit_file_status.clas.testclasses.abap
@@ -432,6 +432,7 @@ CLASS lcl_status_result IMPLEMENTATION.
   METHOD constructor.
 
     mt_results = it_results.
+    SORT mt_results BY path filename.
 
   ENDMETHOD.
 
@@ -478,10 +479,14 @@ CLASS ltcl_status_helper DEFINITION FOR TESTING.
           iv_path     TYPE string DEFAULT '/'
           iv_filename TYPE string
           iv_sha1     TYPE zif_abapgit_definitions=>ty_sha1
-          iv_obj_type TYPE tadir-object
-          iv_obj_name TYPE tadir-obj_name
+          iv_obj_type TYPE tadir-object OPTIONAL
+          iv_obj_name TYPE tadir-obj_name OPTIONAL
           iv_devclass TYPE devclass DEFAULT '$Z$',
-      add_state,
+      add_state
+        IMPORTING
+          iv_path     TYPE string DEFAULT '/'
+          iv_filename TYPE string
+          iv_sha1     TYPE zif_abapgit_definitions=>ty_sha1,
       run
         IMPORTING
           iv_devclass      TYPE devclass DEFAULT '$Z$'
@@ -575,7 +580,13 @@ CLASS ltcl_status_helper IMPLEMENTATION.
 
   METHOD add_state.
 
-* todo
+    FIELD-SYMBOLS: <ls_state> LIKE LINE OF mt_state.
+
+    APPEND INITIAL LINE TO mt_state ASSIGNING <ls_state>.
+    <ls_state>-path     = iv_path.
+    <ls_state>-filename = iv_filename.
+    <ls_state>-sha1     = iv_sha1.
+
   ENDMETHOD.
 
   METHOD run.
@@ -618,7 +629,8 @@ CLASS ltcl_calculate_status DEFINITION FOR TESTING RISK LEVEL HARMLESS
       only_local FOR TESTING RAISING zcx_abapgit_exception,
       match FOR TESTING RAISING zcx_abapgit_exception,
       diff FOR TESTING RAISING zcx_abapgit_exception,
-      local_outside_main FOR TESTING RAISING zcx_abapgit_exception.
+      local_outside_main FOR TESTING RAISING zcx_abapgit_exception,
+      complete FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -731,6 +743,240 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = mo_result->get_line( 1 )-rstate
       exp = zif_abapgit_definitions=>c_state-added ).
+
+  ENDMETHOD.
+
+  METHOD complete.
+
+    DATA:
+      ls_line TYPE zif_abapgit_definitions=>ty_result,
+      lv_act  TYPE c LENGTH 3,
+      lv_exp  TYPE c LENGTH 3.
+
+    mo_helper->add_local(
+      iv_path     = '/'
+      iv_filename = '.abapgit.xml'
+      iv_sha1     = '1017'  ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_created_locally.prog.abap'
+      iv_sha1     = '1001' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_created_locally.prog.xml'
+      iv_sha1     = '1022' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_remotely.prog.abap'
+      iv_sha1     = '1016' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_remotely.prog.xml'
+      iv_sha1     = '1003' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_both.prog.abap'
+      iv_sha1     = '1028' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_both.prog.xml'
+      iv_sha1     = '1032' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_locally.prog.abap'
+      iv_sha1     = '1023' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_locally.prog.xml'
+      iv_sha1     = '1033' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_remotely.prog.abap'
+      iv_sha1     = '1018' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_remotely.prog.xml'
+      iv_sha1     = '1011' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_mod_del.prog.abap'
+      iv_sha1     = '1012' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_mod_del.prog.xml'
+      iv_sha1     = '1006' ).
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '1027' ).
+
+    mo_helper->add_remote(
+      iv_path     = '/'
+      iv_filename = '.abapgit.xml'
+      iv_sha1     = '1017' ).
+    mo_helper->add_remote(
+      iv_path     = '/'
+      iv_filename = 'README.md'
+      iv_sha1     = '1007' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '1027' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_created_remotely.prog.abap'
+      iv_sha1     = '1025' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_created_remotely.prog.xml'
+      iv_sha1     = '1015' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_del_mod.prog.abap'
+      iv_sha1     = '1024' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_del_mod.prog.xml'
+      iv_sha1     = '1013' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_locally.prog.abap'
+      iv_sha1     = '1008' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_locally.prog.xml'
+      iv_sha1     = '1009' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_both.prog.abap'
+      iv_sha1     = '1002' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_both.prog.xml'
+      iv_sha1     = '1030' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_locally.prog.abap'
+      iv_sha1     = '1026' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_locally.prog.xml'
+      iv_sha1     = '1021' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_remotely.prog.abap'
+      iv_sha1     = '1019' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_remotely.prog.xml'
+      iv_sha1     = '1031' ).
+
+    mo_helper->add_state(
+      iv_path     = '/'
+      iv_filename = '.abapgit.xml'
+      iv_sha1     = '1017' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '1027' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_locally.prog.abap'
+      iv_sha1     = '1008' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_locally.prog.xml'
+      iv_sha1     = '1009' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_remotely.prog.abap'
+      iv_sha1     = '1016' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_deleted_remotely.prog.xml'
+      iv_sha1     = '1003' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_del_mod.prog.abap'
+      iv_sha1     = '1020' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_del_mod.prog.xml'
+      iv_sha1     = '1029' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_both.prog.abap'
+      iv_sha1     = '1010' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_both.prog.xml'
+      iv_sha1     = '1004' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_locally.prog.abap'
+      iv_sha1     = '1026' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_locally.prog.xml'
+      iv_sha1     = '1021' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_remotely.prog.abap'
+      iv_sha1     = '1018' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_modified_remotely.prog.xml'
+      iv_sha1     = '1011' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_mod_del.prog.abap'
+      iv_sha1     = '1014' ).
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_mod_del.prog.xml'
+      iv_sha1     = '1005' ).
+
+    mo_result = mo_helper->run( ).
+
+    mo_result->assert_lines( 21 ).
+
+    DO 21 TIMES.
+      ls_line = mo_result->get_line( sy-index ).
+      lv_act+0(1) = ls_line-match.
+      lv_act+1(1) = ls_line-lstate.
+      lv_act+2(1) = ls_line-rstate.
+      CASE sy-index.
+        WHEN 1.
+          lv_exp = 'X  '.
+        WHEN 2.
+          lv_exp = '  A'.
+        WHEN 3.
+          lv_exp = 'X  '.
+        WHEN 4 OR 5.
+          lv_exp = ' A '.
+        WHEN 6 OR 7.
+          lv_exp = '  A'.
+        WHEN 8 OR 9.
+          lv_exp = ' DM'.
+        WHEN 10 OR 11.
+          lv_exp = ' D '.
+        WHEN 12 OR 13.
+          lv_exp = '  D'.
+        WHEN 14 OR 15.
+          lv_exp = ' MD'.
+        WHEN 16 OR 17.
+          lv_exp = ' MM'.
+        WHEN 18 OR 19.
+          lv_exp = ' M '.
+        WHEN 20 OR 21.
+          lv_exp = '  M'.
+      ENDCASE.
+
+      cl_abap_unit_assert=>assert_equals(
+        act = lv_act
+        exp = lv_exp
+        msg = |Line { sy-index }: { ls_line-filename }| ).
+    ENDDO.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -209,7 +209,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD bind_listener.
@@ -536,12 +536,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     FIELD-SYMBOLS <ls_object> LIKE LINE OF ms_data-local_checksums.
 
     LOOP AT ms_data-local_checksums ASSIGNING <ls_object>.
-      " Check if item exists
-      READ TABLE mt_local TRANSPORTING NO FIELDS
-        WITH KEY item = <ls_object>-item.
-      IF sy-subrc = 0.
-        APPEND LINES OF <ls_object>-files TO rt_checksums.
-      ENDIF.
+      APPEND LINES OF <ls_object>-files TO rt_checksums.
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -453,7 +453,7 @@ INTERFACE zif_abapgit_definitions
       unchanged TYPE c LENGTH 1 VALUE '',
       added     TYPE c LENGTH 1 VALUE 'A',
       modified  TYPE c LENGTH 1 VALUE 'M',
-      deleted   TYPE c LENGTH 1 VALUE 'D', "For future use
+      deleted   TYPE c LENGTH 1 VALUE 'D',
       mixed     TYPE c LENGTH 1 VALUE '*',
     END OF c_state .
   CONSTANTS:


### PR DESCRIPTION
In case objects are deleted locally or remotely, abapGit now compares against the last known state (checksum). 

Before: Deleted objects are shown as "added" for the opposite side

![image](https://user-images.githubusercontent.com/59966492/97372590-5aa13580-188a-11eb-8ade-4800ef7ce9be.png)

![image](https://user-images.githubusercontent.com/59966492/97372597-612fad00-188a-11eb-8188-37e30c4bbc7b.png)

After: Deleted objects are properly shown as "deleted" (see lines 3 + 4)
The screenshot also shows other known state combinations that are included in a new test in the test class. 

![image](https://user-images.githubusercontent.com/59966492/97376110-ec14a580-1892-11eb-84fe-88f4217c305f.png)

Closes https://github.com/abapGit/abapGit/issues/4030