### PR TITLE
bugfix, the selected commit is not the current commit

### DIFF
--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -104,7 +104,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_online IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
 
   METHOD fetch_remote.
@@ -136,11 +136,6 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_selected_branch.
-    rv_name = ms_data-branch_name.
-  ENDMETHOD.
-
-
   METHOD get_commit_display_url.
 
     rv_url = me->get_default_commit_display_url( iv_hash ).
@@ -158,6 +153,12 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |provider not yet supported| ).
     ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD get_current_remote.
+    fetch_remote( ).
+    rv_sha1 = mv_current_commit.
   ENDMETHOD.
 
 
@@ -208,20 +209,14 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_selected_branch.
+    rv_name = ms_data-branch_name.
+  ENDMETHOD.
+
+
   METHOD get_selected_commit.
-    rv_sha1 = mv_current_commit.
-  ENDMETHOD.
-
-
-  METHOD get_current_remote.
-    fetch_remote( ).
-    rv_sha1 = mv_current_commit.
-  ENDMETHOD.
-
-
-  METHOD select_commit.
-    reset_remote( ).
-    mv_current_commit = iv_sha1.
+* todo
+*    rv_sha1 = mv_current_commit.
   ENDMETHOD.
 
 
@@ -338,6 +333,12 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
     reset_remote( ).
     set( iv_branch_name = iv_branch_name ).
 
+  ENDMETHOD.
+
+
+  METHOD select_commit.
+    reset_remote( ).
+    mv_current_commit = iv_sha1.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -215,8 +215,7 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
 
   METHOD get_selected_commit.
-* todo
-*    rv_sha1 = mv_current_commit.
+* todo, rv_sha1 = mv_current_commit.
   ENDMETHOD.
 
 


### PR DESCRIPTION
If the user chooses branch 'A' the current commit for branch 'A' might be '123abc', this does not signify that the user has selected to checkout specifically '123abc'

closes #4091 