### PR TITLE
http, add basic unit test

### DIFF
--- a/src/http/zcl_abapgit_http_agent.clas.abap
+++ b/src/http/zcl_abapgit_http_agent.clas.abap
@@ -4,14 +4,13 @@ CLASS zcl_abapgit_http_agent DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+
     INTERFACES zif_abapgit_http_agent .
 
     CLASS-METHODS create
       RETURNING
         VALUE(ri_instance) TYPE REF TO zif_abapgit_http_agent .
-
-    METHODS constructor.
-
+    METHODS constructor .
   PROTECTED SECTION.
   PRIVATE SECTION.
 

--- a/src/http/zcl_abapgit_http_agent.clas.testclasses.abap
+++ b/src/http/zcl_abapgit_http_agent.clas.testclasses.abap
@@ -1,0 +1,26 @@
+
+CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
+
+  PRIVATE SECTION.
+    METHODS create FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD create.
+
+    DATA li_agent TYPE REF TO zif_abapgit_http_agent.
+    DATA li_response TYPE REF TO zif_abapgit_http_response.
+
+    li_agent = zcl_abapgit_http_agent=>create( ).
+    li_response = li_agent->request( 'https://httpbin.org/get' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_response->is_ok( )
+      exp = abap_true ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/http/zcl_abapgit_http_agent.clas.xml
+++ b/src/http/zcl_abapgit_http_agent.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
note that this will trigger external communication in the unit tests by calling https://httpbin.org/get, but I cannot really think of other ways to test it properly

HTTP communication is central to abapGit communication, so need to get this under test so the git part can be put under test