### PR TITLE
Dialogs: Enhance HTML form with table control

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1137,6 +1137,7 @@ settings_tab tr:first-child td { border-top: 0px; }
   font-size: 14px;
   height: 2.5em;
   background-color: #ddd;
+  border: 1px solid #ddd;
   padding: 0px 10px;
 }
 .dialog table tbody td {

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -67,6 +67,7 @@ span.separator {
 .nodisplay    { display: none }
 .m-em5-sides  { margin-left: 0.5em; margin-right: 0.5em }
 .w600px       { width: 600px }
+.w1000px      { width: 1000px }
 .wmax600px    { max-width: 600px }
 .auto-center  { /* use with max-width */
   width: 100%;
@@ -1109,6 +1110,7 @@ settings_tab tr:first-child td { border-top: 0px; }
   width: 100%;
   box-sizing: border-box;
   padding: 10px;
+  font-family: Arial,Helvetica,sans-serif;
 }
 .dialog .radio-container input[type="radio"] {
   visibility: hidden;
@@ -1127,6 +1129,24 @@ settings_tab tr:first-child td { border-top: 0px; }
 }
 .dialog .radio-container input[type="radio"]:checked + label {
   border: 1px solid transparent;
+}
+.dialog table {
+  width: 100%;
+}
+.dialog table thead td {
+  font-size: 14px;
+  height: 2.5em;
+  background-color: #ddd;
+  padding: 0px 10px;
+}
+.dialog table tbody td {
+  border: 1px solid #ccc;
+  background-color: white;
+}
+.dialog table td input {
+  margin: 0px 2px;
+  border: 0px;
+  background: none;
 }
 .dialog li.with-command div.input-container {
   display: table-cell;

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -1,23 +1,25 @@
 CLASS zcl_abapgit_html_form DEFINITION
   PUBLIC
   FINAL
-  CREATE PRIVATE.
+  CREATE PRIVATE .
 
   PUBLIC SECTION.
+
+    CONSTANTS c_rows TYPE string VALUE 'rows' ##NO_TEXT.
 
     CLASS-METHODS create
       IMPORTING
         !iv_form_id    TYPE csequence OPTIONAL
         !iv_help_page  TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form .
     METHODS render
       IMPORTING
         !iv_form_class     TYPE csequence
         !io_values         TYPE REF TO zcl_abapgit_string_map
         !io_validation_log TYPE REF TO zcl_abapgit_string_map OPTIONAL
       RETURNING
-        VALUE(ri_html)     TYPE REF TO zif_abapgit_html.
+        VALUE(ri_html)     TYPE REF TO zif_abapgit_html .
     METHODS command
       IMPORTING
         !iv_label      TYPE csequence
@@ -25,7 +27,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_is_main    TYPE abap_bool DEFAULT abap_false
         !iv_as_a       TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
     METHODS text
       IMPORTING
         !iv_label       TYPE csequence
@@ -40,7 +42,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_min         TYPE i DEFAULT cl_abap_math=>min_int4
         !iv_max         TYPE i DEFAULT cl_abap_math=>max_int4
       RETURNING
-        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form .
     METHODS textarea
       IMPORTING
         !iv_label       TYPE csequence
@@ -50,7 +52,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_readonly    TYPE abap_bool DEFAULT abap_false
         !iv_placeholder TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form .
     METHODS number
       IMPORTING
         !iv_label      TYPE csequence
@@ -61,14 +63,14 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_min        TYPE i DEFAULT cl_abap_math=>min_int4
         !iv_max        TYPE i DEFAULT cl_abap_math=>max_int4
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
     METHODS checkbox
       IMPORTING
         !iv_label      TYPE csequence
         !iv_name       TYPE csequence
         !iv_hint       TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
     METHODS radio
       IMPORTING
         !iv_label         TYPE csequence
@@ -76,34 +78,47 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_default_value TYPE csequence OPTIONAL
         !iv_hint          TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self)    TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self)    TYPE REF TO zcl_abapgit_html_form .
     METHODS option
       IMPORTING
         !iv_label      TYPE csequence
         !iv_value      TYPE csequence
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+    METHODS table
+      IMPORTING
+        !iv_label      TYPE csequence
+        !iv_name       TYPE csequence
+        !iv_hint       TYPE csequence OPTIONAL
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+    METHODS column
+      IMPORTING
+        !iv_label      TYPE csequence
+        !iv_width      TYPE csequence OPTIONAL
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
     METHODS start_group
       IMPORTING
         !iv_label      TYPE csequence
         !iv_name       TYPE csequence
         !iv_hint       TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
     METHODS normalize_form_data
       IMPORTING
         !io_form_data       TYPE REF TO zcl_abapgit_string_map
       RETURNING
         VALUE(ro_form_data) TYPE REF TO zcl_abapgit_string_map
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     METHODS validate_required_fields
       IMPORTING
         !io_form_data            TYPE REF TO zcl_abapgit_string_map
       RETURNING
         VALUE(ro_validation_log) TYPE REF TO zcl_abapgit_string_map
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -111,9 +126,9 @@ CLASS zcl_abapgit_html_form DEFINITION
       BEGIN OF ty_subitem,
         label TYPE string,
         value TYPE string,
-      END OF ty_subitem.
+      END OF ty_subitem .
     TYPES:
-      ty_subitems TYPE STANDARD TABLE OF ty_subitem WITH DEFAULT KEY.
+      ty_subitems TYPE STANDARD TABLE OF ty_subitem WITH DEFAULT KEY .
     TYPES:
       BEGIN OF ty_field,
         type          TYPE i,
@@ -134,7 +149,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         min           TYPE i,
         max           TYPE i,
 *        onclick ???
-      END OF ty_field.
+      END OF ty_field .
     TYPES:
       BEGIN OF ty_command,
         label   TYPE string,
@@ -142,7 +157,16 @@ CLASS zcl_abapgit_html_form DEFINITION
         is_main TYPE abap_bool,
         as_a    TYPE abap_bool,
 *        onclick ???
-      END OF ty_command.
+      END OF ty_command .
+    TYPES:
+      BEGIN OF ty_attr,
+        value       TYPE string,
+        error       TYPE string,
+        hint        TYPE string,
+        readonly    TYPE string,
+        placeholder TYPE string,
+        required    TYPE string,
+      END OF ty_attr.
 
     CONSTANTS:
       BEGIN OF c_field_type,
@@ -152,25 +176,52 @@ CLASS zcl_abapgit_html_form DEFINITION
         field_group TYPE i VALUE 4,
         number      TYPE i VALUE 5,
         textarea    TYPE i VALUE 6,
-      END OF c_field_type.
+        table       TYPE i VALUE 7,
+      END OF c_field_type .
     DATA:
       mt_fields TYPE STANDARD TABLE OF ty_field
-          WITH UNIQUE SORTED KEY by_name COMPONENTS name.
+            WITH UNIQUE SORTED KEY by_name COMPONENTS name .
     DATA:
-      mt_commands TYPE STANDARD TABLE OF ty_command.
-    DATA mv_form_id TYPE string.
-    DATA mv_help_page TYPE string.
+      mt_commands TYPE STANDARD TABLE OF ty_command .
+    DATA mv_form_id TYPE string .
+    DATA mv_help_page TYPE string .
 
     METHODS render_field
       IMPORTING
         !ii_html           TYPE REF TO zif_abapgit_html
         !io_values         TYPE REF TO zcl_abapgit_string_map
         !io_validation_log TYPE REF TO zcl_abapgit_string_map
-        !is_field          TYPE ty_field.
+        !is_field          TYPE ty_field .
+    METHODS render_field_text
+      IMPORTING
+        !ii_html  TYPE REF TO zif_abapgit_html
+        !is_field TYPE ty_field
+        !is_attr  TYPE ty_attr.
+    METHODS render_field_textarea
+      IMPORTING
+        !ii_html  TYPE REF TO zif_abapgit_html
+        !is_field TYPE ty_field
+        !is_attr  TYPE ty_attr.
+    METHODS render_field_checkbox
+      IMPORTING
+        !ii_html  TYPE REF TO zif_abapgit_html
+        !is_field TYPE ty_field
+        !is_attr  TYPE ty_attr.
+    METHODS render_field_radio
+      IMPORTING
+        !ii_html  TYPE REF TO zif_abapgit_html
+        !is_field TYPE ty_field
+        !is_attr  TYPE ty_attr.
+    METHODS render_field_table
+      IMPORTING
+        !ii_html   TYPE REF TO zif_abapgit_html
+        !is_field  TYPE ty_field
+        !is_attr   TYPE ty_attr
+        !io_values TYPE REF TO zcl_abapgit_string_map.
     METHODS render_command
       IMPORTING
         !ii_html TYPE REF TO zif_abapgit_html
-        !is_cmd  TYPE ty_command.
+        !is_cmd  TYPE ty_command .
 ENDCLASS.
 
 
@@ -188,6 +239,29 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
     ls_field-hint  = iv_hint.
 
     APPEND ls_field TO mt_fields.
+
+    ro_self = me.
+
+  ENDMETHOD.
+
+
+  METHOD column.
+
+    FIELD-SYMBOLS <ls_last> LIKE LINE OF mt_fields.
+    DATA ls_column LIKE LINE OF <ls_last>-subitems.
+    DATA lv_size TYPE i.
+
+    lv_size = lines( mt_fields ).
+    ASSERT lv_size > 0. " Exception ? Maybe add zcx_no_check ?
+
+    READ TABLE mt_fields INDEX lv_size ASSIGNING <ls_last>.
+    ASSERT sy-subrc = 0.
+    ASSERT <ls_last>-type = c_field_type-table.
+
+    ls_column-label = iv_label.
+    ls_column-value = iv_width.
+
+    APPEND ls_column TO <ls_last>-subitems.
 
     ro_self = me.
 
@@ -231,6 +305,8 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
   METHOD normalize_form_data.
 
     DATA lv_value TYPE string.
+    DATA lv_rows TYPE i.
+    DATA lv_row TYPE i.
     FIELD-SYMBOLS <ls_field> LIKE LINE OF mt_fields.
 
     CREATE OBJECT ro_form_data.
@@ -248,12 +324,21 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
           iv_key = <ls_field>-name
           iv_val = to_upper( lv_value ) ).
       ELSEIF <ls_field>-type = c_field_type-number.
-        IF lv_value NA '0123456789- '.
-
-        ENDIF.
+        " Numeric value is checked in validation
         ro_form_data->set(
           iv_key = <ls_field>-name
-          iv_val = lv_value ).
+          iv_val = condense( val = lv_value del = ` ` ) ).
+      ELSEIF <ls_field>-type = c_field_type-table.
+        lv_rows = io_form_data->get( |{ <ls_field>-name }-{ c_rows }| ).
+        DO lv_rows TIMES.
+          lv_row = sy-index.
+          DO lines( <ls_field>-subitems ) TIMES.
+            lv_value = io_form_data->get( |{ <ls_field>-name }-{ lv_row }-{ sy-index }| ).
+            ro_form_data->set(
+              iv_key = |{ <ls_field>-name }-{ lv_row }-{ sy-index }|
+              iv_val = lv_value ).
+          ENDDO.
+        ENDDO.
       ELSE.
         ro_form_data->set(
           iv_key = <ls_field>-name
@@ -439,47 +524,55 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
 
   METHOD render_field.
 
-    DATA lv_opt_id TYPE string.
-    DATA lv_error TYPE string.
-    DATA lv_value TYPE string.
-    DATA lv_checked TYPE string.
-    DATA lv_item_class TYPE string.
-    DATA lv_hint TYPE string.
-    DATA lv_required TYPE string.
-    DATA lv_attr TYPE string.
-    DATA lv_type TYPE string.
-    DATA lv_rows TYPE i.
-    FIELD-SYMBOLS <ls_opt> LIKE LINE OF is_field-subitems.
+    DATA:
+      ls_attr       TYPE ty_attr,
+      lv_item_class TYPE string.
 
-    " Get value and validation error from maps
-    lv_value = io_values->get( is_field-name ).
+    " Get value and validation error
+    ls_attr-value = escape( val    = io_values->get( is_field-name )
+                            format = cl_abap_format=>e_html_attr ).
+
     IF io_validation_log IS BOUND.
-      lv_error = io_validation_log->get( is_field-name ).
+      ls_attr-error = io_validation_log->get( is_field-name ).
+      IF ls_attr-error IS NOT INITIAL.
+        ls_attr-error = escape( val    = ls_attr-error
+                                format = cl_abap_format=>e_html_text ).
+        ls_attr-error = |<small>{ ls_attr-error }</small>|.
+      ENDIF.
+    ENDIF.
+
+    " Prepare field attributes
+    IF is_field-required = abap_true.
+      ls_attr-required = ' <em>*</em>'.
+    ENDIF.
+
+    IF is_field-hint IS NOT INITIAL.
+      ls_attr-hint = escape( val    = is_field-hint
+                             format = cl_abap_format=>e_html_attr ).
+      ls_attr-hint = | title="{ ls_attr-hint }"|.
+    ENDIF.
+
+    IF is_field-placeholder IS NOT INITIAL.
+      ls_attr-placeholder = escape( val    = is_field-placeholder
+                                    format = cl_abap_format=>e_html_attr ).
+      ls_attr-placeholder = | placeholder="{ ls_attr-placeholder }"|.
+    ENDIF.
+
+    IF is_field-readonly = abap_true.
+      ls_attr-readonly = ' readonly'.
     ENDIF.
 
     " Prepare item class
     lv_item_class = is_field-item_class.
-    IF lv_error IS NOT INITIAL.
+    IF ls_attr-error IS NOT INITIAL.
       lv_item_class = condense( lv_item_class && ' error' ).
+    ENDIF.
+    IF is_field-type = c_field_type-text AND is_field-max BETWEEN 1 AND 20.
+      " Reduced width for short fields
+      lv_item_class = lv_item_class && ' w40'.
     ENDIF.
     IF lv_item_class IS NOT INITIAL.
       lv_item_class = | class="{ lv_item_class }"|.
-    ENDIF.
-
-    IF is_field-required = abap_true.
-      lv_required = ' <em>*</em>'.
-    ENDIF.
-
-    IF is_field-hint IS NOT INITIAL.
-      lv_hint = | title="{ is_field-hint }"|.
-    ENDIF.
-
-    IF is_field-readonly = abap_true.
-      lv_attr = lv_attr && ' readonly'.
-    ENDIF.
-
-    IF is_field-placeholder IS NOT INITIAL.
-      lv_attr = lv_attr && | placeholder="{ is_field-placeholder }"|.
     ENDIF.
 
     " Render field
@@ -488,85 +581,221 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
     CASE is_field-type.
       WHEN c_field_type-text OR c_field_type-number.
 
-        ii_html->add( |<label for="{ is_field-name }"{ lv_hint }>{ is_field-label }{ lv_required }</label>| ).
-        IF lv_error IS NOT INITIAL.
-          ii_html->add( |<small>{ lv_error }</small>| ).
-        ENDIF.
-
-        IF is_field-side_action IS NOT INITIAL.
-          ii_html->add( '<div class="input-container">' ). " Ugly :(
-        ENDIF.
-
-        IF is_field-type = c_field_type-number.
-          lv_type = 'number'.
-        ELSEIF is_field-password = abap_true.
-          lv_type = 'password'.
-        ELSE.
-          lv_type = 'text'.
-        ENDIF.
-
-        ii_html->add( |<input type="{ lv_type }" name="{ is_field-name }" id="{
-          is_field-name }" value="{ lv_value }"{ is_field-dblclick }{ lv_attr }>| ).
-
-        IF is_field-side_action IS NOT INITIAL.
-          ii_html->add( '</div>' ).
-          ii_html->add( '<div class="command-container">' ).
-          ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }">| ).
-          ii_html->add( '</div>' ).
-        ENDIF.
+        render_field_text(
+          ii_html  = ii_html
+          is_field = is_field
+          is_attr  = ls_attr ).
 
       WHEN c_field_type-textarea.
 
-        ii_html->add( |<label for="{ is_field-name }"{ lv_hint }>{ is_field-label }{ lv_required }</label>| ).
-        IF lv_error IS NOT INITIAL.
-          ii_html->add( |<small>{ lv_error }</small>| ).
-        ENDIF.
-
-        lv_rows = lines( zcl_abapgit_convert=>split_string( lv_value ) ) + 1.
-
-        ii_html->add( |<textarea name="{ is_field-name }" id="{
-          is_field-name }" rows="{ lv_rows }"{ lv_attr }>| ).
-        ii_html->add( escape( val    = lv_value
-                              format = cl_abap_format=>e_html_attr ) ).
-        ii_html->add( |</textarea>| ).
+        render_field_textarea(
+          ii_html  = ii_html
+          is_field = is_field
+          is_attr  = ls_attr ).
 
       WHEN c_field_type-checkbox.
 
-        IF lv_error IS NOT INITIAL.
-          ii_html->add( |<small>{ lv_error }</small>| ).
-        ENDIF.
-        IF lv_value = abap_true OR lv_value = 'on'. " boolc return ` ` which is not initial -> bug after 1st validation
-          lv_checked = ' checked'.
-        ENDIF.
-        ii_html->add( |<input type="checkbox" name="{ is_field-name }" id="{ is_field-name }"{ lv_checked }>| ).
-        ii_html->add( |<label for="{ is_field-name }"{ lv_hint }>{ is_field-label }</label>| ).
+        render_field_checkbox(
+          ii_html  = ii_html
+          is_field = is_field
+          is_attr  = ls_attr ).
 
       WHEN c_field_type-radio.
 
-        ii_html->add( |<label{ lv_hint }>{ is_field-label }</label>| ).
-        IF lv_error IS NOT INITIAL.
-          ii_html->add( |<small>{ lv_error }</small>| ).
-        ENDIF.
-        ii_html->add( |<div class="radio-container">| ).
+        render_field_radio(
+          ii_html  = ii_html
+          is_field = is_field
+          is_attr  = ls_attr ).
 
-        LOOP AT is_field-subitems ASSIGNING <ls_opt>.
-          CLEAR lv_checked.
-          IF lv_value = <ls_opt>-value OR ( lv_value IS INITIAL AND <ls_opt>-value = is_field-default_value ).
-            lv_checked = ' checked'.
-          ENDIF.
-          lv_opt_id = |{ is_field-name }{ sy-tabix }|.
-          ii_html->add( |<input type="radio" name="{ is_field-name }" id="{
-            lv_opt_id }" value="{ <ls_opt>-value }"{ lv_checked }>| ).
-          ii_html->add( |<label for="{ lv_opt_id }">{ <ls_opt>-label }</label>| ).
-        ENDLOOP.
+      WHEN c_field_type-table.
 
-        ii_html->add( '</div>' ).
+        render_field_table(
+          ii_html   = ii_html
+          is_field  = is_field
+          is_attr   = ls_attr
+          io_values = io_values ).
 
       WHEN OTHERS.
         ASSERT 1 = 0.
     ENDCASE.
 
     ii_html->add( '</li>' ).
+
+  ENDMETHOD.
+
+
+  METHOD render_field_checkbox.
+
+    DATA lv_checked TYPE string.
+
+    IF is_attr-error IS NOT INITIAL.
+      ii_html->add( is_attr-error ).
+    ENDIF.
+
+    IF is_attr-value = abap_true OR is_attr-value = 'on'.
+      " boolc return ` ` which is not initial -> bug after 1st validation
+      lv_checked = ' checked'.
+    ENDIF.
+
+    ii_html->add( |<input type="checkbox" name="{ is_field-name }" id="{ is_field-name }"{ lv_checked }>| ).
+    ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{ is_field-label }</label>| ).
+
+  ENDMETHOD.
+
+
+  METHOD render_field_radio.
+
+    DATA:
+      lv_value     TYPE string,
+      lv_checked   TYPE string,
+      lv_opt_id    TYPE string,
+      lv_opt_value TYPE string.
+
+    FIELD-SYMBOLS <ls_opt> LIKE LINE OF is_field-subitems.
+
+    ii_html->add( |<label{ is_attr-hint }>{ is_field-label }</label>| ).
+
+    IF is_attr-error IS NOT INITIAL.
+      ii_html->add( is_attr-error ).
+    ENDIF.
+
+    ii_html->add( |<div class="radio-container">| ).
+
+    LOOP AT is_field-subitems ASSIGNING <ls_opt>.
+      lv_opt_value = escape( val    = <ls_opt>-value
+                             format = cl_abap_format=>e_html_attr ).
+
+      CLEAR lv_checked.
+      IF is_attr-value = lv_opt_value OR ( is_attr-value IS INITIAL AND lv_opt_value = is_field-default_value ).
+        lv_checked = ' checked'.
+      ENDIF.
+
+      lv_opt_id = |{ is_field-name }{ sy-tabix }|.
+      ii_html->add( |<input type="radio" name="{ is_field-name }" id="{
+                    lv_opt_id }" value="{ lv_opt_value }"{ lv_checked }>| ).
+      ii_html->add( |<label for="{ lv_opt_id }">{ <ls_opt>-label }</label>| ).
+    ENDLOOP.
+
+    ii_html->add( '</div>' ).
+
+  ENDMETHOD.
+
+
+  METHOD render_field_table.
+
+    DATA:
+      lv_value     TYPE string,
+      lv_rows      TYPE i,
+      lv_cell_id   TYPE string,
+      lv_opt_value TYPE string.
+
+    FIELD-SYMBOLS <ls_subitem> LIKE LINE OF is_field-subitems.
+
+    ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{
+                  is_field-label }</label>| ).
+
+    IF is_attr-error IS NOT INITIAL.
+      ii_html->add( is_attr-error ).
+    ENDIF.
+
+    ii_html->add( |<table name="{ is_field-name }" id="{ is_field-name }" class="table-container">| ).
+
+    ii_html->add( |<thead>| ).
+    ii_html->add( |<tr>| ).
+    LOOP AT is_field-subitems ASSIGNING <ls_subitem>.
+      CLEAR lv_value.
+      IF <ls_subitem>-value IS NOT INITIAL.
+        lv_value = escape( val    = <ls_subitem>-value
+                           format = cl_abap_format=>e_html_attr ).
+        lv_value = | width="{ lv_value }"|.
+      ENDIF.
+      ii_html->add( |<td{ lv_value }>{ <ls_subitem>-label }</td>| ).
+    ENDLOOP.
+    ii_html->add( |</tr>| ).
+    ii_html->add( |</thead>| ).
+
+    lv_rows = io_values->get( |{ is_field-name }-{ c_rows }| ).
+
+    ii_html->add( |<tbody>| ).
+    DO lv_rows TIMES.
+      lv_rows = sy-index.
+      ii_html->add( |<tr>| ).
+      LOOP AT is_field-subitems ASSIGNING <ls_subitem>.
+        lv_cell_id = |{ is_field-name }-{ lv_rows }-{ sy-tabix }|.
+        lv_value = escape( val    = io_values->get( lv_cell_id )
+                           format = cl_abap_format=>e_html_attr ).
+        ii_html->add( |<td><input type="text" name="{ lv_cell_id }" id="{
+                      lv_cell_id }" value="{ lv_value }"></td>| ).
+      ENDLOOP.
+      ii_html->add( |</tr>| ).
+    ENDDO.
+    ii_html->add( |</tbody>| ).
+
+    ii_html->add( |</table>| ).
+
+    " Hidden field with number of rows to simplify getting values from form
+    lv_value = |{ is_field-name }-{ c_rows }|.
+    ii_html->add( |<input type="number" name="{ lv_value }" id="{
+                  lv_value }" value="{ lv_rows }" style="display:none">| ).
+
+  ENDMETHOD.
+
+
+  METHOD render_field_text.
+
+    DATA lv_type TYPE string.
+
+    ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{
+                  is_field-label }{ is_attr-required }</label>| ).
+
+    IF is_attr-error IS NOT INITIAL.
+      ii_html->add( is_attr-error ).
+    ENDIF.
+
+    IF is_field-side_action IS NOT INITIAL.
+      ii_html->add( '<div class="input-container">' ). " Ugly :(
+    ENDIF.
+
+    IF is_field-type = c_field_type-number.
+      lv_type = 'number'.
+    ELSEIF is_field-password = abap_true.
+      lv_type = 'password'.
+    ELSE.
+      lv_type = 'text'.
+    ENDIF.
+
+    ii_html->add( |<input type="{ lv_type }" name="{ is_field-name }" id="{
+                  is_field-name }" value="{ is_attr-value }" { is_field-dblclick }{
+                  is_attr-placeholder }{ is_attr-readonly }>| ).
+
+    IF is_field-side_action IS NOT INITIAL.
+      ii_html->add( '</div>' ).
+      ii_html->add( '<div class="command-container">' ).
+      ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }">| ).
+      ii_html->add( '</div>' ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD render_field_textarea.
+
+    DATA lv_rows TYPE i.
+
+    ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{
+                  is_field-label }{ is_attr-required }</label>| ).
+
+    IF is_attr-error IS NOT INITIAL.
+      ii_html->add( is_attr-error ).
+    ENDIF.
+
+    lv_rows = lines( zcl_abapgit_convert=>split_string( is_attr-value ) ) + 1. " one new row
+
+    ii_html->add( |<textarea name="{ is_field-name }" id="{
+                  is_field-name }" rows="{ lv_rows }"{ is_attr-readonly }>| ).
+    ii_html->add( escape( val    = is_attr-value
+                          format = cl_abap_format=>e_html_attr ) ).
+    ii_html->add( |</textarea>| ).
 
   ENDMETHOD.
 
@@ -578,6 +807,22 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
     ls_field-type  = c_field_type-field_group.
     ls_field-label = iv_label.
     ls_field-name  = iv_name.
+    ls_field-hint  = iv_hint.
+
+    APPEND ls_field TO mt_fields.
+
+    ro_self = me.
+
+  ENDMETHOD.
+
+
+  METHOD table.
+
+    DATA ls_field LIKE LINE OF mt_fields.
+
+    ls_field-type  = c_field_type-table.
+    ls_field-name  = iv_name.
+    ls_field-label = iv_label.
     ls_field-hint  = iv_hint.
 
     APPEND ls_field TO mt_fields.
@@ -671,7 +916,7 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
             CATCH cx_root.
               ro_validation_log->set(
                 iv_key = <ls_field>-name
-                iv_val = |{ <ls_field>-label } is not a number| ).
+                iv_val = |{ <ls_field>-label } is not numeric| ).
               CONTINUE.
           ENDTRY.
           IF <ls_field>-min <> cl_abap_math=>min_int4 AND lv_number < <ls_field>-min.

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -1,7 +1,7 @@
 CLASS zcl_abapgit_html_form DEFINITION
   PUBLIC
   FINAL
-  CREATE PRIVATE .
+  CREATE PRIVATE.
 
   PUBLIC SECTION.
 
@@ -12,14 +12,14 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_form_id    TYPE csequence OPTIONAL
         !iv_help_page  TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form.
     METHODS render
       IMPORTING
         !iv_form_class     TYPE csequence
         !io_values         TYPE REF TO zcl_abapgit_string_map
         !io_validation_log TYPE REF TO zcl_abapgit_string_map OPTIONAL
       RETURNING
-        VALUE(ri_html)     TYPE REF TO zif_abapgit_html .
+        VALUE(ri_html)     TYPE REF TO zif_abapgit_html.
     METHODS command
       IMPORTING
         !iv_label      TYPE csequence
@@ -27,7 +27,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_is_main    TYPE abap_bool DEFAULT abap_false
         !iv_as_a       TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS text
       IMPORTING
         !iv_label       TYPE csequence
@@ -42,7 +42,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_min         TYPE i DEFAULT cl_abap_math=>min_int4
         !iv_max         TYPE i DEFAULT cl_abap_math=>max_int4
       RETURNING
-        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form.
     METHODS textarea
       IMPORTING
         !iv_label       TYPE csequence
@@ -52,7 +52,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_readonly    TYPE abap_bool DEFAULT abap_false
         !iv_placeholder TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self)  TYPE REF TO zcl_abapgit_html_form.
     METHODS number
       IMPORTING
         !iv_label      TYPE csequence
@@ -63,14 +63,14 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_min        TYPE i DEFAULT cl_abap_math=>min_int4
         !iv_max        TYPE i DEFAULT cl_abap_math=>max_int4
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS checkbox
       IMPORTING
         !iv_label      TYPE csequence
         !iv_name       TYPE csequence
         !iv_hint       TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS radio
       IMPORTING
         !iv_label         TYPE csequence
@@ -78,47 +78,47 @@ CLASS zcl_abapgit_html_form DEFINITION
         !iv_default_value TYPE csequence OPTIONAL
         !iv_hint          TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self)    TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self)    TYPE REF TO zcl_abapgit_html_form.
     METHODS option
       IMPORTING
         !iv_label      TYPE csequence
         !iv_value      TYPE csequence
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS table
       IMPORTING
         !iv_label      TYPE csequence
         !iv_name       TYPE csequence
         !iv_hint       TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS column
       IMPORTING
         !iv_label      TYPE csequence
         !iv_width      TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS start_group
       IMPORTING
         !iv_label      TYPE csequence
         !iv_name       TYPE csequence
         !iv_hint       TYPE csequence OPTIONAL
       RETURNING
-        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form .
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
     METHODS normalize_form_data
       IMPORTING
         !io_form_data       TYPE REF TO zcl_abapgit_string_map
       RETURNING
         VALUE(ro_form_data) TYPE REF TO zcl_abapgit_string_map
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
     METHODS validate_required_fields
       IMPORTING
         !io_form_data            TYPE REF TO zcl_abapgit_string_map
       RETURNING
         VALUE(ro_validation_log) TYPE REF TO zcl_abapgit_string_map
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -126,9 +126,9 @@ CLASS zcl_abapgit_html_form DEFINITION
       BEGIN OF ty_subitem,
         label TYPE string,
         value TYPE string,
-      END OF ty_subitem .
+      END OF ty_subitem.
     TYPES:
-      ty_subitems TYPE STANDARD TABLE OF ty_subitem WITH DEFAULT KEY .
+      ty_subitems TYPE STANDARD TABLE OF ty_subitem WITH DEFAULT KEY.
     TYPES:
       BEGIN OF ty_field,
         type          TYPE i,
@@ -149,7 +149,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         min           TYPE i,
         max           TYPE i,
 *        onclick ???
-      END OF ty_field .
+      END OF ty_field.
     TYPES:
       BEGIN OF ty_command,
         label   TYPE string,
@@ -157,7 +157,7 @@ CLASS zcl_abapgit_html_form DEFINITION
         is_main TYPE abap_bool,
         as_a    TYPE abap_bool,
 *        onclick ???
-      END OF ty_command .
+      END OF ty_command.
     TYPES:
       BEGIN OF ty_attr,
         value       TYPE string,
@@ -177,21 +177,21 @@ CLASS zcl_abapgit_html_form DEFINITION
         number      TYPE i VALUE 5,
         textarea    TYPE i VALUE 6,
         table       TYPE i VALUE 7,
-      END OF c_field_type .
+      END OF c_field_type.
     DATA:
       mt_fields TYPE STANDARD TABLE OF ty_field
-            WITH UNIQUE SORTED KEY by_name COMPONENTS name .
+          WITH UNIQUE SORTED KEY by_name COMPONENTS name.
     DATA:
-      mt_commands TYPE STANDARD TABLE OF ty_command .
-    DATA mv_form_id TYPE string .
-    DATA mv_help_page TYPE string .
+      mt_commands TYPE STANDARD TABLE OF ty_command.
+    DATA mv_form_id TYPE string.
+    DATA mv_help_page TYPE string.
 
     METHODS render_field
       IMPORTING
         !ii_html           TYPE REF TO zif_abapgit_html
         !io_values         TYPE REF TO zcl_abapgit_string_map
         !io_validation_log TYPE REF TO zcl_abapgit_string_map
-        !is_field          TYPE ty_field .
+        !is_field          TYPE ty_field.
     METHODS render_field_text
       IMPORTING
         !ii_html  TYPE REF TO zif_abapgit_html
@@ -221,7 +221,7 @@ CLASS zcl_abapgit_html_form DEFINITION
     METHODS render_command
       IMPORTING
         !ii_html TYPE REF TO zif_abapgit_html
-        !is_cmd  TYPE ty_command .
+        !is_cmd  TYPE ty_command.
 ENDCLASS.
 
 
@@ -691,8 +691,7 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_subitem> LIKE LINE OF is_field-subitems.
 
-    ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{
-                  is_field-label }</label>| ).
+    ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{ is_field-label }</label>| ).
 
     IF is_attr-error IS NOT INITIAL.
       ii_html->add( is_attr-error ).

--- a/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
@@ -57,6 +57,95 @@ CLASS ltcl_test_form IMPLEMENTATION.
       act = lo_log->size( )
       exp = 0 ).
 
+    " New form
+    lo_cut = zcl_abapgit_html_form=>create( ).
+
+    lo_cut->text(
+      iv_name        = 'field3'
+      iv_min         = 3
+      iv_max         = 10
+      iv_label       = 'Field name 3' ).
+
+    lo_form_data->set(
+      iv_key = 'field3'
+      iv_val = 'xy' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field3' )
+      exp = '*must not be shorter*' ).
+
+    lo_form_data->set(
+      iv_key = 'field3'
+      iv_val = '01234567890123' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field3' )
+      exp = '*must not be longer*' ).
+
+    lo_form_data->set(
+      iv_key = 'field3'
+      iv_val = 'xyz!' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 0 ).
+
+    " New form
+    lo_cut = zcl_abapgit_html_form=>create( ).
+
+    lo_cut->number(
+      iv_name        = 'field4'
+      iv_min         = 100
+      iv_max         = 200
+      iv_label       = 'Field name 4' ).
+
+    lo_form_data->set(
+      iv_key = 'field4'
+      iv_val = '123-456' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field4' )
+      exp = '*is not numeric*' ).
+
+    lo_form_data->set(
+      iv_key = 'field4'
+      iv_val = '50' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field4' )
+      exp = '*must not be lower*' ).
+
+    lo_form_data->set(
+      iv_key = 'field4'
+      iv_val = '250' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field4' )
+      exp = '*must not be higher*' ).
+
+    lo_form_data->set(
+      iv_key = 'field4'
+      iv_val = '150' ).
+    lo_log = lo_cut->validate_required_fields( lo_form_data ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 0 ).
+
   ENDMETHOD.
 
   METHOD normalize.
@@ -86,6 +175,19 @@ CLASS ltcl_test_form IMPLEMENTATION.
     lo_cut->checkbox(
       iv_name        = 'chk2'
       iv_label       = 'Checkbox2' ).
+    lo_cut->number(
+      iv_name        = 'num1'
+      iv_label       = 'Number 1' ).
+    lo_cut->table(
+      iv_name        = 'tab1'
+      iv_label       = 'Table 1' ).
+    lo_cut->column(
+      iv_label       = 'Column 1' ).
+    lo_cut->column(
+      iv_label       = 'Column 2' ).
+    lo_cut->number(
+      iv_name        = |tab1-{ zcl_abapgit_html_form=>c_rows }|
+      iv_label       = 'Number of Rows' ). " simulate hidden form field
 
     lo_form_data->set(
       iv_key = 'field1'
@@ -93,7 +195,7 @@ CLASS ltcl_test_form IMPLEMENTATION.
     lo_form_data->set(
       iv_key = 'field2'
       iv_val = 'val2' ).
-    " Intentinally field3 is not specificed
+    " Intentionally field3 is not specificed
     lo_form_data->set(
       iv_key = 'chk1'
       iv_val = '' ).
@@ -103,6 +205,27 @@ CLASS ltcl_test_form IMPLEMENTATION.
     lo_form_data->set(
       iv_key = 'chk3'
       iv_val = 'on' ). " Extra field - filtered by normalizing
+
+    lo_form_data->set(
+      iv_key = 'num1'
+      iv_val = '   1234' ).
+
+    " Table with 2 rows, 2 columns
+    lo_form_data->set(
+      iv_key = |tab1-{ zcl_abapgit_html_form=>c_rows }|
+      iv_val = '2' ).
+    lo_form_data->set(
+      iv_key = |tab1-1-1|
+      iv_val = 'abc' ).
+    lo_form_data->set(
+      iv_key = |tab1-1-2|
+      iv_val = '123' ).
+    lo_form_data->set(
+      iv_key = |tab1-2-1|
+      iv_val = '' ).
+    lo_form_data->set(
+      iv_key = |tab1-2-2|
+      iv_val = '0' ).
 
     lo_normalized_exp->set(
       iv_key = 'field1'
@@ -119,6 +242,29 @@ CLASS ltcl_test_form IMPLEMENTATION.
     lo_normalized_exp->set(
       iv_key = 'chk2'
       iv_val = 'X' ).
+    lo_normalized_exp->set(
+      iv_key = 'chk2'
+      iv_val = 'X' ).
+
+    lo_normalized_exp->set(
+      iv_key = 'num1'
+      iv_val = '1234' ).
+
+    lo_normalized_exp->set(
+      iv_key = |tab1-{ zcl_abapgit_html_form=>c_rows }|
+      iv_val = '2' ).
+    lo_normalized_exp->set(
+      iv_key = |tab1-1-1|
+      iv_val = 'abc' ).
+    lo_normalized_exp->set(
+      iv_key = |tab1-1-2|
+      iv_val = '123' ).
+    lo_normalized_exp->set(
+      iv_key = |tab1-2-1|
+      iv_val = '' ).
+    lo_normalized_exp->set(
+      iv_key = |tab1-2-2|
+      iv_val = '0' ).
 
     lo_normalized_act = lo_cut->normalize_form_data( lo_form_data ).
     cl_abap_unit_assert=>assert_equals(

--- a/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.testclasses.abap
@@ -181,10 +181,8 @@ CLASS ltcl_test_form IMPLEMENTATION.
     lo_cut->table(
       iv_name        = 'tab1'
       iv_label       = 'Table 1' ).
-    lo_cut->column(
-      iv_label       = 'Column 1' ).
-    lo_cut->column(
-      iv_label       = 'Column 2' ).
+    lo_cut->column( iv_label = 'Column 1' ).
+    lo_cut->column( iv_label = 'Column 2' ).
     lo_cut->number(
       iv_name        = |tab1-{ zcl_abapgit_html_form=>c_rows }|
       iv_label       = 'Number of Rows' ). " simulate hidden form field


### PR DESCRIPTION
- Adds option to maintain data using a table control
- Extends UTs with several cases that were included in #4172
- Table control to be used by "repo settings" #4171
- Minor: Change textarea to Arial font for more consistent look
- Refactor: Split render_field into type-specific methods

Example:

![image](https://user-images.githubusercontent.com/59966492/100014535-7e31a000-2da4-11eb-9b2a-06929862008b.png)
