### PR TITLE
Fix: Several repos for same URL

### DIFF
--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -359,7 +359,7 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
     " check if url is already in use for a different package
     lt_repos = zcl_abapgit_persist_factory=>get_repo( )->list( ).
-    LOOP AT lt_repos ASSIGNING <ls_repo>.
+    LOOP AT lt_repos ASSIGNING <ls_repo> WHERE offline = abap_false.
 
       lv_check_repo_address = zcl_abapgit_url=>url_address( <ls_repo>-url ).
 


### PR DESCRIPTION
Regression from #4313:
Fix "Malformed URL" error if at least one offline repo exists

![image](https://user-images.githubusercontent.com/59966492/102148453-752f6e00-3e3a-11eb-9e72-a4459a34e1d7.png)
