### PR TITLE
Move type ty_seocompotx_tt

### DIFF
--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -87,7 +87,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_clas IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -110,7 +110,7 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
           lt_local_implementations TYPE seop_source_string,
           lt_local_macros          TYPE seop_source_string,
           lt_test_classes          TYPE seop_source_string,
-          lt_descriptions          TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+          lt_descriptions          TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt,
           ls_class_key             TYPE seoclskey,
           lt_attributes            TYPE zif_abapgit_definitions=>ty_obj_attribute_tt.
 
@@ -325,7 +325,7 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
   METHOD serialize_descr.
 
-    DATA: lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+    DATA: lt_descriptions TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt,
           lv_language     TYPE spras.
 
     IF ii_xml->i18n_params( )-serialize_master_lang_only = abap_true.

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -49,7 +49,7 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
   METHOD deserialize_abap.
     DATA: ls_vseointerf   TYPE vseointerf,
           lt_source       TYPE seop_source_string,
-          lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+          lt_descriptions TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt,
           ls_clskey       TYPE seoclskey.
 
 
@@ -139,7 +139,7 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
 
   METHOD serialize_xml.
     DATA:
-      lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+      lt_descriptions TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt,
       ls_vseointerf   TYPE vseointerf,
       ls_clskey       TYPE seoclskey,
       lt_lines        TYPE tlinetab,

--- a/src/objects/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/zif_abapgit_oo_object_fnc.intf.abap
@@ -5,6 +5,9 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
          END OF ty_includes,
          ty_includes_tt TYPE STANDARD TABLE OF ty_includes WITH DEFAULT KEY.
 
+  TYPES:
+    ty_seocompotx_tt TYPE STANDARD TABLE OF seocompotx WITH DEFAULT KEY .
+
   METHODS:
     create
       IMPORTING
@@ -43,7 +46,7 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
     update_descriptions
       IMPORTING
         is_key          TYPE seoclskey
-        it_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+        it_descriptions TYPE ty_seocompotx_tt,
     add_to_activation_list
       IMPORTING
         is_item TYPE zif_abapgit_definitions=>ty_item
@@ -125,7 +128,7 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
         iv_obejct_name         TYPE seoclsname
         iv_language            TYPE spras OPTIONAL
       RETURNING
-        VALUE(rt_descriptions) TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+        VALUE(rt_descriptions) TYPE ty_seocompotx_tt,
     delete
       IMPORTING
         is_deletion_key TYPE seoclskey

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -212,8 +212,6 @@ INTERFACE zif_abapgit_definitions
       status TYPE ty_results_ts_path,
     END OF ty_stage_files .
   TYPES:
-    ty_seocompotx_tt TYPE STANDARD TABLE OF seocompotx WITH DEFAULT KEY .
-  TYPES:
     BEGIN OF ty_tpool.
       INCLUDE TYPE textpool.
   TYPES: split TYPE c LENGTH 8.


### PR DESCRIPTION
This moves type `ty_seocompotx_tt`, from the generic definitions to the specific object handler interface, as it is object specific