### PR TITLE
Move ty_deserialization, ty_step_data, ty_repo_ref_tt

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -11,6 +11,27 @@ CLASS zcl_abapgit_objects DEFINITION
         files TYPE zif_abapgit_definitions=>ty_files_tt,
         item  TYPE zif_abapgit_definitions=>ty_item,
       END OF ty_serialization .
+    TYPES:
+      BEGIN OF ty_deserialization,
+        obj     TYPE REF TO zif_abapgit_object,
+        xml     TYPE REF TO zif_abapgit_xml_input,
+        package TYPE devclass,
+        item    TYPE zif_abapgit_definitions=>ty_item,
+      END OF ty_deserialization .
+    TYPES:
+      ty_deserialization_tt TYPE STANDARD TABLE OF ty_deserialization WITH DEFAULT KEY .
+    TYPES:
+      BEGIN OF ty_step_data,
+        step_id      TYPE zif_abapgit_definitions=>ty_deserialization_step,
+        order        TYPE i,
+        descr        TYPE string,
+        is_ddic      TYPE abap_bool,
+        syntax_check TYPE abap_bool,
+        objects      TYPE ty_deserialization_tt,
+      END OF ty_step_data .
+    TYPES:
+      ty_step_data_tt TYPE STANDARD TABLE OF ty_step_data
+                                  WITH DEFAULT KEY .
 
     CLASS-METHODS serialize
       IMPORTING
@@ -172,7 +193,7 @@ CLASS zcl_abapgit_objects DEFINITION
         zcx_abapgit_exception .
     CLASS-METHODS deserialize_objects
       IMPORTING
-        !is_step  TYPE zif_abapgit_definitions=>ty_step_data
+        !is_step  TYPE ty_step_data
         !ii_log   TYPE REF TO zif_abapgit_log
       CHANGING
         !ct_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
@@ -217,12 +238,12 @@ CLASS zcl_abapgit_objects DEFINITION
         VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
     CLASS-METHODS get_deserialize_steps
       RETURNING
-        VALUE(rt_steps) TYPE zif_abapgit_definitions=>ty_step_data_tt .
+        VALUE(rt_steps) TYPE ty_step_data_tt .
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
+CLASS zcl_abapgit_objects IMPLEMENTATION.
 
 
   METHOD adjust_namespaces.
@@ -582,14 +603,14 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           lv_path     TYPE string,
           lt_items    TYPE zif_abapgit_definitions=>ty_items_tt,
           lt_steps_id TYPE zif_abapgit_definitions=>ty_deserialization_step_tt,
-          lt_steps    TYPE zif_abapgit_definitions=>ty_step_data_tt,
+          lt_steps    TYPE ty_step_data_tt,
           lx_exc      TYPE REF TO zcx_abapgit_exception.
     DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_result>  TYPE zif_abapgit_definitions=>ty_result,
                    <lv_step_id> TYPE LINE OF zif_abapgit_definitions=>ty_deserialization_step_tt,
-                   <ls_step>    TYPE LINE OF zif_abapgit_definitions=>ty_step_data_tt,
-                   <ls_deser>   TYPE LINE OF zif_abapgit_definitions=>ty_deserialization_tt.
+                   <ls_step>    TYPE LINE OF ty_step_data_tt,
+                   <ls_deser>   TYPE LINE OF ty_deserialization_tt.
 
     lt_steps = get_deserialize_steps( ).
 
@@ -910,7 +931,7 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
 
   METHOD get_deserialize_steps.
-    FIELD-SYMBOLS: <ls_step>    TYPE LINE OF zif_abapgit_definitions=>ty_step_data_tt.
+    FIELD-SYMBOLS: <ls_step>    TYPE LINE OF ty_step_data_tt.
 
     APPEND INITIAL LINE TO rt_steps ASSIGNING <ls_step>.
     <ls_step>-step_id      = zif_abapgit_object=>gc_step_id-ddic.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -11,27 +11,6 @@ CLASS zcl_abapgit_objects DEFINITION
         files TYPE zif_abapgit_definitions=>ty_files_tt,
         item  TYPE zif_abapgit_definitions=>ty_item,
       END OF ty_serialization .
-    TYPES:
-      BEGIN OF ty_deserialization,
-        obj     TYPE REF TO zif_abapgit_object,
-        xml     TYPE REF TO zif_abapgit_xml_input,
-        package TYPE devclass,
-        item    TYPE zif_abapgit_definitions=>ty_item,
-      END OF ty_deserialization .
-    TYPES:
-      ty_deserialization_tt TYPE STANDARD TABLE OF ty_deserialization WITH DEFAULT KEY .
-    TYPES:
-      BEGIN OF ty_step_data,
-        step_id      TYPE zif_abapgit_definitions=>ty_deserialization_step,
-        order        TYPE i,
-        descr        TYPE string,
-        is_ddic      TYPE abap_bool,
-        syntax_check TYPE abap_bool,
-        objects      TYPE ty_deserialization_tt,
-      END OF ty_step_data .
-    TYPES:
-      ty_step_data_tt TYPE STANDARD TABLE OF ty_step_data
-                                  WITH DEFAULT KEY .
 
     CLASS-METHODS serialize
       IMPORTING
@@ -193,7 +172,7 @@ CLASS zcl_abapgit_objects DEFINITION
         zcx_abapgit_exception .
     CLASS-METHODS deserialize_objects
       IMPORTING
-        !is_step  TYPE ty_step_data
+        !is_step  TYPE zif_abapgit_objects=>ty_step_data
         !ii_log   TYPE REF TO zif_abapgit_log
       CHANGING
         !ct_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
@@ -238,7 +217,7 @@ CLASS zcl_abapgit_objects DEFINITION
         VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
     CLASS-METHODS get_deserialize_steps
       RETURNING
-        VALUE(rt_steps) TYPE ty_step_data_tt .
+        VALUE(rt_steps) TYPE zif_abapgit_objects=>ty_step_data_tt .
 ENDCLASS.
 
 
@@ -603,14 +582,14 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
           lv_path     TYPE string,
           lt_items    TYPE zif_abapgit_definitions=>ty_items_tt,
           lt_steps_id TYPE zif_abapgit_definitions=>ty_deserialization_step_tt,
-          lt_steps    TYPE ty_step_data_tt,
+          lt_steps    TYPE zif_abapgit_objects=>ty_step_data_tt,
           lx_exc      TYPE REF TO zcx_abapgit_exception.
     DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_result>  TYPE zif_abapgit_definitions=>ty_result,
                    <lv_step_id> TYPE LINE OF zif_abapgit_definitions=>ty_deserialization_step_tt,
-                   <ls_step>    TYPE LINE OF ty_step_data_tt,
-                   <ls_deser>   TYPE LINE OF ty_deserialization_tt.
+                   <ls_step>    TYPE LINE OF zif_abapgit_objects=>ty_step_data_tt,
+                   <ls_deser>   TYPE LINE OF zif_abapgit_objects=>ty_deserialization_tt.
 
     lt_steps = get_deserialize_steps( ).
 
@@ -931,7 +910,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
 
   METHOD get_deserialize_steps.
-    FIELD-SYMBOLS: <ls_step>    TYPE LINE OF ty_step_data_tt.
+    FIELD-SYMBOLS: <ls_step>    TYPE LINE OF zif_abapgit_objects=>ty_step_data_tt.
 
     APPEND INITIAL LINE TO rt_steps ASSIGNING <ls_step>.
     <ls_step>-step_id      = zif_abapgit_object=>gc_step_id-ddic.

--- a/src/objects/zif_abapgit_objects.intf.abap
+++ b/src/objects/zif_abapgit_objects.intf.abap
@@ -1,0 +1,26 @@
+INTERFACE zif_abapgit_objects
+  PUBLIC.
+
+  TYPES:
+    BEGIN OF ty_deserialization,
+      obj     TYPE REF TO zif_abapgit_object,
+      xml     TYPE REF TO zif_abapgit_xml_input,
+      package TYPE devclass,
+      item    TYPE zif_abapgit_definitions=>ty_item,
+    END OF ty_deserialization .
+  TYPES:
+    ty_deserialization_tt TYPE STANDARD TABLE OF ty_deserialization WITH DEFAULT KEY .
+  TYPES:
+    BEGIN OF ty_step_data,
+      step_id      TYPE zif_abapgit_definitions=>ty_deserialization_step,
+      order        TYPE i,
+      descr        TYPE string,
+      is_ddic      TYPE abap_bool,
+      syntax_check TYPE abap_bool,
+      objects      TYPE ty_deserialization_tt,
+    END OF ty_step_data .
+  TYPES:
+    ty_step_data_tt TYPE STANDARD TABLE OF ty_step_data
+                                WITH DEFAULT KEY .
+
+ENDINTERFACE.

--- a/src/objects/zif_abapgit_objects.intf.xml
+++ b/src/objects/zif_abapgit_objects.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_OBJECTS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit: Objects</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -127,7 +127,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_router IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -226,7 +226,7 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
     DATA: lv_key           TYPE zif_abapgit_persistence=>ty_repo-key,
           lv_last_repo_key TYPE zif_abapgit_persistence=>ty_repo-key,
-          lt_repo_list     TYPE zif_abapgit_definitions=>ty_repo_ref_tt.
+          lt_repo_list     TYPE zif_abapgit_persistence=>ty_repos.
 
 
     lv_key = ii_event->query( )->get( 'KEY' ).
@@ -234,7 +234,7 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
     CASE ii_event->mv_action.
       WHEN zcl_abapgit_gui=>c_action-go_home.
         lv_last_repo_key = zcl_abapgit_persistence_user=>get_instance( )->get_repo_show( ).
-        lt_repo_list = zcl_abapgit_repo_srv=>get_instance( )->list( ).
+        lt_repo_list = zcl_abapgit_persist_factory=>get_repo( )->list( ).
 
         IF lv_last_repo_key IS NOT INITIAL.
           CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_repo_view

--- a/src/ui/zcl_abapgit_services_abapgit.clas.abap
+++ b/src/ui/zcl_abapgit_services_abapgit.clas.abap
@@ -60,7 +60,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SERVICES_ABAPGIT IMPLEMENTATION.
+CLASS zcl_abapgit_services_abapgit IMPLEMENTATION.
 
 
   METHOD check_sapgui.
@@ -329,9 +329,9 @@ CLASS ZCL_ABAPGIT_SERVICES_ABAPGIT IMPLEMENTATION.
           ls_r_package     LIKE LINE OF lt_r_package,
           lt_superpackages TYPE zif_abapgit_sap_package=>ty_devclass_tt,
           li_package       TYPE REF TO zif_abapgit_sap_package,
-          lt_repo_list     TYPE zif_abapgit_definitions=>ty_repo_ref_tt.
+          lt_repo_list     TYPE zif_abapgit_repo_srv=>ty_repo_list.
 
-    FIELD-SYMBOLS: <lo_repo>         TYPE LINE OF zif_abapgit_definitions=>ty_repo_ref_tt,
+    FIELD-SYMBOLS: <lo_repo>         TYPE LINE OF zif_abapgit_repo_srv=>ty_repo_list,
                    <lv_superpackage> LIKE LINE OF lt_superpackages.
 
     li_package = zcl_abapgit_factory=>get_sap_package( iv_package ).

--- a/src/zcl_abapgit_migrations.clas.abap
+++ b/src/zcl_abapgit_migrations.clas.abap
@@ -17,12 +17,12 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_MIGRATIONS IMPLEMENTATION.
+CLASS zcl_abapgit_migrations IMPLEMENTATION.
 
 
   METHOD local_dot_abapgit.
 
-    DATA: lt_repos       TYPE zif_abapgit_definitions=>ty_repo_ref_tt,
+    DATA: lt_repos       TYPE zif_abapgit_repo_srv=>ty_repo_list,
           lo_dot_abapgit TYPE REF TO zcl_abapgit_dot_abapgit.
 
     FIELD-SYMBOLS: <lo_repo> LIKE LINE OF lt_repos.

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -28,7 +28,7 @@ CLASS zcl_abapgit_repo_srv DEFINITION
 
     CLASS-DATA gi_ref TYPE REF TO zif_abapgit_repo_srv .
     DATA mv_init TYPE abap_bool VALUE abap_false ##NO_TEXT.
-    DATA mt_list TYPE zif_abapgit_definitions=>ty_repo_ref_tt .
+    DATA mt_list TYPE zif_abapgit_repo_srv=>ty_repo_list .
 
     METHODS determine_branch_name
       IMPORTING
@@ -76,7 +76,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
+CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
 
   METHOD add.
@@ -336,7 +336,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
   METHOD zif_abapgit_repo_srv~is_repo_installed.
 
-    DATA: lt_repo        TYPE zif_abapgit_definitions=>ty_repo_ref_tt,
+    DATA: lt_repo        TYPE zif_abapgit_repo_srv=>ty_repo_list,
           lo_repo        TYPE REF TO zcl_abapgit_repo,
           lv_url         TYPE string,
           lv_package     TYPE devclass,

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -32,8 +32,6 @@ INTERFACE zif_abapgit_definitions
     ty_files_tt TYPE STANDARD TABLE OF ty_file WITH DEFAULT KEY .
   TYPES:
     ty_string_tt TYPE STANDARD TABLE OF string WITH DEFAULT KEY .
-  TYPES:
-    ty_repo_ref_tt TYPE STANDARD TABLE OF REF TO zcl_abapgit_repo WITH DEFAULT KEY .
   TYPES ty_git_branch_type TYPE c LENGTH 2 .
   TYPES:
     BEGIN OF ty_git_branch,

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -360,31 +360,10 @@ INTERFACE zif_abapgit_definitions
          END OF ty_alv_column,
          ty_alv_column_tt TYPE TABLE OF ty_alv_column WITH DEFAULT KEY.
   TYPES:
-    BEGIN OF ty_deserialization,
-      obj     TYPE REF TO zif_abapgit_object,
-      xml     TYPE REF TO zif_abapgit_xml_input,
-      package TYPE devclass,
-      item    TYPE ty_item,
-    END OF ty_deserialization .
-  TYPES:
-    ty_deserialization_tt TYPE STANDARD TABLE OF ty_deserialization WITH DEFAULT KEY .
-  TYPES:
     ty_deserialization_step TYPE string.
   TYPES:
     ty_deserialization_step_tt TYPE STANDARD TABLE OF ty_deserialization_step
                                           WITH DEFAULT KEY .
-  TYPES:
-    BEGIN OF ty_step_data,
-      step_id      TYPE ty_deserialization_step,
-      order        TYPE i,
-      descr        TYPE string,
-      is_ddic      TYPE abap_bool,
-      syntax_check TYPE abap_bool,
-      objects      TYPE ty_deserialization_tt,
-    END OF ty_step_data .
-  TYPES:
-    ty_step_data_tt TYPE STANDARD TABLE OF ty_step_data
-                                WITH DEFAULT KEY .
   TYPES:
     ty_object_type_range TYPE RANGE OF trobjtype,
     ty_object_name_range TYPE RANGE OF sobj_name.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -62,7 +62,7 @@ INTERFACE zif_abapgit_exit
       zcx_abapgit_exception .
   METHODS deserialize_postprocess
     IMPORTING
-      !is_step TYPE zif_abapgit_definitions=>ty_step_data
+      !is_step TYPE zcl_abapgit_objects=>ty_step_data
       !ii_log  TYPE REF TO zif_abapgit_log .
   METHODS get_ci_tests
     IMPORTING

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -62,7 +62,7 @@ INTERFACE zif_abapgit_exit
       zcx_abapgit_exception .
   METHODS deserialize_postprocess
     IMPORTING
-      !is_step TYPE zcl_abapgit_objects=>ty_step_data
+      !is_step TYPE zif_abapgit_objects=>ty_step_data
       !ii_log  TYPE REF TO zif_abapgit_log .
   METHODS get_ci_tests
     IMPORTING

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -1,5 +1,8 @@
 INTERFACE zif_abapgit_repo_srv
-  PUBLIC .
+  PUBLIC.
+
+  TYPES:
+    ty_repo_list TYPE STANDARD TABLE OF REF TO zcl_abapgit_repo WITH DEFAULT KEY.
 
   METHODS delete
     IMPORTING
@@ -23,7 +26,7 @@ INTERFACE zif_abapgit_repo_srv
       zcx_abapgit_exception .
   METHODS list
     RETURNING
-      VALUE(rt_list) TYPE zif_abapgit_definitions=>ty_repo_ref_tt
+      VALUE(rt_list) TYPE ty_repo_list
     RAISING
       zcx_abapgit_exception .
   METHODS new_offline


### PR DESCRIPTION
Remove dependencies from `zif_abapgit_definitions` (see https://github.com/abapGit/abapGit/issues/4179)