### PR TITLE
Remove obsolete late_deser from metadata

### DIFF
--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -78,107 +78,6 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD create_instance.
-    CREATE OBJECT ro_manifest_reader
-      EXPORTING
-        iv_package_name = iv_package_name.
-  ENDMETHOD.
-
-
-  METHOD deserialize.
-
-    DATA: lv_xml  TYPE string,
-          ls_data TYPE zif_abapgit_apack_definitions=>ty_descriptor.
-
-    lv_xml = zcl_abapgit_convert=>xstring_to_string_utf8( iv_xstr ).
-
-    ls_data = from_xml( lv_xml ).
-
-    ro_manifest_reader = create_instance( iv_package_name ).
-
-    ro_manifest_reader = create_instance( iv_package_name ).
-    ro_manifest_reader->set_manifest_descriptor( ls_data ).
-
-  ENDMETHOD.
-
-
-  METHOD from_xml.
-
-    DATA: lv_xml TYPE string.
-
-    lv_xml = iv_xml.
-
-    CALL TRANSFORMATION id
-      OPTIONS value_handling = 'accept_data_loss'
-      SOURCE XML lv_xml
-      RESULT data = rs_data.
-
-  ENDMETHOD.
-
-
-  METHOD get_manifest_descriptor.
-
-    DATA: lo_manifest_provider       TYPE REF TO object,
-          ls_manifest_implementation TYPE ty_s_manifest_declaration.
-
-    IF mv_is_cached IS INITIAL AND mv_package_name IS NOT INITIAL.
-      SELECT SINGLE seometarel~clsname tadir~devclass FROM seometarel "#EC CI_NOORDER
-         INNER JOIN tadir ON seometarel~clsname = tadir~obj_name "#EC CI_BUFFJOIN
-         INTO ls_manifest_implementation
-         WHERE tadir~pgmid = 'R3TR' AND
-               tadir~object = 'CLAS' AND
-               seometarel~version = '1' AND
-               seometarel~refclsname = 'ZIF_APACK_MANIFEST' AND
-               tadir~devclass = me->mv_package_name.
-      IF ls_manifest_implementation IS INITIAL.
-        SELECT SINGLE seometarel~clsname tadir~devclass FROM seometarel "#EC CI_NOORDER
-           INNER JOIN tadir ON seometarel~clsname = tadir~obj_name "#EC CI_BUFFJOIN
-           INTO ls_manifest_implementation
-           WHERE tadir~pgmid = 'R3TR' AND
-                 tadir~object = 'CLAS' AND
-                 seometarel~version = '1' AND
-                 seometarel~refclsname = 'IF_APACK_MANIFEST' AND
-                 tadir~devclass = me->mv_package_name.
-      ENDIF.
-      IF ls_manifest_implementation IS NOT INITIAL.
-        TRY.
-            CREATE OBJECT lo_manifest_provider TYPE (ls_manifest_implementation-clsname).
-          CATCH cx_sy_create_object_error.
-            CLEAR: rs_manifest_descriptor.
-        ENDTRY.
-        IF lo_manifest_provider IS BOUND.
-          me->copy_manifest_descriptor( io_manifest_provider = lo_manifest_provider ).
-        ENDIF.
-      ENDIF.
-
-      mv_is_cached = abap_true.
-
-    ENDIF.
-
-    rs_manifest_descriptor = me->ms_cached_descriptor.
-  ENDMETHOD.
-
-
-  METHOD has_manifest.
-
-    DATA: ls_returned_manifest TYPE zif_abapgit_apack_definitions=>ty_descriptor.
-
-    ls_returned_manifest = get_manifest_descriptor( ).
-
-    rv_has_manifest = abap_false.
-    IF ls_returned_manifest IS NOT INITIAL.
-      rv_has_manifest = abap_true.
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD set_manifest_descriptor.
-    mv_is_cached = abap_true.
-    ms_cached_descriptor = is_manifest_descriptor.
-    format_version( ).
-  ENDMETHOD.
-
   METHOD copy_manifest_descriptor.
 
     DATA: ls_my_manifest_wo_deps TYPE zif_abapgit_apack_definitions=>ty_descriptor_wo_dependencies,
@@ -212,6 +111,30 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD create_instance.
+    CREATE OBJECT ro_manifest_reader
+      EXPORTING
+        iv_package_name = iv_package_name.
+  ENDMETHOD.
+
+
+  METHOD deserialize.
+
+    DATA: lv_xml  TYPE string,
+          ls_data TYPE zif_abapgit_apack_definitions=>ty_descriptor.
+
+    lv_xml = zcl_abapgit_convert=>xstring_to_string_utf8( iv_xstr ).
+
+    ls_data = from_xml( lv_xml ).
+
+    ro_manifest_reader = create_instance( iv_package_name ).
+
+    ro_manifest_reader = create_instance( iv_package_name ).
+    ro_manifest_reader->set_manifest_descriptor( ls_data ).
+
+  ENDMETHOD.
+
+
   METHOD format_version.
 
     FIELD-SYMBOLS: <ls_dependency> TYPE zif_abapgit_apack_definitions=>ty_dependency.
@@ -226,4 +149,80 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD from_xml.
+
+    DATA: lv_xml TYPE string.
+
+    lv_xml = iv_xml.
+
+    CALL TRANSFORMATION id
+      OPTIONS value_handling = 'accept_data_loss'
+      SOURCE XML lv_xml
+      RESULT data = rs_data.
+
+  ENDMETHOD.
+
+
+  METHOD get_manifest_descriptor.
+
+    DATA: lo_manifest_provider       TYPE REF TO object,
+          ls_manifest_implementation TYPE ty_s_manifest_declaration.
+
+    IF mv_is_cached IS INITIAL AND mv_package_name IS NOT INITIAL.
+      SELECT SINGLE seometarel~clsname tadir~devclass FROM seometarel "#EC CI_NOORDER
+         INNER JOIN tadir ON seometarel~clsname = tadir~obj_name "#EC CI_BUFFJOIN
+         INTO ls_manifest_implementation
+         WHERE tadir~pgmid = 'R3TR' AND
+               tadir~object = 'CLAS' AND
+               seometarel~version = '1' AND
+               seometarel~refclsname = 'ZIF_APACK_MANIFEST' AND
+               tadir~devclass = mv_package_name.
+      IF ls_manifest_implementation IS INITIAL.
+        SELECT SINGLE seometarel~clsname tadir~devclass FROM seometarel "#EC CI_NOORDER
+           INNER JOIN tadir ON seometarel~clsname = tadir~obj_name "#EC CI_BUFFJOIN
+           INTO ls_manifest_implementation
+           WHERE tadir~pgmid = 'R3TR' AND
+                 tadir~object = 'CLAS' AND
+                 seometarel~version = '1' AND
+                 seometarel~refclsname = 'IF_APACK_MANIFEST' AND
+                 tadir~devclass = mv_package_name.
+      ENDIF.
+      IF ls_manifest_implementation IS NOT INITIAL.
+        TRY.
+            CREATE OBJECT lo_manifest_provider TYPE (ls_manifest_implementation-clsname).
+          CATCH cx_sy_create_object_error.
+            CLEAR: rs_manifest_descriptor.
+        ENDTRY.
+        IF lo_manifest_provider IS BOUND.
+          copy_manifest_descriptor( io_manifest_provider = lo_manifest_provider ).
+        ENDIF.
+      ENDIF.
+
+      mv_is_cached = abap_true.
+
+    ENDIF.
+
+    rs_manifest_descriptor = ms_cached_descriptor.
+  ENDMETHOD.
+
+
+  METHOD has_manifest.
+
+    DATA: ls_returned_manifest TYPE zif_abapgit_apack_definitions=>ty_descriptor.
+
+    ls_returned_manifest = get_manifest_descriptor( ).
+
+    rv_has_manifest = abap_false.
+    IF ls_returned_manifest IS NOT INITIAL.
+      rv_has_manifest = abap_true.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD set_manifest_descriptor.
+    mv_is_cached = abap_true.
+    ms_cached_descriptor = is_manifest_descriptor.
+    format_version( ).
+  ENDMETHOD.
 ENDCLASS.

--- a/src/apack/zcl_abapgit_apack_reader.clas.testclasses.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.testclasses.abap
@@ -23,8 +23,8 @@ CLASS ltcl_apack_manifest_reader IMPLEMENTATION.
     ls_apack_manifest_descriptor-version = '1.42'.
     ls_apack_manifest_descriptor-git_url = 'https://github.com/abapGit/abapGit.git'.
 
-    me->mo_manifest_reader = zcl_abapgit_apack_reader=>create_instance( '$TMP' ).
-    me->mo_manifest_reader->set_manifest_descriptor( ls_apack_manifest_descriptor ).
+    mo_manifest_reader = zcl_abapgit_apack_reader=>create_instance( '$TMP' ).
+    mo_manifest_reader->set_manifest_descriptor( ls_apack_manifest_descriptor ).
 
   ENDMETHOD.
 

--- a/src/apack/zcl_abapgit_apack_writer.clas.abap
+++ b/src/apack/zcl_abapgit_apack_writer.clas.abap
@@ -30,7 +30,7 @@ CLASS zcl_abapgit_apack_writer IMPLEMENTATION.
 
 
   METHOD constructor.
-    me->ms_manifest_descriptor = is_apack_manifest_descriptor.
+    ms_manifest_descriptor = is_apack_manifest_descriptor.
   ENDMETHOD.
 
 

--- a/src/git/zcl_abapgit_git_branch_list.clas.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.abap
@@ -90,7 +90,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
+CLASS zcl_abapgit_git_branch_list IMPLEMENTATION.
 
 
   METHOD complete_heads_branch_name.
@@ -108,8 +108,8 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
       EXPORTING
         iv_data        = iv_data
       IMPORTING
-        et_list        = me->mt_branches
-        ev_head_symref = me->mv_head_symref ).
+        et_list        = mt_branches
+        ev_head_symref = mv_head_symref ).
 
   ENDMETHOD.
 

--- a/src/objects/ecatt/zcl_abapgit_ecatt_script_downl.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_script_downl.clas.abap
@@ -51,7 +51,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
+CLASS zcl_abapgit_ecatt_script_downl IMPLEMENTATION.
 
 
   METHOD download.
@@ -194,7 +194,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
         ex_errmsg       = lv_errmsg ).
 
     IF li_artmp_node IS INITIAL OR lv_rc_args_tmpl > 0.
-      me->raise_download_exception(
+      raise_download_exception(
           textid        = cx_ecatt_apl_util=>download_processing
           previous      = ex_ecatt
           called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_ARTMP_TO_TEMPLATE'
@@ -203,7 +203,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
 
     lv_rc = li_artmp_node->set_value( value = lv_text ).
     IF lv_rc <> 0.
-      me->raise_download_exception(
+      raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
             called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_ARTMP_TO_TEMPLATE' ).
@@ -225,7 +225,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
                   parent = root_node ).
 
     IF li_blob_node IS INITIAL.
-      me->raise_download_exception(
+      raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
             called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_BLOB_TO_TEMPLATE' ).
@@ -239,7 +239,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
 
     lv_rc = li_blob_node->set_value( value = lv_text ).
     IF lv_rc <> 0.
-      me->raise_download_exception(
+      raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
             called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_BLOB_TO_TEMPLATE' ).
@@ -362,7 +362,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
           OTHERS       = 2.
 
       IF sy-subrc <> 0.
-        me->raise_download_exception(
+        raise_download_exception(
               textid   = cx_ecatt_apl_util=>download_processing
               previous = ex_ecatt ).
       ENDIF.
@@ -371,7 +371,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
       lv_rc = li_deep_tcd->append_child( new_child = li_element ).
 
       IF lv_rc <> 0.
-        me->raise_download_exception(
+        raise_download_exception(
               textid   = cx_ecatt_apl_util=>download_processing
               previous = ex_ecatt ).
       ENDIF.
@@ -410,7 +410,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
                         parent = root_node ).
 
     IF mi_script_node IS INITIAL.
-      me->raise_download_exception(
+      raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
             called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_SCRIPT_TO_TEMPLATE' ).
@@ -428,7 +428,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
         illegal_name = 1
         OTHERS       = 2.
     IF sy-subrc <> 0.
-      me->raise_download_exception(
+      raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
             called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_SCRIPT_TO_TEMPLATE' ).
@@ -437,7 +437,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
 
     lv_rc = mi_script_node->append_child( li_element ).
     IF lv_rc <> 0.
-      me->raise_download_exception(
+      raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
             called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_SCRIPT_TO_TEMPLATE' ).

--- a/src/objects/ecatt/zcl_abapgit_ecatt_sp_upload.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_sp_upload.clas.abap
@@ -128,7 +128,7 @@ CLASS zcl_abapgit_ecatt_sp_upload IMPLEMENTATION.
         lv_exc_occ = 'X'.
     ENDTRY.
 
-    ASSIGN me->ecatt_object TO <lg_ecatt_sp>.
+    ASSIGN ecatt_object TO <lg_ecatt_sp>.
     ASSERT sy-subrc = 0.
 
     lo_ecatt_sp = <lg_ecatt_sp>.

--- a/src/objects/zcl_abapgit_object_dcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_dcls.clas.abap
@@ -10,7 +10,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DCLS IMPLEMENTATION.
+CLASS zcl_abapgit_object_dcls IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -124,9 +124,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DCLS IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_metadata.
     rs_metadata = get_metadata( ).
-
     rs_metadata-delete_tadir = abap_true.
-    rs_metadata-late_deser   = abap_true.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -20,7 +20,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
+CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
 
 
   METHOD is_baseinfo_supported.
@@ -327,7 +327,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
 
     CASE lv_ddtypekind.
       WHEN 'STOB'.
-        me->open_adt_stob( ms_item-obj_name ).
+        open_adt_stob( ms_item-obj_name ).
       WHEN OTHERS.
         zcx_abapgit_exception=>raise( 'DDLS Jump Error' ).
     ENDCASE.

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -36,7 +36,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DEVC IMPLEMENTATION.
+CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -51,7 +51,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DEVC IMPLEMENTATION.
 
 
   METHOD get_package.
-    IF me->zif_abapgit_object~exists( ) = abap_true.
+    IF zif_abapgit_object~exists( ) = abap_true.
       ri_package = load_package( mv_local_devclass ).
     ENDIF.
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_iext.clas.abap
+++ b/src/objects/zcl_abapgit_object_iext.clas.abap
@@ -22,7 +22,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_IEXT IMPLEMENTATION.
+CLASS zcl_abapgit_object_iext IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -79,7 +79,7 @@ CLASS ZCL_ABAPGIT_OBJECT_IEXT IMPLEMENTATION.
     ls_attributes-presp = cl_abap_syst=>get_user_name( ).
     ls_attributes-pwork = ls_attributes-presp.
 
-    IF me->zif_abapgit_object~exists( ) = abap_true.
+    IF zif_abapgit_object~exists( ) = abap_true.
       CALL FUNCTION 'EXTTYPE_UPDATE'
         EXPORTING
           pi_cimtyp     = mv_extension

--- a/src/objects/zcl_abapgit_object_nrob.clas.abap
+++ b/src/objects/zcl_abapgit_object_nrob.clas.abap
@@ -14,7 +14,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_NROB IMPLEMENTATION.
+CLASS zcl_abapgit_object_nrob IMPLEMENTATION.
 
 
   METHOD delete_intervals.
@@ -215,7 +215,6 @@ CLASS ZCL_ABAPGIT_OBJECT_NROB IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_metadata.
     rs_metadata = get_metadata( ).
-    rs_metadata-late_deser = abap_true.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_pers.clas.abap
+++ b/src/objects/zcl_abapgit_object_pers.clas.abap
@@ -9,7 +9,7 @@ CLASS zcl_abapgit_object_pers DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
           is_item     TYPE zif_abapgit_definitions=>ty_item
           iv_language TYPE spras.
 
-protected section.
+  PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES:
       BEGIN OF ty_personalization_object,

--- a/src/objects/zcl_abapgit_object_pers.clas.abap
+++ b/src/objects/zcl_abapgit_object_pers.clas.abap
@@ -9,6 +9,7 @@ CLASS zcl_abapgit_object_pers DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
           is_item     TYPE zif_abapgit_definitions=>ty_item
           iv_language TYPE spras.
 
+protected section.
   PRIVATE SECTION.
     TYPES:
       BEGIN OF ty_personalization_object,
@@ -35,6 +36,7 @@ ENDCLASS.
 
 CLASS zcl_abapgit_object_pers IMPLEMENTATION.
 
+
   METHOD constructor.
 
     super->constructor( is_item     = is_item
@@ -42,6 +44,27 @@ CLASS zcl_abapgit_object_pers IMPLEMENTATION.
 
 
     mv_pers_key = ms_item-obj_name.
+
+  ENDMETHOD.
+
+
+  METHOD get_personalization_object.
+
+    CREATE OBJECT ro_personalization_object
+      EXPORTING
+        p_create                = iv_create
+        p_pers_key              = mv_pers_key
+        p_view_only             = iv_view_only
+      EXCEPTIONS
+        pers_key_already_exists = 1
+        pers_key_does_not_exist = 2
+        transport_view_only     = 3
+        transport_canceled      = 4
+        OTHERS                  = 5.
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -134,9 +157,7 @@ CLASS zcl_abapgit_object_pers IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_metadata.
     rs_metadata = get_metadata( ).
-
     rs_metadata-delete_tadir = abap_true.
-    rs_metadata-late_deser   = abap_true.
   ENDMETHOD.
 
 
@@ -214,26 +235,4 @@ CLASS zcl_abapgit_object_pers IMPLEMENTATION.
                  ig_data = ls_personalization_object ).
 
   ENDMETHOD.
-
-
-  METHOD get_personalization_object.
-
-    CREATE OBJECT ro_personalization_object
-      EXPORTING
-        p_create                = iv_create
-        p_pers_key              = mv_pers_key
-        p_view_only             = iv_view_only
-      EXCEPTIONS
-        pers_key_already_exists = 1
-        pers_key_does_not_exist = 2
-        transport_view_only     = 3
-        transport_canceled      = 4
-        OTHERS                  = 5.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -40,7 +40,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
+CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
 
 
   METHOD clear_fields.
@@ -168,7 +168,9 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
     CONSTANTS lc_activity_delete_06 TYPE activ_auth VALUE '06'.
 
     TRY.
-        me->zif_abapgit_object~exists( ).
+        IF zif_abapgit_object~exists( ) = abap_false.
+          RETURN.
+        ENDIF.
       CATCH zcx_abapgit_exception.
         RETURN.
     ENDTRY.

--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -39,7 +39,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SSFO IMPLEMENTATION.
+CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
 
 
   METHOD code_item_section_handling.
@@ -146,20 +146,20 @@ CLASS ZCL_ABAPGIT_OBJECT_SSFO IMPLEMENTATION.
 
     DATA: ls_range_node_code TYPE LINE OF ty_string_range.
 
-    IF me->gt_range_node_codes IS INITIAL.
+    IF gt_range_node_codes IS INITIAL.
       ls_range_node_code-sign   = 'I'.
       ls_range_node_code-option = 'EQ'.
       ls_range_node_code-low    = 'CODE'.
-      INSERT ls_range_node_code INTO TABLE me->gt_range_node_codes.
+      INSERT ls_range_node_code INTO TABLE gt_range_node_codes.
       ls_range_node_code-low    = 'GTYPES'.
-      INSERT ls_range_node_code INTO TABLE me->gt_range_node_codes.
+      INSERT ls_range_node_code INTO TABLE gt_range_node_codes.
       ls_range_node_code-low    = 'GCODING'.
-      INSERT ls_range_node_code INTO TABLE me->gt_range_node_codes.
+      INSERT ls_range_node_code INTO TABLE gt_range_node_codes.
       ls_range_node_code-low    = 'FCODING'.
-      INSERT ls_range_node_code INTO TABLE me->gt_range_node_codes.
+      INSERT ls_range_node_code INTO TABLE gt_range_node_codes.
     ENDIF.
 
-    rt_range_node_codes = me->gt_range_node_codes.
+    rt_range_node_codes = gt_range_node_codes.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_susc.clas.abap
+++ b/src/objects/zcl_abapgit_object_susc.clas.abap
@@ -30,7 +30,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SUSC IMPLEMENTATION.
+CLASS zcl_abapgit_object_susc IMPLEMENTATION.
 
 
   METHOD delete_class.
@@ -136,7 +136,9 @@ CLASS ZCL_ABAPGIT_OBJECT_SUSC IMPLEMENTATION.
     lv_auth_object_class = ms_item-obj_name.
 
     TRY.
-        me->zif_abapgit_object~exists( ).
+        IF zif_abapgit_object~exists( ) = abap_false.
+          RETURN.
+        ENDIF.
       CATCH zcx_abapgit_exception.
         RETURN.
     ENDTRY.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -108,7 +108,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
+CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
 
   METHOD clear_dd03p_fields.
@@ -369,6 +369,16 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
         zcx_abapgit_exception=>raise( |error from DDIF_TABL_PUT @TEXTS, { sy-subrc }| ).
       ENDIF.
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD is_db_table_category.
+
+    " values from domain TABCLASS
+    rv_is_db_table_type = boolc( iv_tabclass = 'TRANSP'
+                              OR iv_tabclass = 'CLUSTER'
+                              OR iv_tabclass = 'POOL' ).
 
   ENDMETHOD.
 
@@ -812,7 +822,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
     CREATE OBJECT li_local_version_output TYPE zcl_abapgit_xml_output.
 
-    me->zif_abapgit_object~serialize( li_local_version_output ).
+    zif_abapgit_object~serialize( li_local_version_output ).
 
     CREATE OBJECT li_local_version_input
       TYPE zcl_abapgit_xml_input
@@ -996,15 +1006,4 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
                  ig_data = ls_extras ).
 
   ENDMETHOD.
-
-
-  METHOD is_db_table_category.
-
-    " values from domain TABCLASS
-    rv_is_db_table_type = boolc( iv_tabclass = 'TRANSP'
-                              OR iv_tabclass = 'CLUSTER'
-                              OR iv_tabclass = 'POOL' ).
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_tobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_tobj.clas.abap
@@ -22,7 +22,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TOBJ IMPLEMENTATION.
+CLASS zcl_abapgit_object_tobj IMPLEMENTATION.
 
 
   METHOD delete_extra.
@@ -226,7 +226,6 @@ CLASS ZCL_ABAPGIT_OBJECT_TOBJ IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_metadata.
     rs_metadata = get_metadata( ).
-    rs_metadata-late_deser = abap_true.
     rs_metadata-delete_tadir = abap_true.
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -109,7 +109,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
+CLASS zcl_abapgit_object_tran IMPLEMENTATION.
 
 
   METHOD add_data.
@@ -719,7 +719,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
 
       WHEN OTHERS.
 
-        me->clear_functiongroup_globals( ).
+        clear_functiongroup_globals( ).
 
         CALL FUNCTION 'RPY_TRANSACTION_INSERT'
           EXPORTING

--- a/src/objects/zcl_abapgit_object_udmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_udmo.clas.abap
@@ -96,7 +96,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
+CLASS zcl_abapgit_object_udmo IMPLEMENTATION.
 
 
   METHOD access_free.
@@ -106,8 +106,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     CALL FUNCTION 'RS_ACCESS_PERMISSION'
       EXPORTING
         mode                     = 'FREE'
-        object                   = me->ms_object_type
-        object_class             = me->c_transport_object_class
+        object                   = ms_object_type
+        object_class             = c_transport_object_class
       EXCEPTIONS
         canceled_in_corr         = 1
         enqueued_by_user         = 2
@@ -144,8 +144,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
         authority_check          = abap_true
         global_lock              = abap_true
         mode                     = 'MODIFY'
-        object                   = me->ms_object_type
-        object_class             = me->c_transport_object_class
+        object                   = ms_object_type
+        object_class             = c_transport_object_class
       EXCEPTIONS
         canceled_in_corr         = 1
         enqueued_by_user         = 2
@@ -174,9 +174,9 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
 
     " Conversion to Data model
-    me->mv_data_model = is_item-obj_name.
+    mv_data_model = is_item-obj_name.
     " Default activation state is active
-    me->mv_activation_state = c_active_state.
+    mv_activation_state = c_active_state.
     " Derive the data model's text object
     mv_text_object = 'UDMD' && is_item-obj_name.
     " And set the text object to active
@@ -184,8 +184,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     mv_lxe_text_name = mv_text_object.
 
     " Correction and Transport System object
-    me->ms_object_type-objtype = c_correction_object_type.
-    me->ms_object_type-objname = is_item-obj_name.
+    ms_object_type-objtype = c_correction_object_type.
+    ms_object_type-objname = is_item-obj_name.
 
 
   ENDMETHOD.
@@ -200,8 +200,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
     CALL FUNCTION 'RS_CORR_INSERT'
       EXPORTING
-        object              = me->ms_object_type
-        object_class        = me->c_transport_object_class
+        object              = ms_object_type
+        object_class        = c_transport_object_class
         devclass            = iv_package
         master_language     = mv_language
         mode                = 'INSERT'
@@ -271,8 +271,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
       SELECT MAX( dokversion )
       INTO ls_header-tdversion
       FROM dokhl
-      WHERE id = me->c_lxe_text_type
-      AND   object = me->mv_text_object
+      WHERE id = c_lxe_text_type
+      AND   object = mv_text_object
       AND   langu = ls_udmo_long_text-language.
 
       " Increment the version
@@ -282,10 +282,10 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
       " This function module takes care of the variation in text processing between various objects.
       CALL FUNCTION 'LXE_OBJ_DOKU_PUT_XSTRING'
         EXPORTING
-          slang   = me->mv_language
+          slang   = mv_language
           tlang   = ls_udmo_long_text-language
-          objtype = me->c_lxe_text_type
-          objname = me->mv_lxe_text_name
+          objtype = c_lxe_text_type
+          objname = mv_lxe_text_name
           header  = ls_udmo_long_text-header
           content = ls_udmo_long_text-content.
 
@@ -348,7 +348,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
         INTO ls_dm40t
         WHERE sprache  = ls_udmo_text-sprache
         AND   dmoid    = ls_udmo_text-dmoid
-        AND   as4local = me->mv_activation_state.
+        AND   as4local = mv_activation_state.
 
       IF sy-subrc = 0.
         " There is already an active description for this language
@@ -395,8 +395,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
     CALL FUNCTION 'SDU_SAA_CHECK'
       EXPORTING
-        obj_name   = me->ms_object_type-objname
-        obj_type   = me->ms_object_type-objtype
+        obj_name   = ms_object_type-objname
+        obj_type   = ms_object_type-objtype
       EXCEPTIONS
         wrong_type = 01.
 
@@ -414,8 +414,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
     SELECT * FROM dm41s
       INTO TABLE lt_udmo_entities
-      WHERE dmoid = me->mv_data_model
-      AND as4local = me->mv_activation_state.
+      WHERE dmoid = mv_data_model
+      AND as4local = mv_activation_state.
 
 
     LOOP AT lt_udmo_entities ASSIGNING <ls_udmo_entity>.
@@ -466,8 +466,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     SELECT sprache AS language
       FROM dm40t
       INTO TABLE lt_udmo_languages
-      WHERE dmoid    = me->mv_data_model
-      AND   as4local = me->mv_activation_state
+      WHERE dmoid    = mv_data_model
+      AND   as4local = mv_activation_state
       ORDER BY sprache ASCENDING.                       "#EC CI_NOFIRST
 
     " For every language for which a short text is maintained,
@@ -482,8 +482,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
       CALL FUNCTION 'LXE_OBJ_DOKU_GET_XSTRING'
         EXPORTING
           lang    = ls_udmo_language-language
-          objtype = me->c_lxe_text_type
-          objname = me->mv_lxe_text_name
+          objtype = c_lxe_text_type
+          objname = mv_lxe_text_name
         IMPORTING
           header  = ls_udmo_long_text-header
           content = ls_udmo_long_text-content
@@ -522,8 +522,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     SELECT SINGLE *
     FROM dm40l
     INTO ls_dm40l
-    WHERE dmoid    = me->mv_data_model
-    AND   as4local = me->mv_activation_state.
+    WHERE dmoid    = mv_data_model
+    AND   as4local = mv_activation_state.
 
 
     IF sy-subrc <> 0.
@@ -554,8 +554,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     SELECT sprache dmoid as4local langbez
       FROM dm40t
       INTO CORRESPONDING FIELDS OF TABLE lt_udmo_texts
-      WHERE dmoid    = me->mv_data_model
-      AND   as4local = me->mv_activation_state
+      WHERE dmoid    = mv_data_model
+      AND   as4local = mv_activation_state
       ORDER BY sprache ASCENDING.                       "#EC CI_NOFIRST
 
     " You are reminded that descriptions in other languages do not have to be in existence.
@@ -572,9 +572,9 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
     CALL FUNCTION 'RS_TREE_OBJECT_PLACEMENT'
       EXPORTING
-        object    = me->mv_data_model
+        object    = mv_data_model
         operation = 'INSERT'
-        type      = me->c_correction_object_type.
+        type      = c_correction_object_type.
 
   ENDMETHOD.
 
@@ -583,8 +583,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
     SELECT SINGLE lstuser INTO rv_user
       FROM dm40l
-      WHERE dmoid = me->mv_data_model
-      AND as4local = me->mv_activation_state.
+      WHERE dmoid = mv_data_model
+      AND as4local = mv_activation_state.
 
     IF sy-subrc <> 0.
       rv_user = c_user_unknown.
@@ -605,7 +605,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
     CALL FUNCTION 'RPY_DATAMODEL_DELETE'
       EXPORTING
-        model_name       = me->mv_data_model
+        model_name       = mv_data_model
       EXCEPTIONS
         cancelled        = 1
         permission_error = 2
@@ -652,7 +652,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
 
       CATCH zcx_abapgit_exception.
 
-        me->access_free( ).
+        access_free( ).
 
         zcx_abapgit_exception=>raise( 'Error in deserialisation of UDMO' ).
 
@@ -670,8 +670,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     "  See Function Module SDU_MODEL_EXISTS
 
     SELECT COUNT( * ) FROM  dm40l
-           WHERE  dmoid     = me->mv_data_model
-           AND    as4local  = me->mv_activation_state.
+           WHERE  dmoid     = mv_data_model
+           AND    as4local  = mv_activation_state.
 
     rv_bool = boolc( sy-subrc = 0 ).
 
@@ -760,9 +760,9 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
     ENDIF.
 
     serialize_model( io_xml ).
-    me->serialize_entities( io_xml ).
-    me->serialize_short_texts( io_xml ).
-    me->serialize_long_texts( io_xml ).
+    serialize_entities( io_xml ).
+    serialize_short_texts( io_xml ).
+    serialize_long_texts( io_xml ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_ueno.clas.abap
+++ b/src/objects/zcl_abapgit_object_ueno.clas.abap
@@ -105,7 +105,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
+CLASS zcl_abapgit_object_ueno IMPLEMENTATION.
 
 
   METHOD build_text_name.
@@ -119,7 +119,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
     DATA ls_text_name TYPE ty_text_name.
 
     ls_text_name-id = iv_id.
-    ls_text_name-entity = me->mv_entity_id.
+    ls_text_name-entity = mv_entity_id.
     ls_text_name-modifier = 'A%'.
 
     rv_result = ls_text_name.
@@ -132,7 +132,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
     super->constructor( is_item  =  is_item
                         iv_language = iv_language ).
 
-    me->mv_entity_id = is_item-obj_name.
+    mv_entity_id = is_item-obj_name.
 
   ENDMETHOD.
 
@@ -145,7 +145,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
     SELECT *
       FROM dm02l
       INTO TABLE lt_dm02l
-      WHERE entid = me->mv_entity_id.
+      WHERE entid = mv_entity_id.
 
     LOOP AT lt_dm02l INTO ls_dm02l.
 
@@ -154,7 +154,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
           key1     = ls_dm02l-entid
           key2     = ls_dm02l-as4local
           key3     = '00'
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'UENC' "Entity Comments
         EXCEPTIONS
           ret_code = 0.
@@ -164,7 +164,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
           key1     = ls_dm02l-entid
           key2     = ls_dm02l-as4local
           key3     = '00'
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'UEND' "Entity Definition
         EXCEPTIONS
           ret_code = 0.
@@ -174,7 +174,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
           key1     = ls_dm02l-entid
           key2     = ls_dm02l-as4local
           key3     = '00'
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'UENE' "Entity Example
         EXCEPTIONS
           ret_code = 0.
@@ -192,13 +192,13 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
     SELECT *
       FROM dm42s
       INTO TABLE lt_dm42s
-      WHERE entidto = me->mv_entity_id.
+      WHERE entidto = mv_entity_id.
 
     LOOP AT lt_dm42s INTO ls_dm42s.
 
       CALL FUNCTION 'SDU_DOCU_DELETE'
         EXPORTING
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'URL1'
           key1     = ls_dm42s-entidto
           key2     = ls_dm42s-as4local
@@ -209,7 +209,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
 
       CALL FUNCTION 'SDU_DOCU_DELETE'
         EXPORTING
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'URL2'
           key1     = ls_dm42s-entidto
           key2     = ls_dm42s-as4local
@@ -220,7 +220,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
 
       CALL FUNCTION 'SDU_DOCU_DELETE'
         EXPORTING
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'URLC'
           key1     = ls_dm42s-entidto
           key2     = ls_dm42s-as4local
@@ -243,13 +243,13 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
     SELECT *
       FROM dm45l
       INTO TABLE lt_dm45l
-      WHERE entid = me->ms_item-obj_name.
+      WHERE entid = ms_item-obj_name.
 
     LOOP AT lt_dm45l INTO ls_dm45l.
 
       CALL FUNCTION 'SDU_DOCU_DELETE'
         EXPORTING
-          langu    = me->mv_language
+          langu    = mv_language
           obj_id   = 'USPD'
           key1     = ls_dm45l-entid
           key2     = ls_dm45l-as4local
@@ -343,7 +343,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
 
       CALL FUNCTION 'LXE_OBJ_DOKU_PUT_XSTRING'
         EXPORTING
-          slang       = me->mv_language
+          slang       = mv_language
           tlang       = ls_docu-language
           objtype     = ls_docu-header-tdid
           objname     = lv_objname
@@ -367,8 +367,8 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
 
     CALL FUNCTION 'SDU_SAA_CHECK'
       EXPORTING
-        obj_name   = me->ms_item-obj_name
-        obj_type   = me->ms_item-obj_type
+        obj_name   = ms_item-obj_name
+        obj_type   = ms_item-obj_type
       EXCEPTIONS
         wrong_type = 01.
 
@@ -444,7 +444,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
     DATA lv_objname         TYPE lxeobjname.
 
 
-    ls_dokvl-object = me->build_text_name( iv_id = iv_id ).
+    ls_dokvl-object = build_text_name( iv_id = iv_id ).
 
     SELECT id object langu
       FROM dokvl
@@ -492,7 +492,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UENO IMPLEMENTATION.
 
     SELECT SINGLE lstuser INTO rv_user
       FROM dm02l
-      WHERE entid = me->mv_entity_id
+      WHERE entid = mv_entity_id
       AND as4local = c_active_state.
 
     IF sy-subrc <> 0.

--- a/src/objects/zcl_abapgit_object_vcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_vcls.clas.abap
@@ -22,7 +22,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_VCLS IMPLEMENTATION.
+CLASS zcl_abapgit_object_vcls IMPLEMENTATION.
 
 
   METHOD check_lock.
@@ -184,8 +184,8 @@ CLASS ZCL_ABAPGIT_OBJECT_VCLS IMPLEMENTATION.
       lv_argument       TYPE seqg3-garg,
       lv_argument_langu TYPE seqg3-garg.
 
-    lv_argument       = me->ms_item-obj_name.
-    lv_argument_langu = |@{ me->ms_item-obj_name }|.
+    lv_argument       = ms_item-obj_name.
+    lv_argument_langu = |@{ ms_item-obj_name }|.
 
     "Check all relevant maintein tabeles for view clusters
     IF check_lock( iv_tabname = 'VCLDIR'

--- a/src/objects/zcl_abapgit_object_webi.clas.abap
+++ b/src/objects/zcl_abapgit_object_webi.clas.abap
@@ -61,7 +61,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
+CLASS zcl_abapgit_object_webi IMPLEMENTATION.
 
 
   METHOD handle_endpoint.
@@ -144,9 +144,9 @@ CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
       LOOP AT is_webi-pvepparameter ASSIGNING <ls_parameter>
           WHERE function = <ls_function>-function.
 
-        li_parameter = me->handle_single_parameter( iv_name        = <ls_parameter>-vepparam
-                                                    ii_function    = li_function
-                                                    iv_parameter_type = <ls_parameter>-vepparamtype ).
+        li_parameter = handle_single_parameter( iv_name           = <ls_parameter>-vepparam
+                                                ii_function       = li_function
+                                                iv_parameter_type = <ls_parameter>-vepparamtype ).
 
         li_parameter->set_name_mapped_to( <ls_parameter>-mappedname ).
         li_parameter->set_is_exposed( <ls_parameter>-is_exposed ).

--- a/src/objects/zcl_abapgit_objects_saxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_saxx_super.clas.abap
@@ -303,19 +303,7 @@ CLASS zcl_abapgit_objects_saxx_super IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_deserialize_steps.
-
-    DATA: ls_meta TYPE zif_abapgit_definitions=>ty_metadata.
-
-    ls_meta = zif_abapgit_object~get_metadata( ).
-
-    IF ls_meta-late_deser = abap_true.
-      APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
-    ELSEIF ls_meta-ddic = abap_true.
-      APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-    ELSE.
-      APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
-    ENDIF.
-
+    APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -82,7 +82,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SYNTAX_HIGHLIGHTER IMPLEMENTATION.
+CLASS zcl_abapgit_syntax_highlighter IMPLEMENTATION.
 
 
   METHOD add_rule.
@@ -192,8 +192,8 @@ CLASS ZCL_ABAPGIT_SYNTAX_HIGHLIGHTER IMPLEMENTATION.
       CLEAR ls_rule. " Failed read equals no style
       READ TABLE mt_rules INTO ls_rule WITH KEY token = <ls_match>-token.
 
-      lv_chunk = me->apply_style( iv_line  = lv_chunk
-                                  iv_class = ls_rule-style ).
+      lv_chunk = apply_style( iv_line  = lv_chunk
+                              iv_class = ls_rule-style ).
 
       rv_line = rv_line && lv_chunk.
     ENDLOOP.
@@ -266,16 +266,16 @@ CLASS ZCL_ABAPGIT_SYNTAX_HIGHLIGHTER IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    lt_matches = me->parse_line( iv_line ).
+    lt_matches = parse_line( iv_line ).
 
-    me->order_matches( EXPORTING iv_line    = iv_line
-                       CHANGING  ct_matches = lt_matches ).
+    order_matches( EXPORTING iv_line    = iv_line
+                   CHANGING  ct_matches = lt_matches ).
 
-    me->extend_matches( EXPORTING iv_line    = iv_line
-                        CHANGING  ct_matches = lt_matches ).
+    extend_matches( EXPORTING iv_line    = iv_line
+                    CHANGING  ct_matches = lt_matches ).
 
-    rv_line = me->format_line( iv_line    = iv_line
-                               it_matches = lt_matches ).
+    rv_line = format_line( iv_line    = iv_line
+                           it_matches = lt_matches ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -109,7 +109,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
+CLASS zcl_abapgit_gui IMPLEMENTATION.
 
 
   METHOD back.
@@ -196,7 +196,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
 
   METHOD free.
 
-    SET HANDLER me->on_event FOR mi_html_viewer ACTIVATION space.
+    SET HANDLER on_event FOR mi_html_viewer ACTIVATION space.
     mi_html_viewer->close_document( ).
     mi_html_viewer->free( ).
     FREE mi_html_viewer.
@@ -398,7 +398,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
     APPEND ls_event TO lt_events.
 
     mi_html_viewer->set_registered_events( lt_events ).
-    SET HANDLER me->on_event FOR mi_html_viewer.
+    SET HANDLER on_event FOR mi_html_viewer.
 
   ENDMETHOD.
 

--- a/src/ui/core/zcl_abapgit_gui_asset_manager.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_asset_manager.clas.abap
@@ -45,7 +45,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
+CLASS zcl_abapgit_gui_asset_manager IMPLEMENTATION.
 
 
   METHOD get_mime_asset.
@@ -156,7 +156,7 @@ CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
   METHOD zif_abapgit_gui_asset_manager~get_text_asset.
 
     DATA ls_asset TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
-    ls_asset = me->zif_abapgit_gui_asset_manager~get_asset( iv_url ).
+    ls_asset = zif_abapgit_gui_asset_manager~get_asset( iv_url ).
 
     IF ls_asset-type <> 'text'.
       zcx_abapgit_exception=>raise( |Not a text asset: { iv_url }| ).

--- a/src/ui/zcl_abapgit_html_viewer_gui.clas.abap
+++ b/src/ui/zcl_abapgit_html_viewer_gui.clas.abap
@@ -26,7 +26,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HTML_VIEWER_GUI IMPLEMENTATION.
+CLASS zcl_abapgit_html_viewer_gui IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -44,7 +44,7 @@ CLASS ZCL_ABAPGIT_HTML_VIEWER_GUI IMPLEMENTATION.
     APPEND ls_event TO lt_events.
 
     mo_html_viewer->set_registered_events( lt_events ).
-    SET HANDLER me->on_event FOR mo_html_viewer.
+    SET HANDLER on_event FOR mo_html_viewer.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_news.clas.abap
+++ b/src/zcl_abapgit_news.clas.abap
@@ -88,7 +88,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_NEWS IMPLEMENTATION.
+CLASS zcl_abapgit_news IMPLEMENTATION.
 
 
   METHOD compare_versions.
@@ -216,7 +216,7 @@ CLASS ZCL_ABAPGIT_NEWS IMPLEMENTATION.
 
 
   METHOD get_log.
-    rt_log = me->mt_log.
+    rt_log = mt_log.
   ENDMETHOD.
 
 
@@ -246,7 +246,7 @@ CLASS ZCL_ABAPGIT_NEWS IMPLEMENTATION.
 
 
   METHOD latest_version.
-    rv_version = me->mv_latest_version.
+    rv_version = mv_latest_version.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -138,13 +138,13 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
   METHOD get_commit_display_url.
 
-    rv_url = me->get_default_commit_display_url( iv_hash ).
+    rv_url = get_default_commit_display_url( iv_hash ).
 
     zcl_abapgit_exit=>get_instance( )->adjust_display_commit_url(
       EXPORTING
-        iv_repo_url           = me->get_url( )
-        iv_repo_name          = me->get_name( )
-        iv_repo_key           = me->get_key( )
+        iv_repo_url           = get_url( )
+        iv_repo_name          = get_name( )
+        iv_repo_key           = get_key( )
         iv_commit_hash        = iv_hash
       CHANGING
         cv_display_url        = rv_url ).
@@ -167,7 +167,7 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
     DATA ls_result TYPE match_result.
     FIELD-SYMBOLS <ls_provider_match> TYPE submatch_result.
 
-    rv_url = me->get_url( ).
+    rv_url = get_url( ).
 
     FIND REGEX '^http(?:s)?:\/\/(?:www\.)?(github\.com|bitbucket\.org|gitlab\.com)\/' IN rv_url RESULTS ls_result.
     IF sy-subrc = 0.

--- a/src/zcl_abapgit_transport_mass.clas.locals_imp.abap
+++ b/src/zcl_abapgit_transport_mass.clas.locals_imp.abap
@@ -143,9 +143,9 @@ CLASS lcl_transport_zipper IMPLEMENTATION.
 
   METHOD constructor.
 
-    CONCATENATE sy-datlo sy-timlo INTO me->mv_timestamp SEPARATED BY '_'.
+    CONCATENATE sy-datlo sy-timlo INTO mv_timestamp SEPARATED BY '_'.
 
-    me->mv_full_folder = get_full_folder( iv_folder = iv_folder ).
+    mv_full_folder = get_full_folder( iv_folder = iv_folder ).
 
     cl_gui_frontend_services=>get_file_separator(
       CHANGING


### PR DESCRIPTION
The field `late_deser` in `ZIF_ABAPGIT_DEFINITIONS=>ty_metadata` is obsolete:

```abap
  TYPES:
    BEGIN OF ty_metadata,
      class        TYPE string,
      version      TYPE string,
      late_deser   TYPE abap_bool, " refactor: can be removed later. replaced by steps
      delete_tadir TYPE abap_bool,
      ddic         TYPE abap_bool,
    END OF ty_metadata .
```

The PR removes the remaining usage with one exception: `ZCL_ABAPGIT_OBJECTS_BRIDGE->GET_DESERIALIZE_STEPS` still depends on the field. In order to remove it completely, the plug-in interface `zif_abapgitp_plugin` (https://github.com/abapGit/abapGit-Plugins/blob/master/src/zif_abapgitp_plugin.intf.abap) will have to be changed.