### PR TITLE
Reduce flicker of status bar during deserialize

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -840,8 +840,6 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
         zcl_abapgit_objects_activation=>activate( abap_false ).
     ENDCASE.
 
-    li_progress->off( ).
-
 *   Call postprocessing
     li_exit = zcl_abapgit_exit=>get_instance( ).
 


### PR DESCRIPTION
The progress bar should not be turned off after `deserialize_object` (but only at end of `deserialize`).