### PR TITLE
dot abapgit file, move file build

### DIFF
--- a/src/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/zcl_abapgit_dot_abapgit.clas.abap
@@ -22,6 +22,11 @@ CLASS zcl_abapgit_dot_abapgit DEFINITION
         VALUE(rv_xstr) TYPE xstring
       RAISING
         zcx_abapgit_exception .
+    METHODS to_file
+      RETURNING
+        VALUE(rs_file) TYPE zif_abapgit_definitions=>ty_file
+      RAISING
+        zcx_abapgit_exception.
     METHODS get_data
       RETURNING
         VALUE(rs_data) TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit .
@@ -283,6 +288,14 @@ CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
 
   METHOD set_starting_folder.
     ms_data-starting_folder = iv_path.
+  ENDMETHOD.
+
+
+  METHOD to_file.
+    rs_file-path     = zif_abapgit_definitions=>c_root_dir.
+    rs_file-filename = zif_abapgit_definitions=>c_dot_abapgit.
+    rs_file-data     = serialize( ).
+    rs_file-sha1     = zcl_abapgit_hash=>sha1_blob( rs_file-data ).
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -186,11 +186,6 @@ CLASS zcl_abapgit_repo DEFINITION
         !is_change_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask
       RAISING
         zcx_abapgit_exception .
-    METHODS build_dotabapgit_file
-      RETURNING
-        VALUE(rs_file) TYPE zif_abapgit_definitions=>ty_file
-      RAISING
-        zcx_abapgit_exception .
     METHODS build_apack_manifest_file
       RETURNING
         VALUE(rs_file) TYPE zif_abapgit_definitions=>ty_file
@@ -232,16 +227,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       rs_file-data     = zcl_abapgit_convert=>string_to_xstring_utf8( lo_manifest_writer->serialize( ) ).
       rs_file-sha1     = zcl_abapgit_hash=>sha1_blob( rs_file-data ).
     ENDIF.
-  ENDMETHOD.
-
-
-  METHOD build_dotabapgit_file.
-
-    rs_file-path     = zif_abapgit_definitions=>c_root_dir.
-    rs_file-filename = zif_abapgit_definitions=>c_dot_abapgit.
-    rs_file-data     = get_dot_abapgit( )->serialize( ).
-    rs_file-sha1     = zcl_abapgit_hash=>sha1_blob( rs_file-data ).
-
   ENDMETHOD.
 
 
@@ -471,7 +456,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     ENDIF.
 
     APPEND INITIAL LINE TO rt_files ASSIGNING <ls_return>.
-    <ls_return>-file = build_dotabapgit_file( ).
+    <ls_return>-file = get_dot_abapgit( )->to_file( ).
 
     ls_apack_file = build_apack_manifest_file( ).
     IF ls_apack_file IS NOT INITIAL.


### PR DESCRIPTION
move responsibility for building the dotabapgit file to the dotabapgit class instead of the repo

this makes the dotabapgit object independent of the repo, so it can be used by itself

idea is to move much of the logic in method ZCL_ABAPGIT_REPO->GET_FILES_LOCAL to `zcl_abapgit_serialize`

https://github.com/abapGit/abapGit/issues/2127#issuecomment-732262897