### PR TITLE
Remove two places wih repo class insantiation

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -711,7 +711,7 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         ENDCASE.
       WHEN zif_abapgit_definitions=>c_action-zip_export.                      " Export repo as ZIP
         lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
-        lv_xstr = zcl_abapgit_zip=>export( lo_repo ).
+        lv_xstr = zcl_abapgit_zip=>encode_files( lo_repo->get_files_local( ) ).
         file_download( iv_package = lo_repo->get_package( )
                        iv_xstr    = lv_xstr ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -34,7 +34,6 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS get_files_local
       IMPORTING
         !ii_log         TYPE REF TO zif_abapgit_log OPTIONAL
-        !it_filter      TYPE zif_abapgit_definitions=>ty_tadir_tt OPTIONAL
       RETURNING
         VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_item_tt
       RAISING
@@ -426,7 +425,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
   METHOD get_files_local.
 
-* todo, after refactoring is done, I think the IT_FILTER parameter can be removed
 
     DATA: lo_serialize TYPE REF TO zcl_abapgit_serialize.
 
@@ -444,8 +442,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       iv_package        = get_package( )
       io_dot_abapgit    = get_dot_abapgit( )
       is_local_settings = get_local_settings( )
-      ii_log            = ii_log
-      it_filter         = it_filter ).
+      ii_log            = ii_log ).
 
     mt_local                 = rt_files.
     mv_request_local_refresh = abap_false. " Fulfill refresh

--- a/src/zcl_abapgit_transport.clas.abap
+++ b/src/zcl_abapgit_transport.clas.abap
@@ -288,12 +288,13 @@ CLASS ZCL_ABAPGIT_TRANSPORT IMPLEMENTATION.
 
   METHOD zip.
 
-    DATA: lt_requests TYPE trwbo_requests,
-          lt_tadir    TYPE zif_abapgit_definitions=>ty_tadir_tt,
-          lv_package  TYPE devclass,
-          ls_data     TYPE zif_abapgit_persistence=>ty_repo,
-          lo_repo     TYPE REF TO zcl_abapgit_repo_offline,
-          lt_trkorr   TYPE trwbo_request_headers.
+    DATA: lt_requests       TYPE trwbo_requests,
+          lt_tadir          TYPE zif_abapgit_definitions=>ty_tadir_tt,
+          lv_package        TYPE devclass,
+          lo_dot_abapgit    TYPE REF TO zcl_abapgit_dot_abapgit,
+          ls_local_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings,
+          lo_repo           TYPE REF TO zcl_abapgit_repo_offline,
+          lt_trkorr         TYPE trwbo_request_headers.
 
 
     IF is_trkorr IS SUPPLIED.
@@ -317,24 +318,19 @@ CLASS ZCL_ABAPGIT_TRANSPORT IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error finding super package' ).
     ENDIF.
 
-    ls_data-key         = 'TZIP'.
-    ls_data-package     = lv_package.
-    ls_data-dot_abapgit = zcl_abapgit_dot_abapgit=>build_default( )->get_data( ).
-
+    lo_dot_abapgit = zcl_abapgit_dot_abapgit=>build_default( ).
     IF iv_logic IS SUPPLIED AND iv_logic IS NOT INITIAL.
-      ls_data-dot_abapgit-folder_logic = iv_logic.
+      lo_dot_abapgit->set_folder_logic( iv_logic ).
     ELSE.
-      ls_data-dot_abapgit-folder_logic = zcl_abapgit_ui_factory=>get_popups( )->popup_folder_logic( ).
+      lo_dot_abapgit->set_folder_logic( zcl_abapgit_ui_factory=>get_popups( )->popup_folder_logic( ) ).
     ENDIF.
 
-    CREATE OBJECT lo_repo
-      EXPORTING
-        is_data = ls_data.
-
     rv_xstr = zcl_abapgit_zip=>export(
-      io_repo     = lo_repo
-      it_filter   = lt_tadir
-      iv_show_log = iv_show_log_popup ).
+      iv_package        = lv_package
+      io_dot_abapgit    = lo_dot_abapgit
+      is_local_settings = ls_local_settings
+      it_filter         = lt_tadir
+      iv_show_log       = iv_show_log_popup ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -13,11 +13,13 @@ CLASS zcl_abapgit_zip DEFINITION
         zcx_abapgit_exception .
     CLASS-METHODS export
       IMPORTING
-        !io_repo       TYPE REF TO zcl_abapgit_repo
-        !iv_show_log   TYPE abap_bool DEFAULT abap_true
-        !it_filter     TYPE zif_abapgit_definitions=>ty_tadir_tt OPTIONAL
+        !is_local_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings
+        !iv_package        TYPE devclass
+        !io_dot_abapgit    TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_show_log       TYPE abap_bool DEFAULT abap_true
+        !it_filter         TYPE zif_abapgit_definitions=>ty_tadir_tt OPTIONAL
       RETURNING
-        VALUE(rv_xstr) TYPE xstring
+        VALUE(rv_xstr)     TYPE xstring
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS export_object
@@ -97,22 +99,28 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
   METHOD export.
 
-    DATA: li_log     TYPE REF TO zif_abapgit_log,
-          lt_zip     TYPE zif_abapgit_definitions=>ty_files_item_tt,
-          lv_package TYPE devclass.
+    DATA li_log       TYPE REF TO zif_abapgit_log.
+    DATA lt_zip       TYPE zif_abapgit_definitions=>ty_files_item_tt.
+    DATA lo_serialize TYPE REF TO zcl_abapgit_serialize.
 
 
     CREATE OBJECT li_log TYPE zcl_abapgit_log.
     li_log->set_title( 'Zip Export Log' ).
 
-    lv_package = io_repo->get_package( ).
-
-    IF zcl_abapgit_factory=>get_sap_package( lv_package )->exists( ) = abap_false.
-      zcx_abapgit_exception=>raise( |Package { lv_package } doesn't exist| ).
+    IF zcl_abapgit_factory=>get_sap_package( iv_package )->exists( ) = abap_false.
+      zcx_abapgit_exception=>raise( |Package { iv_package } doesn't exist| ).
     ENDIF.
 
-    lt_zip = io_repo->get_files_local( ii_log    = li_log
-                                       it_filter = it_filter ).
+    CREATE OBJECT lo_serialize
+      EXPORTING
+        iv_serialize_master_lang_only = is_local_settings-serialize_master_lang_only.
+
+    lt_zip = lo_serialize->files_local(
+      iv_package        = iv_package
+      io_dot_abapgit    = io_dot_abapgit
+      is_local_settings = is_local_settings
+      ii_log            = li_log
+      it_filter         = it_filter ).
 
     IF li_log->count( ) > 0 AND iv_show_log = abap_true.
       zcl_abapgit_log_viewer=>show_log( li_log ).
@@ -179,33 +187,35 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
   METHOD export_package.
 
-    DATA: lo_repo   TYPE REF TO zcl_abapgit_repo_offline,
-          ls_data   TYPE zif_abapgit_persistence=>ty_repo,
-          li_popups TYPE REF TO zif_abapgit_popups.
+    DATA: ls_local_settings             TYPE zif_abapgit_persistence=>ty_repo-local_settings,
+          lo_dot_abapgit                TYPE REF TO zcl_abapgit_dot_abapgit,
+          li_popups                     TYPE REF TO zif_abapgit_popups,
+          lv_folder_logic               TYPE string,
+          lv_package                    TYPE devclass,
+          lv_serialize_master_lang_only TYPE abap_bool.
 
-    DATA lv_serialize_master_lang_only TYPE abap_bool.
-
-    ls_data-key = 'DUMMY'.
-    ls_data-dot_abapgit = zcl_abapgit_dot_abapgit=>build_default( )->get_data( ).
 
     li_popups = zcl_abapgit_ui_factory=>get_popups( ).
     li_popups->popup_package_export(
       IMPORTING
-        ev_package      = ls_data-package
-        ev_folder_logic = ls_data-dot_abapgit-folder_logic
+        ev_package                    = lv_package
+        ev_folder_logic               = lv_folder_logic
         ev_serialize_master_lang_only = lv_serialize_master_lang_only ).
-    IF ls_data-package IS INITIAL.
+    IF lv_package IS INITIAL.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
     ENDIF.
 
-    ls_data-local_settings-serialize_master_lang_only = lv_serialize_master_lang_only.
+    ls_local_settings-serialize_master_lang_only = lv_serialize_master_lang_only.
 
-    CREATE OBJECT lo_repo
-      EXPORTING
-        is_data = ls_data.
+    lo_dot_abapgit = zcl_abapgit_dot_abapgit=>build_default( ).
+    lo_dot_abapgit->set_folder_logic( lv_folder_logic ).
 
-    ev_xstr = export( lo_repo ).
-    ev_package = ls_data-package.
+    ev_xstr = export(
+      is_local_settings = ls_local_settings
+      iv_package        = lv_package
+      io_dot_abapgit    = lo_dot_abapgit ).
+
+    ev_package = lv_package.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -4,6 +4,13 @@ CLASS zcl_abapgit_zip DEFINITION
 
   PUBLIC SECTION.
 
+    CLASS-METHODS encode_files
+      IMPORTING
+        !it_files      TYPE zif_abapgit_definitions=>ty_files_item_tt
+      RETURNING
+        VALUE(rv_xstr) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS export
       IMPORTING
         !io_repo       TYPE REF TO zcl_abapgit_repo
@@ -30,22 +37,16 @@ CLASS zcl_abapgit_zip DEFINITION
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS save_binstring_to_localfile
-      IMPORTING iv_filename  TYPE string
-                iv_binstring TYPE xstring
-      RAISING   zcx_abapgit_exception.
-
+      IMPORTING
+        !iv_filename  TYPE string
+        !iv_binstring TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
   PROTECTED SECTION.
 
     CLASS-DATA gv_prev TYPE string .
   PRIVATE SECTION.
 
-    CLASS-METHODS encode_files
-      IMPORTING
-        !it_files      TYPE zif_abapgit_definitions=>ty_files_item_tt
-      RETURNING
-        VALUE(rv_xstr) TYPE xstring
-      RAISING
-        zcx_abapgit_exception .
     CLASS-METHODS filename
       IMPORTING
         !iv_str      TYPE string
@@ -58,7 +59,7 @@ CLASS zcl_abapgit_zip DEFINITION
       CHANGING
         !ct_files TYPE zif_abapgit_definitions=>ty_files_tt
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     CLASS-METHODS unzip_file
       IMPORTING
         !iv_xstr        TYPE xstring


### PR DESCRIPTION
* zip class, method `encode_files` as public, used in router
* zip class, call file serialization without repository object
* transport class, call file serialization without repository object
* zcl_abapgit_repo->get_files_local remove `filter` input parameter, not supplied from anywhere now

#2127