### PR TITLE
UI: Clear progress bar

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -578,6 +578,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Error during uninstall. Check the log.' ).
     ENDIF.
 
+    li_progress->off( ).
+
   ENDMETHOD.
 
 
@@ -760,6 +762,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     zcl_abapgit_default_transport=>get_instance( )->reset( ).
 
+    li_progress->off( ).
+
   ENDMETHOD.
 
 
@@ -835,6 +839,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
         zcl_abapgit_objects_activation=>activate( abap_true ).
         zcl_abapgit_objects_activation=>activate( abap_false ).
     ENDCASE.
+
+    li_progress->off( ).
 
 *   Call postprocessing
     li_exit = zcl_abapgit_exit=>get_instance( ).

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -637,6 +637,8 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
     register_deferred_script( render_scripts( ) ).
 
+    li_progress->off( ).
+
   ENDMETHOD.
 
 

--- a/src/utils/zcl_abapgit_progress.clas.abap
+++ b/src/utils/zcl_abapgit_progress.clas.abap
@@ -33,7 +33,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_PROGRESS IMPLEMENTATION.
+CLASS zcl_abapgit_progress IMPLEMENTATION.
 
 
   METHOD calc_pct.
@@ -70,6 +70,14 @@ CLASS ZCL_ABAPGIT_PROGRESS IMPLEMENTATION.
   METHOD set_instance.
 
     gi_progress = ii_progress.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_progress~off.
+
+    " Clear the status bar
+    CALL FUNCTION 'SAPGUI_PROGRESS_INDICATOR'.
 
   ENDMETHOD.
 

--- a/src/utils/zif_abapgit_progress.intf.abap
+++ b/src/utils/zif_abapgit_progress.intf.abap
@@ -9,4 +9,5 @@ INTERFACE zif_abapgit_progress
   METHODS set_total
     IMPORTING
       !iv_total TYPE i .
+  METHODS off .
 ENDINTERFACE.

--- a/src/zcl_abapgit_performance_test.clas.locals_imp.abap
+++ b/src/zcl_abapgit_performance_test.clas.locals_imp.abap
@@ -9,4 +9,7 @@ CLASS lcl_dummy_progress IMPLEMENTATION.
 
   METHOD zif_abapgit_progress~show.
   ENDMETHOD.
+
+  METHOD zif_abapgit_progress~off.
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -38,7 +38,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
+CLASS zcl_abapgit_tadir IMPLEMENTATION.
 
 
   METHOD build.
@@ -177,6 +177,8 @@ CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
         APPEND <ls_tadir> TO rt_tadir.
       ENDIF.
     ENDLOOP.
+
+    li_progress->off( ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Clears status/progress bar at end of longer processes and removes leftover messages. 

Closes #3505