### PR TITLE
Exception: Set return for split_text_to_symsg

### DIFF
--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -443,5 +443,7 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
     " Set syst using generic error message
     MESSAGE e001(00) WITH ls_msg-msgv1 ls_msg-msgv2 ls_msg-msgv3 ls_msg-msgv4 INTO sy-lisel.
 
+    rs_msg = ls_msg.
+
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
Fixes return parameter for `ZCX_ABAPGIT_EXCEPTION=>SPLIT_TEXT_TO_SYMSG`