### PR TITLE
refactor ecatt exceptions

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -74,6 +74,7 @@
     "globalMacros": []
   },
   "rules": {
+    "uncaught_exception": true,
     "intf_referencing_clas": false,
     "method_implemented_twice": true,
     "parser_702_chaining": true,

--- a/src/objects/ecatt/zcl_abapgit_ecatt_helper.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_helper.clas.abap
@@ -27,7 +27,7 @@ CLASS zcl_abapgit_ecatt_helper DEFINITION
         RETURNING
           VALUE(ri_template_over_all) TYPE REF TO if_ixml_document
         RAISING
-          cx_ecatt_apl_xml.
+          cx_ecatt_apl.
 
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/objects/ecatt/zcl_abapgit_ecatt_script_downl.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_script_downl.clas.abap
@@ -22,7 +22,7 @@ CLASS zcl_abapgit_ecatt_script_downl DEFINITION
     METHODS:
       set_script_to_template
         RAISING
-          cx_ecatt_apl_util,
+          cx_ecatt_apl,
 
       set_control_data_for_tcd
         IMPORTING
@@ -37,15 +37,15 @@ CLASS zcl_abapgit_ecatt_script_downl DEFINITION
           iv_tabname TYPE string
           iv_node    TYPE string
         RAISING
-          cx_ecatt_apl_util,
+          cx_ecatt_apl,
 
       set_blob_to_template
         RAISING
-          cx_ecatt_apl_util,
+          cx_ecatt_apl,
 
       set_artmp_to_template
         RAISING
-          cx_ecatt_apl_util.
+          cx_ecatt_apl.
 
 ENDCLASS.
 


### PR DESCRIPTION
change some exceptions in ecatt error handling

enable abaplint rule `uncaugt_exception`

also note the changes already done in https://github.com/abaplint/deps