### PR TITLE
ZCL_ABAPGIT_HASH add shorthand SHA1 methods

### DIFF
--- a/src/git/zcl_abapgit_git_pack.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_pack.clas.testclasses.abap
@@ -326,8 +326,7 @@ CLASS ltcl_pack IMPLEMENTATION.
 * blob
     lv_data = lc_data.
     CLEAR ls_object.
-    ls_object-sha1 = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                             iv_data = lv_data ).
+    ls_object-sha1 = zcl_abapgit_hash=>sha1_blob( lv_data ).
     ls_object-type = zif_abapgit_definitions=>c_type-blob.
     ls_object-data = lv_data.
     ls_object-index = 1.
@@ -343,8 +342,7 @@ CLASS ltcl_pack IMPLEMENTATION.
     ls_commit-body      = 'body'.
     lv_data = zcl_abapgit_git_pack=>encode_commit( ls_commit ).
     CLEAR ls_object.
-    ls_object-sha1 = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-commit
-                                             iv_data = lv_data ).
+    ls_object-sha1 = zcl_abapgit_hash=>sha1_commit( lv_data ).
     ls_object-type = zif_abapgit_definitions=>c_type-commit.
     ls_object-data = lv_data.
     ls_object-index = 2.
@@ -359,8 +357,7 @@ CLASS ltcl_pack IMPLEMENTATION.
     APPEND ls_node TO lt_nodes.
     lv_data = zcl_abapgit_git_pack=>encode_tree( lt_nodes ).
     CLEAR ls_object.
-    ls_object-sha1 = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-tree
-                                             iv_data = lv_data ).
+    ls_object-sha1 = zcl_abapgit_hash=>sha1_tree( lv_data ).
     ls_object-type = zif_abapgit_definitions=>c_type-tree.
     ls_object-data = lv_data.
     ls_object-index = 3.
@@ -380,8 +377,7 @@ CLASS ltcl_pack IMPLEMENTATION.
 
   METHOD object_blob.
 
-    rs_object-sha1 = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                             iv_data = iv_data ).
+    rs_object-sha1 = zcl_abapgit_hash=>sha1_blob( iv_data ).
     rs_object-type = zif_abapgit_definitions=>c_type-blob.
     rs_object-data = iv_data.
     rs_object-index = 1.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -223,7 +223,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
 
   METHOD adjust_namespaces.
@@ -1197,9 +1197,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     rs_files_and_item-item-inactive = boolc( li_obj->is_active( ) = abap_false ).
 
     LOOP AT rs_files_and_item-files ASSIGNING <ls_file>.
-      <ls_file>-sha1 = zcl_abapgit_hash=>sha1(
-        iv_type = zif_abapgit_definitions=>c_type-blob
-        iv_data = <ls_file>-data ).
+      <ls_file>-sha1 = zcl_abapgit_hash=>sha1_blob( <ls_file>-data ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
@@ -127,9 +127,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
     lv_new_file_content = zcl_abapgit_convert=>string_to_xstring_utf8( lv_merge_content ).
 
     READ TABLE mt_conflicts ASSIGNING <ls_conflict> INDEX mv_current_conflict_index.
-    <ls_conflict>-result_sha1 = zcl_abapgit_hash=>sha1(
-      iv_type = zif_abapgit_definitions=>c_type-blob
-      iv_data = lv_new_file_content ).
+    <ls_conflict>-result_sha1 = zcl_abapgit_hash=>sha1_blob( lv_new_file_content ).
     <ls_conflict>-result_data = lv_new_file_content.
     mo_merge->resolve_conflict( <ls_conflict> ).
 

--- a/src/utils/zcl_abapgit_hash.clas.abap
+++ b/src/utils/zcl_abapgit_hash.clas.abap
@@ -17,6 +17,40 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
+
+    CLASS-METHODS sha1_commit
+      IMPORTING
+        !iv_data       TYPE xstring
+      RETURNING
+        VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS sha1_tree
+      IMPORTING
+        !iv_data       TYPE xstring
+      RETURNING
+        VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS sha1_tag
+      IMPORTING
+        !iv_data       TYPE xstring
+      RETURNING
+        VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS sha1_blob
+      IMPORTING
+        !iv_data       TYPE xstring
+      RETURNING
+        VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
+
+
     CLASS-METHODS sha1_raw
       IMPORTING
         !iv_data       TYPE xstring
@@ -24,11 +58,13 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_hash IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_HASH IMPLEMENTATION.
 
 
   METHOD adler32.
@@ -102,6 +138,18 @@ CLASS zcl_abapgit_hash IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD sha1_blob.
+    rv_sha1 = sha1( iv_type = zif_abapgit_definitions=>c_type-blob
+                    iv_data = iv_data ).
+  ENDMETHOD.
+
+
+  METHOD sha1_commit.
+    rv_sha1 = sha1( iv_type = zif_abapgit_definitions=>c_type-commit
+                    iv_data = iv_data ).
+  ENDMETHOD.
+
+
   METHOD sha1_raw.
 
     DATA: lv_hash  TYPE string,
@@ -121,5 +169,17 @@ CLASS zcl_abapgit_hash IMPLEMENTATION.
     rv_sha1 = lv_hash.
     TRANSLATE rv_sha1 TO LOWER CASE.
 
+  ENDMETHOD.
+
+
+  METHOD sha1_tag.
+    rv_sha1 = sha1( iv_type = zif_abapgit_definitions=>c_type-tag
+                    iv_data = iv_data ).
+  ENDMETHOD.
+
+
+  METHOD sha1_tree.
+    rv_sha1 = sha1( iv_type = zif_abapgit_definitions=>c_type-tree
+                    iv_data = iv_data ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/zcl_abapgit_dot_abapgit.clas.abap
@@ -192,8 +192,7 @@ CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
 
     rs_signature-path     = zif_abapgit_definitions=>c_root_dir.
     rs_signature-filename = zif_abapgit_definitions=>c_dot_abapgit.
-    rs_signature-sha1     = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                                    iv_data = serialize( ) ).
+    rs_signature-sha1     = zcl_abapgit_hash=>sha1_blob( serialize( ) ).
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -210,7 +210,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 
   METHOD bind_listener.
@@ -230,8 +230,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       rs_file-path     = zif_abapgit_definitions=>c_root_dir.
       rs_file-filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
       rs_file-data     = zcl_abapgit_convert=>string_to_xstring_utf8( lo_manifest_writer->serialize( ) ).
-      rs_file-sha1     = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                                 iv_data = rs_file-data ).
+      rs_file-sha1     = zcl_abapgit_hash=>sha1_blob( rs_file-data ).
     ENDIF.
   ENDMETHOD.
 
@@ -241,8 +240,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     rs_file-path     = zif_abapgit_definitions=>c_root_dir.
     rs_file-filename = zif_abapgit_definitions=>c_dot_abapgit.
     rs_file-data     = get_dot_abapgit( )->serialize( ).
-    rs_file-sha1     = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                               iv_data = rs_file-data ).
+    rs_file-sha1     = zcl_abapgit_hash=>sha1_blob( rs_file-data ).
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -371,8 +371,7 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
       <ls_file>-data = lv_data.
 
-      <ls_file>-sha1 = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                               iv_data = <ls_file>-data ).
+      <ls_file>-sha1 = zcl_abapgit_hash=>sha1_blob( <ls_file>-data ).
 
     ENDLOOP.
 


### PR DESCRIPTION
This adds shorthand methods for the SHA1 calculation of the different git artifacts.
More logic in ZCL_ABAPGIT_HASH, but easier to read and less application logic.