### PR TITLE
suppress syntax warnings

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -73,7 +73,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_LOCL IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -172,22 +172,22 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
       iv_val = ms_settings-display_name ).
     mo_form_data->set(
       iv_key = c_id-ignore_subpackages
-      iv_val = boolc( ms_settings-ignore_subpackages = abap_true ) ).
+      iv_val = boolc( ms_settings-ignore_subpackages = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-serialize_master_lang_only
-      iv_val = boolc( ms_settings-serialize_master_lang_only = abap_true ) ).
+      iv_val = boolc( ms_settings-serialize_master_lang_only = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-write_protected
-      iv_val = boolc( ms_settings-write_protected = abap_true ) ).
+      iv_val = boolc( ms_settings-write_protected = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-only_local_objects
-      iv_val = boolc( ms_settings-only_local_objects = abap_true ) ).
+      iv_val = boolc( ms_settings-only_local_objects = abap_true ) ) ##TYPE.
     mo_form_data->set(
       iv_key = c_id-code_inspector_check_variant
       iv_val = |{ ms_settings-code_inspector_check_variant }| ).
     mo_form_data->set(
       iv_key = c_id-block_commit
-      iv_val = boolc( ms_settings-block_commit = abap_true ) ).
+      iv_val = boolc( ms_settings-block_commit = abap_true ) ) ##TYPE.
 
     " Set for is_dirty check
     mo_form_util->set_data( mo_form_data ).


### PR DESCRIPTION
suppress following syntax warnings, its not possible to use `xsdbool` on 702

![image](https://user-images.githubusercontent.com/5888506/104163954-7e8b0680-53f7-11eb-92fb-da267e3f86cd.png)
