### PR TITLE
Fix dump when using abapGit for more than 50 navigation steps

### DIFF
--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -102,7 +102,7 @@ FORM exit RAISING zcx_abapgit_exception.
       IF zcl_abapgit_ui_factory=>get_gui( )->back( ) = abap_true. " end of stack
         zcl_abapgit_ui_factory=>get_gui( )->free( ). " Graceful shutdown
       ELSE.
-        CALL SELECTION-SCREEN 1001.
+        LEAVE TO SCREEN 1001.
       ENDIF.
   ENDCASE.
 ENDFORM.


### PR DESCRIPTION
Reverting back to a proper exit of screens using `LEAVE TO SCREEN` and avoid increasing the size of the callstack. 

Closes #4279 

PS: The crash mentioned in #4027 was prevented by removing the commit hash from the check screen. It works also with `LEAVE TO SCREEN`.