### PR TITLE
PROG: Remove inactive sources during uninstall

### DIFF
--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -126,8 +126,10 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
         permission_failure         = 3
         reject_deletion            = 4
         OTHERS                     = 5.
-
-    IF sy-subrc <> 0.
+    IF sy-subrc = 2.
+      " Drop also any inactive code that is left in REPOSRC
+      DELETE REPORT lv_program ##SUBRC_OK.
+    ELSEIF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Error from RS_DELETE_PROGRAM: { sy-subrc }| ).
     ENDIF.
 


### PR DESCRIPTION
Fixes uninstall in case program deletion was only partially completed. This can happen when programs contain inactive source code.

![image](https://user-images.githubusercontent.com/59966492/98283752-18ed4a80-1f6e-11eb-9f74-56b7165f2987.png)

