### PR TITLE
Move git url repo methods

### DIFF
--- a/src/git_platform/package.devc.xml
+++ b/src/git_platform/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>abapGit - Git Platform Functionality</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/git_platform/zcl_abapgit_git_url.clas.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.abap
@@ -62,7 +62,9 @@ CLASS ZCL_ABAPGIT_GIT_URL IMPLEMENTATION.
 
     rv_commit_url = iv_repo_url.
 
-    FIND REGEX '^http(?:s)?:\/\/(?:www\.)?(github\.com|bitbucket\.org|gitlab\.com)\/' IN rv_commit_url RESULTS ls_result.
+    FIND REGEX '^http(?:s)?:\/\/(?:www\.)?(github\.com|bitbucket\.org|gitlab\.com)\/'
+      IN rv_commit_url
+      RESULTS ls_result.
     IF sy-subrc = 0.
       READ TABLE ls_result-submatches INDEX 1 ASSIGNING <ls_provider_match>.
       CASE rv_commit_url+<ls_provider_match>-offset(<ls_provider_match>-length).

--- a/src/git_platform/zcl_abapgit_git_url.clas.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.abap
@@ -1,0 +1,82 @@
+CLASS zcl_abapgit_git_url DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS get_commit_display_url
+      IMPORTING
+        !io_repo      TYPE REF TO zcl_abapgit_repo_online
+      RETURNING
+        VALUE(rv_url) TYPE string
+      RAISING
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+
+    METHODS get_default_commit_display_url
+      IMPORTING
+        !iv_repo_url         TYPE string
+        !iv_hash             TYPE zif_abapgit_definitions=>ty_sha1
+      RETURNING
+        VALUE(rv_commit_url) TYPE string
+      RAISING
+        zcx_abapgit_exception .
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_GIT_URL IMPLEMENTATION.
+
+
+  METHOD get_commit_display_url.
+
+    DATA li_exit TYPE REF TO zif_abapgit_exit.
+
+    rv_url = get_default_commit_display_url(
+      iv_repo_url = io_repo->get_url( )
+      iv_hash     = io_repo->get_current_remote( ) ).
+
+    li_exit = zcl_abapgit_exit=>get_instance( ).
+    li_exit->adjust_display_commit_url(
+      EXPORTING
+        iv_repo_url    = io_repo->get_url( )
+        iv_repo_name   = io_repo->get_name( )
+        iv_repo_key    = io_repo->get_key( )
+        iv_commit_hash = io_repo->get_current_remote( )
+      CHANGING
+        cv_display_url = rv_url ).
+
+    IF rv_url IS INITIAL.
+      zcx_abapgit_exception=>raise( |provider not yet supported| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD get_default_commit_display_url.
+
+    DATA ls_result TYPE match_result.
+    FIELD-SYMBOLS <ls_provider_match> TYPE submatch_result.
+
+    rv_commit_url = iv_repo_url.
+
+    FIND REGEX '^http(?:s)?:\/\/(?:www\.)?(github\.com|bitbucket\.org|gitlab\.com)\/' IN rv_commit_url RESULTS ls_result.
+    IF sy-subrc = 0.
+      READ TABLE ls_result-submatches INDEX 1 ASSIGNING <ls_provider_match>.
+      CASE rv_commit_url+<ls_provider_match>-offset(<ls_provider_match>-length).
+        WHEN 'github.com'.
+          REPLACE REGEX '\.git$' IN rv_commit_url WITH space.
+          rv_commit_url = rv_commit_url && |/commit/| && iv_hash.
+        WHEN 'bitbucket.org'.
+          REPLACE REGEX '\.git$' IN rv_commit_url WITH space.
+          rv_commit_url = rv_commit_url && |/commits/| && iv_hash.
+        WHEN 'gitlab.com'.
+          REPLACE REGEX '\.git$' IN rv_commit_url WITH space.
+          rv_commit_url = rv_commit_url && |/-/commit/| && iv_hash.
+      ENDCASE.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
@@ -1,6 +1,7 @@
-CLASS ltcl_repo_online DEFINITION FINAL FOR TESTING
-  DURATION SHORT
-  RISK LEVEL HARMLESS.
+CLASS ltcl_repo_online DEFINITION DEFERRED.
+CLASS zcl_abapgit_git_url DEFINITION LOCAL FRIENDS ltcl_repo_online.
+
+CLASS ltcl_repo_online DEFINITION FINAL FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 
   PRIVATE SECTION.
     METHODS:
@@ -23,8 +24,12 @@ CLASS ltcl_repo_online IMPLEMENTATION.
           lv_testhash      TYPE zif_abapgit_definitions=>ty_sha1 VALUE 'my-SHA1-hash',
           ls_online_repo   TYPE zif_abapgit_persistence=>ty_repo,
           lr_test_repo     TYPE REF TO zcl_abapgit_repo_online,
+          lo_cut           TYPE REF TO zcl_abapgit_git_url,
           lv_show_url      TYPE zif_abapgit_persistence=>ty_repo-url.
+
     FIELD-SYMBOLS <ls_provider_urls> TYPE ty_show_url_test.
+
+    CREATE OBJECT lo_cut.
 
     ls_provider_urls-repo_url = |https://github.com/abapGit/abapGit.git|.
     ls_provider_urls-show_url = |https://github.com/abapGit/abapGit/commit/{ lv_testhash }|.
@@ -49,13 +54,14 @@ CLASS ltcl_repo_online IMPLEMENTATION.
         EXPORTING
           is_data = ls_online_repo.
 
-      lv_show_url = lr_test_repo->get_default_commit_display_url( iv_hash = lv_testhash ).
+      lv_show_url = lo_cut->get_default_commit_display_url(
+        iv_repo_url = lr_test_repo->get_url( )
+        iv_hash     = lv_testhash ).
 
       cl_aunit_assert=>assert_equals( exp  = <ls_provider_urls>-show_url
                                       act  = lv_show_url
                                       quit = cl_aunit_assert=>no ).
     ENDLOOP.
-
 
   ENDMETHOD.
 

--- a/src/git_platform/zcl_abapgit_git_url.clas.xml
+++ b/src/git_platform/zcl_abapgit_git_url.clas.xml
@@ -3,13 +3,14 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>ZCL_ABAPGIT_REPO_ONLINE</CLSNAME>
+    <CLSNAME>ZCL_ABAPGIT_GIT_URL</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>Online Repository</DESCRIPT>
+    <DESCRIPT>abapGit - Git URL</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -167,7 +167,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
 
   METHOD advanced_submenu.
@@ -852,6 +852,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     DATA: lv_commit_hash       TYPE zif_abapgit_definitions=>ty_sha1,
           lv_commit_short_hash TYPE zif_abapgit_definitions=>ty_sha1,
           lv_display_url       TYPE zif_abapgit_persistence=>ty_repo-url,
+          lo_url               TYPE REF TO zcl_abapgit_git_url,
           lv_icon_commit       TYPE string.
 
     lv_commit_hash = io_repo_online->get_current_remote( ).
@@ -861,8 +862,10 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
                                     iv_class = 'pad-sides'
                                     iv_hint  = 'Commit' ).
 
+    CREATE OBJECT lo_url.
+
     TRY.
-        lv_display_url = io_repo_online->get_commit_display_url( lv_commit_hash ).
+        lv_display_url = lo_url->get_commit_display_url( io_repo_online ).
 
         ii_html->add_a( iv_txt   = |{ lv_icon_commit }{ lv_commit_short_hash }|
                         iv_act   = |{ zif_abapgit_definitions=>c_action-url }?url={ lv_display_url }|


### PR DESCRIPTION
This moves methods GET_COMMIT_DISPLAY_URL and GET_DEFAULT_COMMIT_DISPLAY_URL from the repo class to new class in new package GIT_PLATFORM.

we want to keep the repo class small, as its quite complex and central

first part of #4085