### PR TITLE
DEVC: Fix check if package is empty

### DIFF
--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -91,7 +91,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    " SOTR is linked to SAP packages (DEVC)
+    " Ignore the SOTR if is linked to the current SAP package (DEVC)
     SELECT SINGLE obj_name
            FROM tadir
            INTO lv_object_name

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -91,11 +91,12 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       RETURN.
     ENDIF.
 
+    " SOTR is linked to SAP packages (DEVC)
     SELECT SINGLE obj_name
            FROM tadir
            INTO lv_object_name
            WHERE pgmid = 'R3TR'
-           AND NOT ( object = 'DEVC' AND obj_name = iv_package_name )
+           AND NOT ( ( object = 'DEVC' OR object = 'SOTR' ) AND obj_name = iv_package_name )
            AND devclass = iv_package_name.
     rv_is_empty = boolc( sy-subrc <> 0 ).
 


### PR DESCRIPTION
SOTR object is linked to SAP package and removed together with the package on uninstall. Therefore, it should not be taken into account when checking if a package is empty.