### PR TITLE
NSPC: Add warning if namespace does not exist

### DIFF
--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -22,45 +22,88 @@ CLASS zcl_abapgit_file_status DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    CLASS-METHODS: calculate_status
-        IMPORTING iv_devclass       TYPE devclass
-                  io_dot            TYPE REF TO zcl_abapgit_dot_abapgit
-                  it_local          TYPE zif_abapgit_definitions=>ty_files_item_tt
-                  it_remote         TYPE zif_abapgit_definitions=>ty_files_tt
-                  it_cur_state      TYPE zif_abapgit_definitions=>ty_file_signatures_tt
-        RETURNING VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
-        RAISING   zcx_abapgit_exception,
-      run_checks
-        IMPORTING ii_log     TYPE REF TO zif_abapgit_log
-                  it_results TYPE zif_abapgit_definitions=>ty_results_tt
-                  io_dot     TYPE REF TO zcl_abapgit_dot_abapgit
-                  iv_top     TYPE devclass
-        RAISING   zcx_abapgit_exception,
-      build_existing
-        IMPORTING is_local         TYPE zif_abapgit_definitions=>ty_file_item
-                  is_remote        TYPE zif_abapgit_definitions=>ty_file
-                  it_state         TYPE zif_abapgit_definitions=>ty_file_signatures_ts
-        RETURNING VALUE(rs_result) TYPE zif_abapgit_definitions=>ty_result,
-      build_new_local
-        IMPORTING is_local         TYPE zif_abapgit_definitions=>ty_file_item
-        RETURNING VALUE(rs_result) TYPE zif_abapgit_definitions=>ty_result,
-      build_new_remote
-        IMPORTING iv_devclass      TYPE devclass
-                  io_dot           TYPE REF TO zcl_abapgit_dot_abapgit
-                  is_remote        TYPE zif_abapgit_definitions=>ty_file
-                  it_items         TYPE zif_abapgit_definitions=>ty_items_ts
-                  it_state         TYPE zif_abapgit_definitions=>ty_file_signatures_ts
-        RETURNING VALUE(rs_result) TYPE zif_abapgit_definitions=>ty_result
-        RAISING   zcx_abapgit_exception,
-      get_object_package
-        IMPORTING
-          iv_object          TYPE tadir-object
-          iv_obj_name        TYPE tadir-obj_name
-        RETURNING
-          VALUE(rv_devclass) TYPE devclass
-        RAISING
-          zcx_abapgit_exception .
-
+    CLASS-METHODS calculate_status
+      IMPORTING
+        !iv_devclass      TYPE devclass
+        !io_dot           TYPE REF TO zcl_abapgit_dot_abapgit
+        !it_local         TYPE zif_abapgit_definitions=>ty_files_item_tt
+        !it_remote        TYPE zif_abapgit_definitions=>ty_files_tt
+        !it_cur_state     TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS run_checks
+      IMPORTING
+        !ii_log     TYPE REF TO zif_abapgit_log
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
+        !io_dot     TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_top     TYPE devclass
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS build_existing
+      IMPORTING
+        !is_local        TYPE zif_abapgit_definitions=>ty_file_item
+        !is_remote       TYPE zif_abapgit_definitions=>ty_file
+        !it_state        TYPE zif_abapgit_definitions=>ty_file_signatures_ts
+      RETURNING
+        VALUE(rs_result) TYPE zif_abapgit_definitions=>ty_result .
+    CLASS-METHODS build_new_local
+      IMPORTING
+        !is_local        TYPE zif_abapgit_definitions=>ty_file_item
+      RETURNING
+        VALUE(rs_result) TYPE zif_abapgit_definitions=>ty_result .
+    CLASS-METHODS build_new_remote
+      IMPORTING
+        !iv_devclass     TYPE devclass
+        !io_dot          TYPE REF TO zcl_abapgit_dot_abapgit
+        !is_remote       TYPE zif_abapgit_definitions=>ty_file
+        !it_items        TYPE zif_abapgit_definitions=>ty_items_ts
+        !it_state        TYPE zif_abapgit_definitions=>ty_file_signatures_ts
+      RETURNING
+        VALUE(rs_result) TYPE zif_abapgit_definitions=>ty_result
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS get_object_package
+      IMPORTING
+        !iv_object         TYPE tadir-object
+        !iv_obj_name       TYPE tadir-obj_name
+      RETURNING
+        VALUE(rv_devclass) TYPE devclass
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_package_move
+      IMPORTING
+        !ii_log     TYPE REF TO zif_abapgit_log
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_files_folder
+      IMPORTING
+        !ii_log     TYPE REF TO zif_abapgit_log
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_package_folder
+      IMPORTING
+        !ii_log     TYPE REF TO zif_abapgit_log
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
+        !io_dot     TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_top     TYPE devclass
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_multiple_files
+      IMPORTING
+        !ii_log     TYPE REF TO zif_abapgit_log
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_namespace
+      IMPORTING
+        !ii_log     TYPE REF TO zif_abapgit_log
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 
@@ -356,6 +399,178 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD check_files_folder.
+
+    DATA:
+      ls_item     TYPE zif_abapgit_definitions=>ty_item,
+      lt_res_sort LIKE it_results,
+      lt_item_idx LIKE it_results.
+
+    FIELD-SYMBOLS:
+      <ls_result>     LIKE LINE OF it_results,
+      <ls_result_idx> LIKE LINE OF it_results.
+
+    " Collect object index
+    lt_res_sort = it_results.
+    SORT lt_res_sort BY obj_type ASCENDING obj_name ASCENDING.
+
+    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL AND packmove = abap_false.
+
+      IF NOT ( <ls_result>-obj_type = ls_item-obj_type
+          AND <ls_result>-obj_name = ls_item-obj_name ).
+        APPEND INITIAL LINE TO lt_item_idx ASSIGNING <ls_result_idx>.
+        <ls_result_idx>-obj_type = <ls_result>-obj_type.
+        <ls_result_idx>-obj_name = <ls_result>-obj_name.
+        <ls_result_idx>-path     = <ls_result>-path.
+        MOVE-CORRESPONDING <ls_result> TO ls_item.
+      ENDIF.
+
+    ENDLOOP.
+
+    LOOP AT it_results ASSIGNING <ls_result>
+      WHERE NOT obj_type IS INITIAL AND obj_type <> 'DEVC' AND packmove = abap_false.
+
+      READ TABLE lt_item_idx ASSIGNING <ls_result_idx>
+        WITH KEY obj_type = <ls_result>-obj_type obj_name = <ls_result>-obj_name
+        BINARY SEARCH. " Sorted above
+
+      IF sy-subrc <> 0 OR <ls_result>-path <> <ls_result_idx>-path. " All paths are same
+        ii_log->add( iv_msg = |Files for object { <ls_result>-obj_type } {
+                              <ls_result>-obj_name } are not placed in the same folder|
+                     iv_type = 'W'
+                     iv_rc   = '1' ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD check_multiple_files.
+
+    DATA:
+      lt_res_sort LIKE it_results,
+      ls_file     TYPE zif_abapgit_definitions=>ty_file_signature.
+
+    FIELD-SYMBOLS <ls_result> LIKE LINE OF it_results.
+
+    lt_res_sort = it_results.
+    SORT lt_res_sort BY filename ASCENDING.
+
+    LOOP AT lt_res_sort ASSIGNING <ls_result> WHERE obj_type <> 'DEVC' AND packmove = abap_false.
+      IF <ls_result>-filename IS NOT INITIAL AND <ls_result>-filename = ls_file-filename.
+        ii_log->add( iv_msg  = |Multiple files with same filename, { <ls_result>-filename }|
+                     iv_type = 'W'
+                     iv_rc   = '3' ).
+      ENDIF.
+
+      IF <ls_result>-filename IS INITIAL.
+        ii_log->add( iv_msg  = |Filename is empty for object { <ls_result>-obj_type } { <ls_result>-obj_name }|
+                     iv_type = 'W'
+                     iv_rc   = '4' ).
+      ENDIF.
+
+      MOVE-CORRESPONDING <ls_result> TO ls_file.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD check_namespace.
+
+    DATA:
+      lv_namespace TYPE namespace,
+      lt_namespace TYPE TABLE OF namespace.
+
+    FIELD-SYMBOLS <ls_result> LIKE LINE OF it_results.
+
+    " Collect all namespaces based on name of xml-files
+    LOOP AT it_results ASSIGNING <ls_result>.
+      FIND REGEX '#(.*)#.*\..*\.xml' IN <ls_result>-filename SUBMATCHES lv_namespace.
+      IF sy-subrc = 0.
+        lv_namespace = '/' && to_upper( lv_namespace ) && '/'.
+        COLLECT lv_namespace INTO lt_namespace.
+      ENDIF.
+    ENDLOOP.
+
+    LOOP AT lt_namespace INTO lv_namespace.
+      CALL FUNCTION 'TR_CHECK_NAMESPACE'
+        EXPORTING
+          iv_namespace        = lv_namespace
+        EXCEPTIONS
+          namespace_not_valid = 1
+          OTHERS              = 2.
+      IF sy-subrc <> 0.
+        ii_log->add( iv_msg  = |Namespace { lv_namespace } does not exist. Create it in transaction SE03|
+                     iv_type = 'W'
+                     iv_rc   = '6' ).
+      ENDIF.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD check_package_folder.
+
+    DATA:
+      lv_path         TYPE string,
+      lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
+
+    FIELD-SYMBOLS <ls_result> LIKE LINE OF it_results.
+
+    lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
+
+    LOOP AT it_results ASSIGNING <ls_result>
+      WHERE NOT package IS INITIAL AND NOT path IS INITIAL AND packmove = abap_false.
+
+      lv_path = lo_folder_logic->package_to_path(
+        iv_top     = iv_top
+        io_dot     = io_dot
+        iv_package = <ls_result>-package ).
+
+      IF lv_path <> <ls_result>-path.
+        ii_log->add( iv_msg = |Package and path does not match for object, {
+                       <ls_result>-obj_type } { <ls_result>-obj_name }|
+                     iv_type = 'W'
+                     iv_rc   = '2' ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD check_package_move.
+
+    DATA:
+      lt_move_idx LIKE it_results.
+
+    FIELD-SYMBOLS:
+      <ls_result>      LIKE LINE OF it_results,
+      <ls_result_move> LIKE LINE OF it_results.
+
+    LOOP AT it_results ASSIGNING <ls_result>
+      WHERE lstate = zif_abapgit_definitions=>c_state-added AND packmove = abap_true.
+
+      READ TABLE lt_move_idx TRANSPORTING NO FIELDS
+        WITH KEY obj_type = <ls_result>-obj_type obj_name = <ls_result>-obj_name
+        BINARY SEARCH. " Sorted since it_result is sorted
+      IF sy-subrc <> 0.
+        ii_log->add( iv_msg  = |Changed package assignment for object {
+                               <ls_result>-obj_type } { <ls_result>-obj_name }|
+                     iv_type = 'W'
+                     iv_rc   = '5' ).
+        APPEND INITIAL LINE TO lt_move_idx ASSIGNING <ls_result_move>.
+        <ls_result_move>-obj_type = <ls_result>-obj_type.
+        <ls_result_move>-obj_name = <ls_result>-obj_name.
+        <ls_result_move>-path     = <ls_result>-path.
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD get_object_package.
     DATA: lv_name    TYPE devclass,
           li_package TYPE REF TO zif_abapgit_sap_package.
@@ -412,128 +627,37 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
 
   METHOD run_checks.
 
-    DATA: lv_path         TYPE string,
-          ls_item         TYPE zif_abapgit_definitions=>ty_item,
-          ls_file         TYPE zif_abapgit_definitions=>ty_file_signature,
-          lt_res_sort     LIKE it_results,
-          lt_item_idx     LIKE it_results,
-          lt_move_idx     LIKE it_results,
-          lv_namespace    TYPE namespace,
-          lt_namespace    TYPE TABLE OF namespace,
-          lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
-
-    FIELD-SYMBOLS: <ls_res1> LIKE LINE OF it_results,
-                   <ls_res2> LIKE LINE OF it_results.
-
     " This method just adds messages to the log. No log, nothing to do here
     IF ii_log IS INITIAL.
       RETURN.
     ENDIF.
 
     " Find all objects which were assigned to a different package
-    LOOP AT it_results ASSIGNING <ls_res1>
-      WHERE lstate = zif_abapgit_definitions=>c_state-added AND packmove = abap_true.
-      READ TABLE lt_move_idx TRANSPORTING NO FIELDS
-        WITH KEY obj_type = <ls_res1>-obj_type obj_name = <ls_res1>-obj_name
-        BINARY SEARCH. " Sorted since it_result is sorted
-      IF sy-subrc <> 0.
-        ii_log->add( iv_msg  = |Changed package assignment for object { <ls_res1>-obj_type } { <ls_res1>-obj_name }|
-                     iv_type = 'W'
-                     iv_rc   = '5' ).
-        APPEND INITIAL LINE TO lt_move_idx ASSIGNING <ls_res2>.
-        <ls_res2>-obj_type = <ls_res1>-obj_type.
-        <ls_res2>-obj_name = <ls_res1>-obj_name.
-        <ls_res2>-path     = <ls_res1>-path.
-      ENDIF.
-    ENDLOOP.
-
-    " Collect object indexe
-    lt_res_sort = it_results.
-    SORT lt_res_sort BY obj_type ASCENDING obj_name ASCENDING.
-
-    LOOP AT it_results ASSIGNING <ls_res1> WHERE NOT obj_type IS INITIAL AND packmove = abap_false.
-      IF NOT ( <ls_res1>-obj_type = ls_item-obj_type
-          AND <ls_res1>-obj_name = ls_item-obj_name ).
-        APPEND INITIAL LINE TO lt_item_idx ASSIGNING <ls_res2>.
-        <ls_res2>-obj_type = <ls_res1>-obj_type.
-        <ls_res2>-obj_name = <ls_res1>-obj_name.
-        <ls_res2>-path     = <ls_res1>-path.
-        MOVE-CORRESPONDING <ls_res1> TO ls_item.
-      ENDIF.
-    ENDLOOP.
+    check_package_move(
+      ii_log     = ii_log
+      it_results = it_results ).
 
     " Check files for one object is in the same folder
-    LOOP AT it_results ASSIGNING <ls_res1>
-      WHERE NOT obj_type IS INITIAL AND obj_type <> 'DEVC' AND packmove = abap_false.
-      READ TABLE lt_item_idx ASSIGNING <ls_res2>
-        WITH KEY obj_type = <ls_res1>-obj_type obj_name = <ls_res1>-obj_name
-        BINARY SEARCH. " Sorted above
-
-      IF sy-subrc <> 0 OR <ls_res1>-path <> <ls_res2>-path. " All paths are same
-        ii_log->add( iv_msg = |Files for object { <ls_res1>-obj_type } {
-                       <ls_res1>-obj_name } are not placed in the same folder|
-                     iv_type = 'W'
-                     iv_rc   = '1' ).
-      ENDIF.
-    ENDLOOP.
+    check_files_folder(
+      ii_log     = ii_log
+      it_results = it_results ).
 
     " Check that objects are created in package corresponding to folder
-    lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
-    LOOP AT it_results ASSIGNING <ls_res1>
-      WHERE NOT package IS INITIAL AND NOT path IS INITIAL AND packmove = abap_false.
-      lv_path = lo_folder_logic->package_to_path(
-        iv_top     = iv_top
-        io_dot     = io_dot
-        iv_package = <ls_res1>-package ).
-      IF lv_path <> <ls_res1>-path.
-        ii_log->add( iv_msg = |Package and path does not match for object, {
-                       <ls_res1>-obj_type } { <ls_res1>-obj_name }|
-                     iv_type = 'W'
-                     iv_rc   = '2' ).
-      ENDIF.
-    ENDLOOP.
+    check_package_folder(
+      ii_log     = ii_log
+      it_results = it_results
+      io_dot     = io_dot
+      iv_top     = iv_top ).
 
     " Check for multiple files with same filename
-    SORT lt_res_sort BY filename ASCENDING.
-
-    LOOP AT lt_res_sort ASSIGNING <ls_res1> WHERE obj_type <> 'DEVC' AND packmove = abap_false.
-      IF <ls_res1>-filename IS NOT INITIAL AND <ls_res1>-filename = ls_file-filename.
-        ii_log->add( iv_msg  = |Multiple files with same filename, { <ls_res1>-filename }|
-                     iv_type = 'W'
-                     iv_rc   = '3' ).
-      ENDIF.
-
-      IF <ls_res1>-filename IS INITIAL.
-        ii_log->add( iv_msg  = |Filename is empty for object { <ls_res1>-obj_type } { <ls_res1>-obj_name }|
-                     iv_type = 'W'
-                     iv_rc   = '4' ).
-      ENDIF.
-
-      MOVE-CORRESPONDING <ls_res1> TO ls_file.
-    ENDLOOP.
+    check_multiple_files(
+      ii_log     = ii_log
+      it_results = it_results ).
 
     " Check if namespaces exist already
-    LOOP AT it_results ASSIGNING <ls_res1>.
-      FIND REGEX '#(.*)#.*\..*\.xml' IN <ls_res1>-filename SUBMATCHES lv_namespace.
-      IF sy-subrc = 0.
-        lv_namespace = '/' && to_upper( lv_namespace ) && '/'.
-        COLLECT lv_namespace INTO lt_namespace.
-      ENDIF.
-    ENDLOOP.
-
-    LOOP AT lt_namespace INTO lv_namespace.
-      CALL FUNCTION 'TR_CHECK_NAMESPACE'
-        EXPORTING
-          iv_namespace        = lv_namespace
-        EXCEPTIONS
-          namespace_not_valid = 1
-          OTHERS              = 2.
-      IF sy-subrc <> 0.
-        ii_log->add( iv_msg  = |Namespace { lv_namespace } does not exist. Create it in transaction SE03|
-                     iv_type = 'W'
-                     iv_rc   = '6' ).
-      ENDIF.
-    ENDLOOP.
+    check_namespace(
+      ii_log     = ii_log
+      it_results = it_results ).
 
   ENDMETHOD.
 

--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -531,7 +531,7 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
       IF sy-subrc <> 0.
         ii_log->add( iv_msg  = |Namespace { lv_namespace } does not exist. Create it in transaction SE03|
                      iv_type = 'W'
-                     iv_rc   = '5' ).
+                     iv_rc   = '6' ).
       ENDIF.
     ENDLOOP.
 

--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -514,7 +514,7 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
 
     " Check if namespaces exist already
     LOOP AT it_results ASSIGNING <ls_res1>.
-      FIND REGEX '#(.*)#\..*\.xml' IN <ls_res1>-filename SUBMATCHES lv_namespace.
+      FIND REGEX '#(.*)#.*\..*\.xml' IN <ls_res1>-filename SUBMATCHES lv_namespace.
       IF sy-subrc = 0.
         lv_namespace = '/' && to_upper( lv_namespace ) && '/'.
         COLLECT lv_namespace INTO lt_namespace.

--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -514,7 +514,7 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
 
     " Check if namespaces exist already
     LOOP AT it_results ASSIGNING <ls_res1>.
-      FIND REGEX '#(.*)#' IN <ls_res1>-filename SUBMATCHES lv_namespace.
+      FIND REGEX '#(.*)#\..*\.xml' IN <ls_res1>-filename SUBMATCHES lv_namespace.
       IF sy-subrc = 0.
         lv_namespace = '/' && to_upper( lv_namespace ) && '/'.
         COLLECT lv_namespace INTO lt_namespace.

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -25,8 +25,8 @@ CLASS ltcl_run_checks DEFINITION FOR TESTING RISK LEVEL HARMLESS
       neg_incorrect_path_vs_pack FOR TESTING RAISING zcx_abapgit_exception,
       neg_similar_filenames FOR TESTING RAISING zcx_abapgit_exception,
       neg_empty_filenames FOR TESTING RAISING zcx_abapgit_exception,
-      check_namespace FOR TESTING RAISING zcx_abapgit_exception,
-      package_move FOR TESTING RAISING zcx_abapgit_exception.
+      package_move FOR TESTING RAISING zcx_abapgit_exception,
+      check_namespace FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -325,34 +325,6 @@ CLASS ltcl_run_checks IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD check_namespace.
-
-    " 5 Missing namespace
-    append_result( iv_obj_type = 'CLAS'
-                   iv_obj_name = '/NOTEXIST/ZCLASS1'
-                   iv_match    = ' '
-                   iv_lstate   = ' '
-                   iv_rstate   = 'A'
-                   iv_package  = '/NOTEXIST/Z'
-                   iv_path     = '/'
-                   iv_filename = '#notexist#zclass1.clas.abap' ).
-
-    zcl_abapgit_file_status=>run_checks(
-      ii_log     = mi_log
-      it_results = mt_results
-      io_dot     = mo_dot
-      iv_top     = '/NOTEXIST/Z' ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = mi_log->count( )
-      exp = 1 ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = mi_log->has_rc( '5' )
-      exp = abap_true ).
-
-  ENDMETHOD.
-
   METHOD package_move.
 
     " 5 Changed package assignment
@@ -429,6 +401,34 @@ CLASS ltcl_run_checks IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       act = mi_log->has_rc( '5' )
+      exp = abap_true ).
+
+  ENDMETHOD.
+
+  METHOD check_namespace.
+
+    " 5 Missing namespace
+    append_result( iv_obj_type = 'CLAS'
+                   iv_obj_name = '/NOTEXIST/ZCLASS1'
+                   iv_match    = ' '
+                   iv_lstate   = ' '
+                   iv_rstate   = 'A'
+                   iv_package  = '/NOTEXIST/Z'
+                   iv_path     = '/'
+                   iv_filename = '#notexist#zclass1.clas.xml' ).
+
+    zcl_abapgit_file_status=>run_checks(
+      ii_log     = mi_log
+      it_results = mt_results
+      io_dot     = mo_dot
+      iv_top     = '/NOTEXIST/Z' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_log->count( )
+      exp = 1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_log->has_rc( '6' )
       exp = abap_true ).
 
   ENDMETHOD.

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -25,6 +25,7 @@ CLASS ltcl_run_checks DEFINITION FOR TESTING RISK LEVEL HARMLESS
       neg_incorrect_path_vs_pack FOR TESTING RAISING zcx_abapgit_exception,
       neg_similar_filenames FOR TESTING RAISING zcx_abapgit_exception,
       neg_empty_filenames FOR TESTING RAISING zcx_abapgit_exception,
+      check_namespace FOR TESTING RAISING zcx_abapgit_exception,
       package_move FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
@@ -320,6 +321,34 @@ CLASS ltcl_run_checks IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       act = mi_log->has_rc( '4' )
+      exp = abap_true ).
+
+  ENDMETHOD.
+
+  METHOD check_namespace.
+
+    " 5 Missing namespace
+    append_result( iv_obj_type = 'CLAS'
+                   iv_obj_name = '/NOTEXIST/ZCLASS1'
+                   iv_match    = ' '
+                   iv_lstate   = ' '
+                   iv_rstate   = 'A'
+                   iv_package  = '/NOTEXIST/Z'
+                   iv_path     = '/'
+                   iv_filename = '#notexist#zclass1.clas.abap' ).
+
+    zcl_abapgit_file_status=>run_checks(
+      ii_log     = mi_log
+      it_results = mt_results
+      io_dot     = mo_dot
+      iv_top     = '/NOTEXIST/Z' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_log->count( )
+      exp = 1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_log->has_rc( '5' )
       exp = abap_true ).
 
   ENDMETHOD.

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -407,7 +407,7 @@ CLASS ltcl_run_checks IMPLEMENTATION.
 
   METHOD check_namespace.
 
-    " 5 Missing namespace
+    " 6 Missing namespace
     append_result( iv_obj_type = 'CLAS'
                    iv_obj_name = '/NOTEXIST/ZCLASS1'
                    iv_match    = ' '


### PR DESCRIPTION
Part 1 of #835

If a repo contains objects in a namespace and the namespace does not exist in the local system, then a warning is shown pointing to SE03.

Test https://github.com/mbtools/TEST_MISSING_NSPC

![image](https://user-images.githubusercontent.com/59966492/104858320-346cbe00-58ec-11eb-8b8b-ae87f03d5689.png)
