### PR TITLE
ACID: Avoid "no changes found" popup

### DIFF
--- a/src/objects/zcl_abapgit_object_acid.clas.abap
+++ b/src/objects/zcl_abapgit_object_acid.clas.abap
@@ -14,7 +14,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_ACID IMPLEMENTATION.
+CLASS zcl_abapgit_object_acid IMPLEMENTATION.
 
 
   METHOD create_object.
@@ -49,7 +49,15 @@ CLASS ZCL_ABAPGIT_OBJECT_ACID IMPLEMENTATION.
 
 
     lo_aab = create_object( ).
-    lo_aab->enqueue( ).
+    lo_aab->enqueue(
+      EXCEPTIONS
+        foreign_lock = 1
+        system_error = 2
+        cts_error    = 3
+        others       = 4 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
     lo_aab->delete(
       EXCEPTIONS
         prop_error       = 1
@@ -63,7 +71,7 @@ CLASS ZCL_ABAPGIT_OBJECT_ACID IMPLEMENTATION.
         where_used_error = 9
         OTHERS           = 10 ).
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error deleting ACID object' ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
     lo_aab->dequeue( ).
 
@@ -77,13 +85,48 @@ CLASS ZCL_ABAPGIT_OBJECT_ACID IMPLEMENTATION.
 
 
     io_xml->read( EXPORTING iv_name = 'DESCRIPTION'
-                  CHANGING cg_data = lv_description ).
+                  CHANGING  cg_data = lv_description ).
 
     lo_aab = create_object( ).
-    lo_aab->enqueue( ).
-    lo_aab->set_descript( lv_description ).
+
+    lo_aab->enqueue(
+      EXCEPTIONS
+        foreign_lock = 1
+        system_error = 2
+        cts_error    = 3
+        OTHERS       = 4 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+    lo_aab->set_descript(
+      EXPORTING
+        im_descript      = lv_description
+      EXCEPTIONS
+        no_authorization = 1
+        OTHERS           = 2 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
     tadir_insert( iv_package ).
-    lo_aab->save( ).
+
+    lo_aab->save(
+      EXCEPTIONS
+        no_descript_specified = 1
+        no_changes_found      = 2
+        prop_error            = 3
+        propt_error           = 4
+        act_error             = 5
+        cts_error             = 6
+        sync_attributes_error = 7
+        action_canceled       = 8
+        OTHERS                = 9 ).
+    IF sy-subrc >= 3.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+    lo_aab->dequeue( ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_acid.clas.abap
+++ b/src/objects/zcl_abapgit_object_acid.clas.abap
@@ -54,7 +54,7 @@ CLASS zcl_abapgit_object_acid IMPLEMENTATION.
         foreign_lock = 1
         system_error = 2
         cts_error    = 3
-        others       = 4 ).
+        OTHERS       = 4 ).
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.


### PR DESCRIPTION
- Fix "no changes found" popup (SAAB/006) in case identical object is deserialized again

![image](https://user-images.githubusercontent.com/59966492/106056375-98e20700-60bc-11eb-8b46-a3246324cbe1.png)

- Change to T100 messages
- Add missing dequeue