### PR TITLE
Allow html viewer to be hidden

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -577,13 +577,27 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
   METHOD sap_gui_actions.
 
-    DATA: ls_item TYPE zif_abapgit_definitions=>ty_item.
+    DATA: ls_item        TYPE zif_abapgit_definitions=>ty_item,
+          lx_ex          TYPE REF TO zcx_abapgit_exception,
+          li_html_viewer TYPE REF TO zif_abapgit_html_viewer.
 
     CASE ii_event->mv_action.
       WHEN zif_abapgit_definitions=>c_action-jump.                          " Open object editor
         ls_item-obj_type = ii_event->query( )->get( 'TYPE' ).
         ls_item-obj_name = ii_event->query( )->get( 'NAME' ).
-        zcl_abapgit_objects=>jump( ls_item ).
+
+        li_html_viewer = zcl_abapgit_ui_factory=>get_html_viewer( ).
+
+        TRY.
+            " Hide HTML Viewer in dummy screen0 for direct CALL SCREEN to work
+            li_html_viewer->set_visiblity( abap_false ).
+            zcl_abapgit_objects=>jump( ls_item ).
+            li_html_viewer->set_visiblity( abap_true ).
+          CATCH zcx_abapgit_exception INTO lx_ex.
+            li_html_viewer->set_visiblity( abap_true ).
+            RAISE EXCEPTION lx_ex.
+        ENDTRY.
+
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
 
       WHEN zif_abapgit_definitions=>c_action-jump_transport.

--- a/src/ui/zcl_abapgit_html_viewer_gui.clas.abap
+++ b/src/ui/zcl_abapgit_html_viewer_gui.clas.abap
@@ -13,20 +13,20 @@ CLASS zcl_abapgit_html_viewer_gui DEFINITION
     DATA mo_html_viewer TYPE REF TO cl_gui_html_viewer .
 
     METHODS on_event
-          FOR EVENT sapevent OF cl_gui_html_viewer
+        FOR EVENT sapevent OF cl_gui_html_viewer
       IMPORTING
-          !action
-          !frame
-          !getdata
-          !postdata
-          !query_table .
+        !action
+        !frame
+        !getdata
+        !postdata
+        !query_table .
 
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HTML_VIEWER_GUI IMPLEMENTATION.
+CLASS zcl_abapgit_html_viewer_gui IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -118,5 +118,17 @@ CLASS ZCL_ABAPGIT_HTML_VIEWER_GUI IMPLEMENTATION.
 
     mo_html_viewer->show_url( iv_url ).
 
+  ENDMETHOD.
+
+  METHOD zif_abapgit_html_viewer~set_visiblity.
+    DATA: lv_visible TYPE c LENGTH 1.
+
+    IF iv_visible = abap_true.
+      lv_visible = cl_gui_container=>visible_true.
+    ELSE.
+      lv_visible = cl_gui_container=>visible_false.
+    ENDIF.
+
+    mo_html_viewer->set_visible( lv_visible ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -180,12 +180,11 @@ CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
 
   METHOD get_html_viewer.
 
-    IF gi_html_viewer IS BOUND.
-      ri_viewer = gi_html_viewer.
-      RETURN.
+    IF gi_html_viewer IS NOT BOUND.
+      CREATE OBJECT gi_html_viewer TYPE zcl_abapgit_html_viewer_gui.
     ENDIF.
 
-    CREATE OBJECT ri_viewer TYPE zcl_abapgit_html_viewer_gui.
+    ri_viewer = gi_html_viewer.
 
   ENDMETHOD.
 

--- a/src/ui/zif_abapgit_html_viewer.intf.abap
+++ b/src/ui/zif_abapgit_html_viewer.intf.abap
@@ -48,4 +48,5 @@ INTERFACE zif_abapgit_html_viewer
     RETURNING
       VALUE(rv_url) TYPE w3url.
   METHODS back .
+  METHODS set_visiblity IMPORTING iv_visible TYPE abap_bool.
 ENDINTERFACE.


### PR DESCRIPTION
Currently we mostly use popups or new external modes for the JUMP methods. One reason is you can work with them in parallel but the other is that using the same mode abapGit uses doesn't work because we are using cl_gui_container=>screen0 for the html viewer. When calling CALL SCREEN the container still exists and even is in the foreground hiding the dynpro behind it. You can only see the screen change by looking at the status.

The approach of using another mode works fine as long as there are APIs that you can call to do this. Sometimes there are none available and you also cannot use BDC with ABAP4_CALL_TRANSACTION as the maintenance transaction is not BDC compatible. This is the case for SHI3 type GHIER using transaction SBACH04.

Directly calling `STREE_EXTERNAL_EDIT` results in this (only status changes):

![image](https://user-images.githubusercontent.com/5270359/99568349-99c92f00-29cf-11eb-8e60-48a690d9dea6.png)

With hiding and showing the HTML viewer:

![image](https://user-images.githubusercontent.com/5270359/99568478-bf563880-29cf-11eb-9eac-8550768698e2.png)

```abap
  METHOD jump.
    (...)

    zcl_abapgit_ui_factory=>get_html_viewer( )->set_visiblity( abap_false ).

    CALL FUNCTION 'STREE_EXTERNAL_EDIT'
      EXPORTING
        structure_id   = lv_structure_id
        language       = mv_language
        edit_structure = abap_false
        no_commit_work = abap_false
        activity       = 'D'
      IMPORTING
        message        = ls_message.
    IF ls_message IS NOT INITIAL.
      MESSAGE ID ls_message-msgid
        TYPE 'S'
        NUMBER ls_message-msgno
        WITH ls_message-msgv1 ls_message-msgv2 ls_message-msgv3 ls_message-msgv4
        DISPLAY LIKE ls_message-msgty.
    ENDIF.

    zcl_abapgit_ui_factory=>get_html_viewer( )->set_visiblity( abap_true ).
```

This unfortunately couples _OBJECTS to _UI (and even to the concrete implementation instead of GUI). Which seems kind of unavoidable when JUMP is located in OBJECT.

I also refactored get_html_viewer in the factory as it for some reason was not really using a singleton pattern. Not sure if that was intentional.