### PR TITLE
Remove dependency on persistence interface from exits

### DIFF
--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -70,13 +70,13 @@ INTERFACE zif_abapgit_exit
     CHANGING
       !ct_ci_repos TYPE ty_ci_repos .
   METHODS adjust_display_commit_url
-    IMPORTING 
+    IMPORTING
       !iv_repo_url    TYPE csequence
       !iv_repo_name   TYPE csequence
       !iv_repo_key    TYPE csequence
       !iv_commit_hash TYPE zif_abapgit_definitions=>ty_sha1
-    CHANGING  
+    CHANGING
       !cv_display_url TYPE csequence
-    RAISING   
+    RAISING
       zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -70,10 +70,13 @@ INTERFACE zif_abapgit_exit
     CHANGING
       !ct_ci_repos TYPE ty_ci_repos .
   METHODS adjust_display_commit_url
-    IMPORTING !iv_repo_url    TYPE zif_abapgit_persistence=>ty_repo-url
-              !iv_repo_name   TYPE string
-              !iv_repo_key    TYPE zif_abapgit_persistence=>ty_value
-              !iv_commit_hash TYPE zif_abapgit_definitions=>ty_sha1
-    CHANGING  !cv_display_url TYPE zif_abapgit_persistence=>ty_repo-url
-    RAISING   zcx_abapgit_exception .
+    IMPORTING 
+      !iv_repo_url    TYPE csequence
+      !iv_repo_name   TYPE csequence
+      !iv_repo_key    TYPE csequence
+      !iv_commit_hash TYPE zif_abapgit_definitions=>ty_sha1
+    CHANGING  
+      !cv_display_url TYPE csequence
+    RAISING   
+      zcx_abapgit_exception .
 ENDINTERFACE.


### PR DESCRIPTION
Minor adjustment to exit interface (`zif_abapgit_exit`)