### PR TITLE
Fix status calculation on package move

### DIFF
--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -6,19 +6,24 @@ CLASS zcl_abapgit_file_status DEFINITION
   PUBLIC SECTION.
 
     CLASS-METHODS status
-      IMPORTING io_repo           TYPE REF TO zcl_abapgit_repo
-                ii_log            TYPE REF TO zif_abapgit_log OPTIONAL
-      RETURNING VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING   zcx_abapgit_exception.
-    CLASS-METHODS: identify_object
-        IMPORTING iv_filename TYPE string
-                  iv_path     TYPE string
-                  iv_devclass TYPE devclass OPTIONAL
-                  io_dot      TYPE REF TO zcl_abapgit_dot_abapgit
-        EXPORTING es_item     TYPE zif_abapgit_definitions=>ty_item
-                  ev_is_xml   TYPE abap_bool
-        RAISING   zcx_abapgit_exception.
-
+      IMPORTING
+        !io_repo          TYPE REF TO zcl_abapgit_repo
+        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS identify_object
+      IMPORTING
+        !iv_filename TYPE string
+        !iv_path     TYPE string
+        !iv_devclass TYPE devclass OPTIONAL
+        !io_dot      TYPE REF TO zcl_abapgit_dot_abapgit
+      EXPORTING
+        !es_item     TYPE zif_abapgit_definitions=>ty_item
+        !ev_is_xml   TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
 

--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -375,11 +375,13 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
       " Check if same file exists in different location
       READ TABLE it_local ASSIGNING <ls_local>
         WITH KEY file-filename = <ls_remote>-filename.
-      IF sy-subrc = 0 AND <ls_local>-file-sha1 = <ls_remote>-sha1.
+      IF sy-subrc = 0.
         <ls_result>-match = abap_false.
         <ls_result>-lstate = zif_abapgit_definitions=>c_state-deleted.
         <ls_result>-rstate = zif_abapgit_definitions=>c_state-unchanged.
-        <ls_result>-packmove = abap_true.
+        IF <ls_local>-file-sha1 = <ls_remote>-sha1.
+          <ls_result>-packmove = abap_true.
+        ENDIF.
       ELSEIF sy-subrc = 4.
         " Check if file existed before and was deleted locally
         READ TABLE lt_state_idx ASSIGNING <ls_state>
@@ -394,7 +396,8 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
     SORT rt_results BY
       obj_type ASCENDING
       obj_name ASCENDING
-      filename ASCENDING.
+      filename ASCENDING
+      path ASCENDING.
 
   ENDMETHOD.
 

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -664,6 +664,9 @@ CLASS ltcl_calculate_status DEFINITION FOR TESTING RISK LEVEL HARMLESS
       moved FOR TESTING RAISING zcx_abapgit_exception,
       local_outside_main FOR TESTING RAISING zcx_abapgit_exception,
       complete FOR TESTING RAISING zcx_abapgit_exception,
+      complete_local,
+      complete_remote,
+      complete_state,
       deleted_remotely FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
@@ -808,12 +811,7 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD complete.
-
-    DATA:
-      ls_line TYPE zif_abapgit_definitions=>ty_result,
-      lv_act  TYPE c LENGTH 4,
-      lv_exp  TYPE c LENGTH 4.
+  METHOD complete_local.
 
     mo_helper->add_local(
       iv_path     = '/'
@@ -883,6 +881,10 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/sub/'
       iv_filename = 'ztest_move_package_w_change.prog.xml'
       iv_sha1     = '1042' ).
+
+  ENDMETHOD.
+
+  METHOD complete_remote.
 
     mo_helper->add_remote(
       iv_path     = '/'
@@ -956,6 +958,10 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/'
       iv_filename = 'ztest_move_package_w_change.prog.xml'
       iv_sha1     = '2042' ).
+
+  ENDMETHOD.
+
+  METHOD complete_state.
 
     mo_helper->add_state(
       iv_path     = '/'
@@ -1034,6 +1040,19 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_filename = 'ztest_move_package_w_change.prog.xml'
       iv_sha1     = '1042' ).
 
+  ENDMETHOD.
+
+  METHOD complete.
+
+    DATA:
+      ls_line TYPE zif_abapgit_definitions=>ty_result,
+      lv_act  TYPE c LENGTH 4,
+      lv_exp  TYPE c LENGTH 4.
+
+    complete_local( ).
+    complete_remote( ).
+    complete_state( ).
+
     mo_result = mo_helper->run( ).
 
     mo_result->assert_lines( 26 ).
@@ -1048,33 +1067,33 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
         WHEN 1.
           lv_exp = 'X  '. " no changes
         WHEN 2.
-          lv_exp = '  A'. " add remotely
+          lv_exp = '  A'. " add remote
         WHEN 3.
           lv_exp = 'X  '. " no change
         WHEN 4 OR 5.
-          lv_exp = ' A '. " add locally
+          lv_exp = ' A '. " add local
         WHEN 6 OR 7.
-          lv_exp = '  A'. " add remotely
+          lv_exp = '  A'. " add remote
         WHEN 8 OR 9.
-          lv_exp = ' DM'.
+          lv_exp = ' DM'. " delete local, modify remote
         WHEN 10 OR 11.
-          lv_exp = ' D '.
+          lv_exp = ' D '. " delete local
         WHEN 12 OR 13.
-          lv_exp = '  D'.
+          lv_exp = '  D'. " delete remote
         WHEN 14 OR 15.
-          lv_exp = ' MD'.
+          lv_exp = ' MD'. " modify local, delete remote
         WHEN 16 OR 17.
-          lv_exp = ' MM'.
+          lv_exp = ' MM'. " modify both sides
         WHEN 18 OR 19.
-          lv_exp = ' M '.
+          lv_exp = ' M '. " modify local
         WHEN 20 OR 21.
-          lv_exp = '  M'.
+          lv_exp = '  M'. " modify remote
         WHEN 22.
           lv_exp = ' D X'. " package move (no change)
         WHEN 23.
           lv_exp = ' D  '. " package move with change
         WHEN 24.
-          lv_exp = 'X   '.
+          lv_exp = 'X   '. " no chagen
         WHEN 25.
           lv_exp = ' A X'. " package move (no change)
         WHEN 26.

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -879,6 +879,10 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/sub/'
       iv_filename = 'package.devc.xml'
       iv_sha1     = '1041' ).
+    mo_helper->add_local(
+      iv_path     = '/src/sub/'
+      iv_filename = 'ztest_move_package_w_change.prog.xml'
+      iv_sha1     = '1042' ).
 
     mo_helper->add_remote(
       iv_path     = '/'
@@ -948,6 +952,10 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/sub/'
       iv_filename = 'package.devc.xml'
       iv_sha1     = '1041' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_move_package_w_change.prog.xml'
+      iv_sha1     = '2042' ).
 
     mo_helper->add_state(
       iv_path     = '/'
@@ -1021,12 +1029,16 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/sub/'
       iv_filename = 'package.devc.xml'
       iv_sha1     = '1041' ).
+    mo_helper->add_state(
+      iv_path     = '/src/sub/'
+      iv_filename = 'ztest_move_package_w_change.prog.xml'
+      iv_sha1     = '1042' ).
 
     mo_result = mo_helper->run( ).
 
-    mo_result->assert_lines( 24 ).
+    mo_result->assert_lines( 26 ).
 
-    DO 24 TIMES.
+    DO 26 TIMES.
       ls_line = mo_result->get_line( sy-index ).
       lv_act+0(1) = ls_line-match.
       lv_act+1(1) = ls_line-lstate.
@@ -1034,15 +1046,15 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       lv_act+3(1) = ls_line-packmove.
       CASE sy-index.
         WHEN 1.
-          lv_exp = 'X  '.
+          lv_exp = 'X  '. " no changes
         WHEN 2.
-          lv_exp = '  A'.
+          lv_exp = '  A'. " add remotely
         WHEN 3.
-          lv_exp = 'X  '.
+          lv_exp = 'X  '. " no change
         WHEN 4 OR 5.
-          lv_exp = ' A '.
+          lv_exp = ' A '. " add locally
         WHEN 6 OR 7.
-          lv_exp = '  A'.
+          lv_exp = '  A'. " add remotely
         WHEN 8 OR 9.
           lv_exp = ' DM'.
         WHEN 10 OR 11.
@@ -1058,11 +1070,15 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
         WHEN 20 OR 21.
           lv_exp = '  M'.
         WHEN 22.
-          lv_exp = ' D X'.
+          lv_exp = ' D X'. " package move (no change)
         WHEN 23.
-          lv_exp = 'X   '.
+          lv_exp = ' D  '. " package move with change
         WHEN 24.
-          lv_exp = ' A X'.
+          lv_exp = 'X   '.
+        WHEN 25.
+          lv_exp = ' A X'. " package move (no change)
+        WHEN 26.
+          lv_exp = ' A  '. " package move with change
       ENDCASE.
 
       cl_abap_unit_assert=>assert_equals(


### PR DESCRIPTION
If an object is moved to another package *and* changed, the status was "blank". Now the object status is properly shown as "added/deleted". Also the `packmove` flag is *not* set anymore since a simple `tadir` change would not be sufficient. 

Extended unit test to cover this case
