### PR TITLE
ZCL_ABAPGIT_REPO_ONLINE: Get remote objects by branch hash on 'Refresh'

### DIFF
--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -216,7 +216,7 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
 
   METHOD get_selected_commit.
-* todo, rv_sha1 = mv_current_commit.
+    rv_sha1 = mv_current_commit.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -121,7 +121,8 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
     li_progress->show( iv_current = 1
                        iv_text    = 'Fetch remote files' ).
 
-    IF get_selected_commit( ) IS INITIAL.
+    IF   mv_request_local_refresh = abap_true
+      OR get_selected_commit( ) IS INITIAL.
       ls_pull = zcl_abapgit_git_porcelain=>pull_by_branch( iv_url         = get_url( )
                                                            iv_branch_name = get_selected_branch( ) ).
     ELSE.


### PR DESCRIPTION
Related to #3040

We have to get the remote objects by the top branch hash via branch name if the user selects 'Refresh' to avoid breaking existing functionality.