### PR TITLE
string map: change set() input value to csequence

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_sett_glob.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_glob.clas.abap
@@ -77,7 +77,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_glob IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_GLOB IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -215,7 +215,7 @@ CLASS zcl_abapgit_gui_page_sett_glob IMPLEMENTATION.
       iv_val = mo_settings->get_proxy_port( ) ).
     mo_form_data->set(
       iv_key = c_id-proxy_auth
-      iv_val = boolc( mo_settings->get_proxy_authentication( ) = abap_true ) ).
+      iv_val = boolc( mo_settings->get_proxy_authentication( ) = abap_true ) ) ##TYPE.
 
     read_proxy_bypass( ).
 
@@ -234,10 +234,10 @@ CLASS zcl_abapgit_gui_page_sett_glob IMPLEMENTATION.
     IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_false.
       mo_form_data->set(
         iv_key = c_id-run_critical_tests
-        iv_val = boolc( mo_settings->get_run_critical_tests( ) = abap_true ) ).
+        iv_val = boolc( mo_settings->get_run_critical_tests( ) = abap_true ) ) ##TYPE.
       mo_form_data->set(
         iv_key = c_id-experimental_features
-        iv_val = boolc( mo_settings->get_experimental_features( ) = abap_true ) ).
+        iv_val = boolc( mo_settings->get_experimental_features( ) = abap_true ) ) ##TYPE.
     ENDIF.
 
     " Set for is_dirty check

--- a/src/ui/zcl_abapgit_gui_page_sett_pers.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_pers.clas.abap
@@ -73,7 +73,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_pers IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_PERS IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -222,13 +222,13 @@ CLASS zcl_abapgit_gui_page_sett_pers IMPLEMENTATION.
     " Interaction
     mo_form_data->set(
       iv_key = c_id-activate_wo_popup
-      iv_val = boolc( ms_settings-activate_wo_popup = abap_true ) ).
+      iv_val = boolc( ms_settings-activate_wo_popup = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-adt_jump_enabled
-      iv_val = boolc( ms_settings-adt_jump_enabled = abap_true ) ).
+      iv_val = boolc( ms_settings-adt_jump_enabled = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-link_hints_enabled
-      iv_val = boolc( ms_settings-link_hints_enabled = abap_true ) ).
+      iv_val = boolc( ms_settings-link_hints_enabled = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-link_hint_key
       iv_val = |{ ms_settings-link_hint_key }| ).
@@ -236,7 +236,7 @@ CLASS zcl_abapgit_gui_page_sett_pers IMPLEMENTATION.
     " Resources
     mo_form_data->set(
       iv_key = c_id-parallel_proc_disabled
-      iv_val = boolc( ms_settings-parallel_proc_disabled = abap_true ) ).
+      iv_val = boolc( ms_settings-parallel_proc_disabled = abap_true ) ) ##TYPE.
 
     " Set for is_dirty check
     mo_form_util->set_data( mo_form_data ).

--- a/src/ui/zcl_abapgit_html_form_utils.clas.abap
+++ b/src/ui/zcl_abapgit_html_form_utils.clas.abap
@@ -59,7 +59,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_html_form_utils IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_HTML_FORM_UTILS IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -173,7 +173,7 @@ CLASS zcl_abapgit_html_form_utils IMPLEMENTATION.
       IF <ls_field>-type = zif_abapgit_html_form=>c_field_type-checkbox.
         ro_form_data->set(
           iv_key = <ls_field>-name
-          iv_val = boolc( lv_value = 'on' ) ).
+          iv_val = boolc( lv_value = 'on' ) ) ##TYPE.
       ELSEIF <ls_field>-type = zif_abapgit_html_form=>c_field_type-text AND <ls_field>-upper_case = abap_true.
         ro_form_data->set(
           iv_key = <ls_field>-name

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -9,64 +9,63 @@ CLASS zcl_abapgit_string_map DEFINITION
       BEGIN OF ty_entry,
         k TYPE string,
         v TYPE string,
-      END OF ty_entry.
+      END OF ty_entry .
     TYPES:
-      ty_entries TYPE SORTED TABLE OF ty_entry WITH UNIQUE KEY k.
+      ty_entries TYPE SORTED TABLE OF ty_entry WITH UNIQUE KEY k .
+
+    DATA mt_entries TYPE ty_entries READ-ONLY .
 
     CLASS-METHODS create
       IMPORTING
-        iv_case_insensitive TYPE abap_bool DEFAULT abap_false
+        !iv_case_insensitive TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(ro_instance) TYPE REF TO zcl_abapgit_string_map.
+        VALUE(ro_instance)   TYPE REF TO zcl_abapgit_string_map .
     METHODS constructor
       IMPORTING
-        iv_case_insensitive TYPE abap_bool DEFAULT abap_false.
+        !iv_case_insensitive TYPE abap_bool DEFAULT abap_false .
     METHODS get
       IMPORTING
-        iv_key        TYPE string
+        !iv_key       TYPE string
       RETURNING
-        VALUE(rv_val) TYPE string.
+        VALUE(rv_val) TYPE string .
     METHODS has
       IMPORTING
-        iv_key        TYPE string
+        !iv_key       TYPE string
       RETURNING
-        VALUE(rv_has) TYPE abap_bool.
+        VALUE(rv_has) TYPE abap_bool .
     METHODS set
       IMPORTING
-        iv_key TYPE string
-        iv_val TYPE string OPTIONAL
+        !iv_key       TYPE string
+        !iv_val       TYPE csequence OPTIONAL
       RETURNING
         VALUE(ro_map) TYPE REF TO zcl_abapgit_string_map
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     METHODS size
       RETURNING
-        VALUE(rv_size) TYPE i.
+        VALUE(rv_size) TYPE i .
     METHODS is_empty
       RETURNING
-        VALUE(rv_yes) TYPE abap_bool.
+        VALUE(rv_yes) TYPE abap_bool .
     METHODS delete
       IMPORTING
-        iv_key TYPE string
+        !iv_key TYPE string
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     METHODS clear
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     METHODS to_abap
       CHANGING
         !cs_container TYPE any
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     METHODS strict
       IMPORTING
-        !iv_strict TYPE abap_bool DEFAULT abap_true
+        !iv_strict         TYPE abap_bool DEFAULT abap_true
       RETURNING
         VALUE(ro_instance) TYPE REF TO zcl_abapgit_string_map .
-    METHODS freeze.
-
-    DATA mt_entries TYPE ty_entries READ-ONLY.
-
+    METHODS freeze .
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA mv_read_only TYPE abap_bool.


### PR DESCRIPTION
so that character fields can be set() without any conversion

`##TYPE` pragma added to get rid of the boolc() warnings due to typing