### PR TITLE
delete unused methods

### DIFF
--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -24,13 +24,6 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
     DATA ms_item TYPE zif_abapgit_definitions=>ty_item .
     DATA mv_language TYPE spras .
 
-    METHODS check_timestamp
-      IMPORTING
-        !iv_timestamp     TYPE timestamp
-        !iv_date          TYPE d
-        !iv_time          TYPE t
-      RETURNING
-        VALUE(rv_changed) TYPE abap_bool .
     METHODS get_metadata
       RETURNING
         VALUE(rs_metadata) TYPE zif_abapgit_definitions=>ty_metadata .
@@ -97,27 +90,6 @@ ENDCLASS.
 
 
 CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
-
-
-  METHOD check_timestamp.
-
-    DATA: lv_ts TYPE timestamp.
-
-    IF sy-subrc = 0 AND iv_date IS NOT INITIAL AND iv_time IS NOT INITIAL.
-      cl_abap_tstmp=>systemtstmp_syst2utc(
-        EXPORTING syst_date = iv_date
-                  syst_time = iv_time
-        IMPORTING utc_tstmp = lv_ts ).
-      IF lv_ts < iv_timestamp.
-        rv_changed = abap_false. " Unchanged
-      ELSE.
-        rv_changed = abap_true.
-      ENDIF.
-    ELSE. " Not found? => changed
-      rv_changed = abap_true.
-    ENDIF.
-
-  ENDMETHOD.
 
 
   METHOD constructor.

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.abap
@@ -142,9 +142,6 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
         VALUE(rs_diff) TYPE zif_abapgit_definitions=>ty_diff
       RAISING
         zcx_abapgit_exception .
-    METHODS is_every_changed_line_patched
-      RETURNING
-        VALUE(rv_everything_patched) TYPE abap_bool .
     CLASS-METHODS is_patch_line_possible
       IMPORTING
         !is_diff_line                    TYPE zif_abapgit_definitions=>ty_diff
@@ -430,35 +427,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
 
     " add beacon at beginning of file
     rv_insert_nav = abap_true.
-
-  ENDMETHOD.
-
-
-  METHOD is_every_changed_line_patched.
-
-    DATA: lt_diff TYPE zif_abapgit_definitions=>ty_diffs_tt.
-
-    FIELD-SYMBOLS:
-      <ls_diff_file> TYPE zcl_abapgit_gui_page_diff=>ty_file_diff,
-      <ls_diff>      TYPE zif_abapgit_definitions=>ty_diff.
-
-    rv_everything_patched = abap_true.
-
-    LOOP AT mt_diff_files ASSIGNING <ls_diff_file>.
-
-      lt_diff = <ls_diff_file>-o_diff->get( ).
-
-      LOOP AT lt_diff ASSIGNING <ls_diff>
-                      WHERE result IS NOT INITIAL
-                      AND   patch_flag = abap_false.
-        rv_everything_patched = abap_false.
-        EXIT.
-      ENDLOOP.
-      IF sy-subrc = 0.
-        EXIT.
-      ENDIF.
-
-    ENDLOOP.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.testclasses.abap
@@ -34,10 +34,6 @@ CLASS ltcl_is_patch_line_possible DEFINITION FINAL FOR TESTING
         IMPORTING
           is_diff_line TYPE zif_abapgit_definitions=>ty_diff OPTIONAL,
 
-      given_fstate
-        IMPORTING
-          iv_fstate TYPE char1,
-
       when_is_patch_line_possible,
 
       then_patch_shd_be_possible,
@@ -224,13 +220,6 @@ CLASS ltcl_is_patch_line_possible IMPLEMENTATION.
   METHOD given_diff_line.
 
     ms_diff_line = is_diff_line.
-
-  ENDMETHOD.
-
-
-  METHOD given_fstate.
-
-    mv_fstate = iv_fstate.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -210,7 +210,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 
   METHOD bind_listener.
@@ -488,9 +488,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       io_dot                = get_dot_abapgit( )
       ii_log                = ii_log ).
 
-    CREATE OBJECT lo_filter
-      EXPORTING
-        iv_package = get_package( ).
+    CREATE OBJECT lo_filter.
 
     lo_filter->apply( EXPORTING it_filter = it_filter
                       CHANGING  ct_tadir  = lt_tadir ).

--- a/src/zcl_abapgit_repo_filter.clas.abap
+++ b/src/zcl_abapgit_repo_filter.clas.abap
@@ -4,10 +4,6 @@ CLASS zcl_abapgit_repo_filter DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-    METHODS constructor
-      IMPORTING
-        !iv_package TYPE devclass.
-
     METHODS apply
       IMPORTING
         it_filter TYPE zif_abapgit_definitions=>ty_tadir_tt
@@ -15,27 +11,16 @@ CLASS zcl_abapgit_repo_filter DEFINITION
         ct_tadir  TYPE zif_abapgit_definitions=>ty_tadir_tt .
 
   PROTECTED SECTION.
-    METHODS get_package
-      RETURNING
-        VALUE(rv_package) TYPE devclass.
 
     METHODS filter_generated_tadir
       CHANGING
-        ct_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
-
-  PRIVATE SECTION.
-    DATA mv_package TYPE devclass.
+        !ct_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt .
 
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_filter IMPLEMENTATION.
-
-
-  METHOD constructor.
-    mv_package = iv_package.
-  ENDMETHOD.
+CLASS ZCL_ABAPGIT_REPO_FILTER IMPLEMENTATION.
 
 
   METHOD apply.
@@ -114,10 +99,4 @@ CLASS zcl_abapgit_repo_filter IMPLEMENTATION.
     ENDLOOP.
 
   ENDMETHOD.
-
-
-  METHOD get_package.
-    rv_package = mv_package.
-  ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
this deletes following unused methods,

- delete ZCL_ABAPGIT_REPO_FILTER->GET_PACKAGE
- ZCL_ABAPGIT_REPO_FILTER delete MV_PACKAGE
- testclass, delete method given_fstate
- delete ZCL_ABAPGIT_GUI_PAGE_PATCH->IS_EVERY_CHANGED_LINE_PATCHED
- delete ZCL_ABAPGIT_OBJECTS_SUPER->CHECK_TIMESTAMP