### PR TITLE
bugfix, PR popup sorting

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -186,7 +186,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -1156,6 +1156,8 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
       IF lines( lt_pulls ) = 0.
         RETURN. " false
       ENDIF.
+
+      SORT lt_pulls BY number DESCENDING.
 
       ls_pull = zcl_abapgit_ui_factory=>get_popups( )->choose_pr_popup( lt_pulls ).
       IF ls_pull IS INITIAL.

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -89,7 +89,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_popups IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_POPUPS IMPLEMENTATION.
 
 
   METHOD add_field.
@@ -633,7 +633,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       APPEND INITIAL LINE TO lt_selection ASSIGNING <ls_sel>.
       <ls_sel>-varoption = |{ <ls_pull>-number } - { <ls_pull>-title } @{ <ls_pull>-user }|.
     ENDLOOP.
-    SORT lt_selection BY varoption DESCENDING.
 
     CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
       EXPORTING


### PR DESCRIPTION
only the output was sorted, this sorts the original table 

note that the previous sorting did not work, as the it reads by index into the original table, 
![image](https://user-images.githubusercontent.com/5888506/99660948-67691180-2a63-11eb-9fdd-ee4a4b6bafac.png)
