### PR TITLE
Uninstall ENQU before TABL

### DIFF
--- a/src/objects/core/zcl_abapgit_dependencies.clas.abap
+++ b/src/objects/core/zcl_abapgit_dependencies.clas.abap
@@ -102,6 +102,9 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
           ELSE.
             <ls_tadir>-korrnum = '750000'.
           ENDIF.
+        WHEN 'ENQU'.
+          " ENQU before TABL
+          <ls_tadir>-korrnum = '725000'.
         WHEN 'DDLS'.
           " DDLS after DCLS but before other DDIC
           <ls_tadir>-korrnum = '720000'.


### PR DESCRIPTION
Lock objects must be uninstalled before corresponding tables