### PR TITLE
UI: Fix HTML validation warnings and error

### DIFF
--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -120,7 +120,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     ri_html->add( '<head>' ).
 
     ri_html->add( '<meta http-equiv="content-type" content="text/html; charset=utf-8">' ).
-    ri_html->add( '<meta http-equiv="x-ua-compatible" content="IE=edge" />' ).
+    ri_html->add( '<meta http-equiv="X-UA-Compatible" content="IE=11,10,9,8" />' ).
 
     ri_html->add( '<title>abapGit</title>' ).
     ri_html->add( '<link rel="stylesheet" type="text/css" href="css/common.css">' ).

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -120,7 +120,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     ri_html->add( '<head>' ).
 
     ri_html->add( '<meta http-equiv="content-type" content="text/html; charset=utf-8">' ).
-    ri_html->add( '<meta http-equiv="X-UA-Compatible" content="IE=11,10,9,8" />' ).
+    ri_html->add( '<meta http-equiv="x-ua-compatible" content="IE=edge" />' ).
 
     ri_html->add( '<title>abapGit</title>' ).
     ri_html->add( '<link rel="stylesheet" type="text/css" href="css/common.css">' ).
@@ -135,7 +135,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
         ri_html->add( '<link rel="stylesheet" type="text/css" href="css/theme-belize-blue.css">' ).
     ENDCASE.
 
-    ri_html->add( '<script type="text/javascript" src="js/common.js"></script>' ).
+    ri_html->add( '<script src="js/common.js"></script>' ).
 
     CASE mo_settings->get_icon_scaling( ). " Enforce icon scaling
       WHEN mo_settings->c_icon_scaling-large.
@@ -313,7 +313,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->add( '<!DOCTYPE html>' ).
-    ri_html->add( '<html>' ).
+    ri_html->add( '<html lang="en">' ).
     ri_html->add( html_head( ) ).
     ri_html->add( '<body>' ).
     ri_html->add( title( ) ).
@@ -332,7 +332,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     li_script = scripts( ).
 
     IF li_script IS BOUND AND li_script->is_empty( ) = abap_false.
-      ri_html->add( '<script type="text/javascript">' ).
+      ri_html->add( '<script>' ).
       ri_html->add( li_script ).
       ri_html->add( 'confirmInitialized();' ).
       ri_html->add( '</script>' ).


### PR DESCRIPTION
Based on https://validator.w3.org/

- Consider adding a lang attribute to the html start tag to declare the language of this document.
- A meta element with an http-equiv attribute whose value is X-UA-Compatible must have a content attribute with the value IE=edge.
- The type attribute is unnecessary for JavaScript resources. (2)

![image](https://user-images.githubusercontent.com/59966492/99019243-e91fe300-2529-11eb-800e-2bb4c7d22a24.png)
