### PR TITLE
Remove obsolete late_deser from metadata

### DIFF
--- a/src/objects/zcl_abapgit_objects_bridge.clas.abap
+++ b/src/objects/zcl_abapgit_objects_bridge.clas.abap
@@ -176,7 +176,9 @@ CLASS zcl_abapgit_objects_bridge IMPLEMENTATION.
 
     DATA ls_meta TYPE ty_metadata.
 
-    ls_meta = zif_abapgit_object~get_metadata( ).
+    CALL METHOD mo_plugin->('ZIF_ABAPGITP_PLUGIN~GET_METADATA')
+      RECEIVING
+        rs_metadata = ls_meta.
 
     IF ls_meta-late_deser = abap_true.
       APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.

--- a/src/objects/zcl_abapgit_objects_bridge.clas.abap
+++ b/src/objects/zcl_abapgit_objects_bridge.clas.abap
@@ -15,6 +15,16 @@ CLASS zcl_abapgit_objects_bridge DEFINITION PUBLIC FINAL CREATE PUBLIC INHERITIN
   PRIVATE SECTION.
     DATA: mo_plugin TYPE REF TO object.
 
+    " Metadata with late_deser to stay compatible with old bridge
+    TYPES:
+      BEGIN OF ty_metadata,
+        class        TYPE string,
+        version      TYPE string,
+        late_deser   TYPE abap_bool,
+        delete_tadir TYPE abap_bool,
+        ddic         TYPE abap_bool,
+      END OF ty_metadata .
+
     TYPES: BEGIN OF ty_s_objtype_map,
              obj_typ      TYPE trobjtype,
              plugin_class TYPE seoclsname,
@@ -27,7 +37,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_BRIDGE IMPLEMENTATION.
+CLASS zcl_abapgit_objects_bridge IMPLEMENTATION.
 
 
   METHOD class_constructor.
@@ -164,7 +174,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_BRIDGE IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
 
-    DATA: ls_meta TYPE zif_abapgit_definitions=>ty_metadata.
+    DATA ls_meta TYPE ty_metadata.
 
     ls_meta = zif_abapgit_object~get_metadata( ).
 
@@ -181,9 +191,13 @@ CLASS ZCL_ABAPGIT_OBJECTS_BRIDGE IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_metadata.
 
+    DATA ls_meta TYPE ty_metadata.
+
     CALL METHOD mo_plugin->('ZIF_ABAPGITP_PLUGIN~GET_METADATA')
       RECEIVING
-        rs_metadata = rs_metadata.
+        rs_metadata = ls_meta.
+
+    MOVE-CORRESPONDING ls_meta TO rs_metadata.
 
   ENDMETHOD.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -145,7 +145,6 @@ INTERFACE zif_abapgit_definitions
     BEGIN OF ty_metadata,
       class        TYPE string,
       version      TYPE string,
-      late_deser   TYPE abap_bool, " refactor: can be removed later. replaced by steps
       delete_tadir TYPE abap_bool,
       ddic         TYPE abap_bool,
     END OF ty_metadata .


### PR DESCRIPTION
Final part to remove late_deser flag. Solution remains compatible with old bridge class which still uses the flag.

Conclusion of #4116 