### PR TITLE
VIEW: Fix deserialize of maintenance views

### DIFF
--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -43,7 +43,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
+CLASS zcl_abapgit_object_view IMPLEMENTATION.
 
 
   METHOD read_view.
@@ -69,7 +69,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
         illegal_input = 1
         OTHERS        = 2.
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from DDIF_VIEW_GET' ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
   ENDMETHOD.
@@ -109,7 +109,8 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
           lt_dd28j TYPE TABLE OF dd28j,
           lt_dd28v TYPE TABLE OF dd28v.
 
-    FIELD-SYMBOLS: <ls_dd27p> LIKE LINE OF lt_dd27p.
+    FIELD-SYMBOLS: <ls_dd27p> LIKE LINE OF lt_dd27p,
+                   <ls_dd28j> LIKE LINE OF lt_dd28j.
 
     io_xml->read( EXPORTING iv_name = 'DD25V'
                   CHANGING cg_data = ls_dd25v ).
@@ -123,6 +124,13 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
                   CHANGING cg_data = lt_dd28j ).
     io_xml->read( EXPORTING iv_name = 'DD28V_TABLE'
                   CHANGING cg_data = lt_dd28v ).
+
+    " Process maintenance views during LATE to avoid issues with missing foreign key relationships (#4306)
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd25v-viewclass = 'C'.
+      RETURN.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd25v-viewclass <> 'C'.
+      RETURN.
+    ENDIF.
 
     lv_name = ms_item-obj_name. " type conversion
 
@@ -159,7 +167,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
         put_refused       = 5
         OTHERS            = 6.
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from DDIF_VIEW_PUT' ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
     zcl_abapgit_objects_activation=>add_item( ms_item ).
@@ -201,6 +209,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 
@@ -241,7 +250,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
             OTHERS              = 3.
 
         IF sy-subrc <> 0.
-          zcx_abapgit_exception=>raise( |Error from RS_TOOL_ACCESS. Subrc={ sy-subrc }| ).
+          zcx_abapgit_exception=>raise_t100( ).
         ENDIF.
 
       WHEN OTHERS.


### PR DESCRIPTION
Maintenance views can have dependencies on tables with foreign keys. Such cases can lead to errors during deserialize since the foreign key relationships between tables are processed only in the "late" step.

This fix moves the processing of maintenance views (viewclass = c) to the "late" step.

Closes #4306