### PR TITLE
W3xx: Add object to transport on uninstall

### DIFF
--- a/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
@@ -182,6 +182,8 @@ CLASS zcl_abapgit_object_w3xx_super IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Cannot delete W3xx params' ).
     ENDIF.
 
+    corr_insert( iv_package ).
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Fix missing transport entry when uninstalling `w3mi` and `w3ht`.