### PR TITLE
Check objects when installing into main package

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -314,7 +314,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     " check package restrictions, closed package, descriptive or
     " functional package
-    CALL METHOD cl_pak_object_types=>check_object_type
+    cl_pak_object_types=>check_object_type(
       EXPORTING
         i_working_mode         = 'I'
         i_package_name         = iv_package
@@ -324,7 +324,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
         wrong_object_type      = 1
         package_not_extensible = 2
         package_not_loaded     = 3
-        OTHERS                 = 4.
+        OTHERS                 = 4 ).
     CASE sy-subrc.
       WHEN 0.
         RETURN.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -219,11 +219,17 @@ CLASS zcl_abapgit_objects DEFINITION
     CLASS-METHODS get_deserialize_steps
       RETURNING
         VALUE(rt_steps) TYPE zif_abapgit_objects=>ty_step_data_tt .
+    CLASS-METHODS check_main_package
+      IMPORTING
+        !iv_package  TYPE devclass
+        !iv_obj_type TYPE tadir-object
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
+CLASS zcl_abapgit_objects IMPLEMENTATION.
 
 
   METHOD adjust_namespaces.
@@ -300,6 +306,33 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
       CONCATENATE LINES OF lt_duplicates INTO lv_all_duplicates SEPARATED BY `, `.
       zcx_abapgit_exception=>raise( |Duplicates: { lv_all_duplicates }| ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD check_main_package.
+
+    " check package restrictions, closed package, descriptive or
+    " functional package
+    CALL METHOD cl_pak_object_types=>check_object_type
+      EXPORTING
+        i_working_mode         = 'I'
+        i_package_name         = iv_package
+        i_pgmid                = 'R3TR'
+        i_object_type          = iv_obj_type
+      EXCEPTIONS
+        wrong_object_type      = 1
+        package_not_extensible = 2
+        package_not_loaded     = 3
+        OTHERS                 = 4.
+    CASE sy-subrc.
+      WHEN 0.
+        RETURN.
+      WHEN 2.
+        zcx_abapgit_exception=>raise( |Object type { iv_obj_type } not allowed for package { iv_package }| ).
+      WHEN OTHERS.
+        zcx_abapgit_exception=>raise_t100(  ).
+    ENDCASE.
 
   ENDMETHOD.
 
@@ -650,6 +683,10 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
             iv_top  = io_repo->get_package( )
             io_dot  = io_repo->get_dot_abapgit( )
             iv_path = <ls_result>-path ).
+
+          check_main_package(
+            iv_package  = lv_package
+            iv_obj_type = ls_item-obj_type ).
 
           IF ls_item-obj_type = 'DEVC'.
             " Packages have the same filename across different folders. The path needs to be supplied


### PR DESCRIPTION
AG will now show an error for objects that are not allowed in a main package.

![image](https://user-images.githubusercontent.com/59966492/100139960-425b1100-2e5e-11eb-8f2f-011d9c12f7f9.png)

Closes https://github.com/abapGit/abapGit/issues/2273