### PR TITLE
Add option to specify own test repo path

### DIFF
--- a/src/objects/zcl_abapgit_objects_ci_tests.clas.abap
+++ b/src/objects/zcl_abapgit_objects_ci_tests.clas.abap
@@ -10,7 +10,8 @@ CLASS zcl_abapgit_objects_ci_tests DEFINITION
     CLASS-METHODS:
       run
         IMPORTING
-          !iv_object TYPE tadir-object.
+          iv_object TYPE tadir-object
+          iv_url    TYPE string OPTIONAL.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -18,7 +19,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_CI_TESTS IMPLEMENTATION.
+CLASS zcl_abapgit_objects_ci_tests IMPLEMENTATION.
 
 
   METHOD run.
@@ -43,7 +44,11 @@ CLASS ZCL_ABAPGIT_OBJECTS_CI_TESTS IMPLEMENTATION.
 
     " Add the default test repo from https://github.com/abapGit-tests
     ls_repo-name = iv_object.
-    ls_repo-clone_url = |https://github.com/abapGit-tests/{ iv_object }|.
+    IF iv_url IS NOT INITIAL.
+      ls_repo-clone_url = iv_url.
+    ELSE.
+      ls_repo-clone_url = |https://github.com/abapGit-tests/{ iv_object }|.
+    ENDIF.
     APPEND ls_repo TO lt_repos.
 
     " Get list of repos via exit


### PR DESCRIPTION
I played around with the CI integration and it is quite useable if the test repo is on a local server. My test runtime went from 3-4s on GitHub down to 0.8-0.9s with a local AGS.

Originally I wanted to try to add a base URL, but AGS likes to create repo URLs with ".git" at the end, which CI doesn't do. 
So we have the current behaviour to run CI using GitHub as default:
```
    zcl_abapgit_objects_ci_tests=>run( 'PDTS' )
```
Or with this PR a test repo can be anywhere you like:
```
    zcl_abapgit_objects_ci_tests=>run(
      EXPORTING
        iv_object = 'PDTS'
        iv_url  = `http://vhcalnplci:8000/sap/zabapgitserver/git/PDTS.git` ).
```
