### PR TITLE
ZCL_ABAPGIT_GIT_URL, remove repo usage

### DIFF
--- a/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
@@ -22,8 +22,6 @@ CLASS ltcl_repo_online IMPLEMENTATION.
     DATA: ls_provider_urls TYPE ty_show_url_test,
           lt_test_urls     TYPE ty_show_url_tests,
           lv_testhash      TYPE zif_abapgit_definitions=>ty_sha1 VALUE 'my-SHA1-hash',
-          ls_online_repo   TYPE zif_abapgit_persistence=>ty_repo,
-          lr_test_repo     TYPE REF TO zcl_abapgit_repo_online,
           lo_cut           TYPE REF TO zcl_abapgit_git_url,
           lv_show_url      TYPE zif_abapgit_persistence=>ty_repo-url.
 
@@ -45,22 +43,13 @@ CLASS ltcl_repo_online IMPLEMENTATION.
     APPEND ls_provider_urls TO lt_test_urls.
 
     LOOP AT lt_test_urls ASSIGNING <ls_provider_urls>.
-      ls_online_repo-key = 'TEST'.
-      ls_online_repo-url = <ls_provider_urls>-repo_url.
-      ls_online_repo-branch_name = |master|.
-      ls_online_repo-offline = abap_false.
-
-      CREATE OBJECT lr_test_repo
-        EXPORTING
-          is_data = ls_online_repo.
-
       lv_show_url = lo_cut->get_default_commit_display_url(
-        iv_repo_url = lr_test_repo->get_url( )
+        iv_repo_url = <ls_provider_urls>-repo_url
         iv_hash     = lv_testhash ).
 
-      cl_aunit_assert=>assert_equals( exp  = <ls_provider_urls>-show_url
-                                      act  = lv_show_url
-                                      quit = cl_aunit_assert=>no ).
+      cl_abap_unit_assert=>assert_equals(
+        exp = <ls_provider_urls>-show_url
+        act = lv_show_url ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
@@ -43,6 +43,7 @@ CLASS ltcl_repo_online IMPLEMENTATION.
     APPEND ls_provider_urls TO lt_test_urls.
 
     LOOP AT lt_test_urls ASSIGNING <ls_provider_urls>.
+    
       lv_show_url = lo_cut->get_default_commit_display_url(
         iv_repo_url = <ls_provider_urls>-repo_url
         iv_hash     = lv_testhash ).

--- a/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.testclasses.abap
@@ -43,7 +43,6 @@ CLASS ltcl_repo_online IMPLEMENTATION.
     APPEND ls_provider_urls TO lt_test_urls.
 
     LOOP AT lt_test_urls ASSIGNING <ls_provider_urls>.
-    
       lv_show_url = lo_cut->get_default_commit_display_url(
         iv_repo_url = <ls_provider_urls>-repo_url
         iv_hash     = lv_testhash ).


### PR DESCRIPTION
https://github.com/abapGit/abapGit/issues/2127#issuecomment-732262897, first part of "C"

plus removes usage of obsolete class `cl_aunit_assert`