### PR TITLE
refactor ZCL_ABAPGIT_TIME

### DIFF
--- a/src/utils/zcl_abapgit_time.clas.abap
+++ b/src/utils/zcl_abapgit_time.clas.abap
@@ -4,78 +4,57 @@ CLASS zcl_abapgit_time DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-    TYPES: ty_unixtime TYPE c LENGTH 16.
+
+    TYPES:
+      ty_unixtime TYPE c LENGTH 16 .
 
     CLASS-METHODS get_unix
-      IMPORTING iv_date        TYPE sy-datum DEFAULT sy-datum
-                iv_time        TYPE sy-uzeit DEFAULT sy-uzeit
-      RETURNING VALUE(rv_time) TYPE ty_unixtime
-      RAISING   zcx_abapgit_exception.
+      RETURNING
+        VALUE(rv_time) TYPE ty_unixtime
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS get_utc
-      IMPORTING iv_unix TYPE ty_unixtime
-      EXPORTING ev_date TYPE sy-datum
-                ev_time TYPE sy-uzeit.
+      IMPORTING
+        !iv_unix TYPE ty_unixtime
+      EXPORTING
+        !ev_date TYPE sy-datum
+        !ev_time TYPE sy-uzeit .
   PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS: c_epoch TYPE d VALUE '19700101'.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_time IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_TIME IMPLEMENTATION.
 
 
   METHOD get_unix.
+* returns seconds since unix epoch
 
-    DATA: lv_i       TYPE i,
-          lv_tz      TYPE tznzone,
-          lv_utcdiff TYPE tznutcdiff,
-          lv_utcsign TYPE tznutcsign.
+    CONSTANTS lc_epoch TYPE timestamp VALUE '19700101000000'.
+    DATA lv_time TYPE timestamp.
+    DATA lv_seconds TYPE tzntstmpl.
 
+    GET TIME STAMP FIELD lv_time.
 
-    lv_i = iv_date - c_epoch.
-    lv_i = lv_i * 86400.
-    lv_i = lv_i + iv_time.
+    lv_seconds = cl_abap_tstmp=>subtract(
+      tstmp1 = lv_time
+      tstmp2 = lc_epoch ).
 
-    CALL FUNCTION 'TZON_GET_OS_TIMEZONE'
-      IMPORTING
-        ef_timezone = lv_tz.
-
-    CALL FUNCTION 'TZON_GET_OFFSET'
-      EXPORTING
-        if_timezone      = lv_tz
-        if_local_date    = iv_date
-        if_local_time    = iv_time
-      IMPORTING
-        ef_utcdiff       = lv_utcdiff
-        ef_utcsign       = lv_utcsign
-      EXCEPTIONS
-        conversion_error = 1
-        OTHERS           = 2.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'Timezone error' ).
-    ENDIF.
-
-    CASE lv_utcsign.
-      WHEN '+'.
-        lv_i = lv_i - lv_utcdiff.
-      WHEN '-'.
-        lv_i = lv_i + lv_utcdiff.
-    ENDCASE.
-
-    rv_time = lv_i.
+    rv_time = round( val = lv_seconds dec = 0 ).
     CONDENSE rv_time.
-    rv_time+11 = lv_utcsign.
-    rv_time+12 = lv_utcdiff.
+    rv_time+11 = '+000000'.
 
   ENDMETHOD.
 
 
   METHOD get_utc.
 
+    CONSTANTS lc_epoch TYPE d VALUE '19700101'.
+
     DATA: lv_i       TYPE i,
-          lv_utcdiff TYPE tznutcdiff,
-          lv_utcsign TYPE tznutcsign.
+          lv_utcdiff TYPE t,
+          lv_utcsign TYPE c LENGTH 1.
 
 
     lv_i = iv_unix(10).
@@ -93,7 +72,7 @@ CLASS zcl_abapgit_time IMPLEMENTATION.
     ev_time = lv_i MOD 86400.
     lv_i = lv_i - ev_time.
     lv_i = lv_i / 86400.
-    ev_date = lv_i + c_epoch.
+    ev_date = lv_i + lc_epoch.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_time.clas.abap
+++ b/src/utils/zcl_abapgit_time.clas.abap
@@ -29,7 +29,7 @@ CLASS ZCL_ABAPGIT_TIME IMPLEMENTATION.
 
 
   METHOD get_unix.
-* returns seconds since unix epoch
+* returns seconds since unix epoch, including timezone indicator
 
     CONSTANTS lc_epoch TYPE timestamp VALUE '19700101000000'.
     DATA lv_time TYPE timestamp.
@@ -41,7 +41,8 @@ CLASS ZCL_ABAPGIT_TIME IMPLEMENTATION.
       tstmp1 = lv_time
       tstmp2 = lc_epoch ).
 
-    rv_time = round( val = lv_seconds dec = 0 ).
+    rv_time = round( val = lv_seconds
+                     dec = 0 ).
     CONDENSE rv_time.
     rv_time+11 = '+000000'.
 

--- a/src/utils/zcl_abapgit_time.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_time.clas.testclasses.abap
@@ -15,9 +15,7 @@ CLASS ltcl_time_test IMPLEMENTATION.
 
     DATA: lv_time TYPE zcl_abapgit_time=>ty_unixtime.
 
-    lv_time = zcl_abapgit_time=>get_unix(
-      iv_date = sy-datum
-      iv_time = sy-uzeit ).
+    lv_time = zcl_abapgit_time=>get_unix( ).
 
     cl_abap_unit_assert=>assert_not_initial( lv_time ).
 


### PR DESCRIPTION
#4443
much less code, and uses `cl_abap_tstmp` instead of random function modules

inputs to method `get_unix` removed, as they were not used from anywhere

can someone help checking if this works on 702? ie. no syntax errors on 702