### PR TITLE
Fix display of log after uninstall

### DIFF
--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -72,6 +72,8 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS refresh
       IMPORTING
         !iv_drop_cache TYPE abap_bool DEFAULT abap_false
+        !iv_drop_log   TYPE abap_bool DEFAULT abap_true
+          PREFERRED PARAMETER iv_drop_cache
       RAISING
         zcx_abapgit_exception .
     METHODS update_local_checksums
@@ -614,7 +616,9 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     mv_request_local_refresh = abap_true.
     reset_remote( ).
 
-    CLEAR mi_log.
+    IF iv_drop_log = abap_true.
+      CLEAR mi_log.
+    ENDIF.
 
     IF iv_drop_cache = abap_true.
       CLEAR mt_local.

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -514,8 +514,7 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
     DATA: lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
     DATA: lx_error TYPE REF TO zcx_abapgit_exception.
 
-    CREATE OBJECT ri_log TYPE zcl_abapgit_log.
-    ri_log->set_title( 'Uninstall Log' ).
+    ri_log = io_repo->create_new_log( 'Uninstall Log' ).
 
     IF io_repo->get_local_settings( )-write_protected = abap_true.
       zcx_abapgit_exception=>raise( 'Cannot purge. Local code is write-protected by repo config' ).
@@ -531,7 +530,7 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
                                      ii_log    = ri_log ).
       CATCH zcx_abapgit_exception INTO lx_error.
         " If uninstall fails, repo needs a refresh to show which objects where deleted and which not
-        io_repo->refresh( ).
+        io_repo->refresh( iv_drop_log = abap_false ).
         RAISE EXCEPTION lx_error.
     ENDTRY.
 


### PR DESCRIPTION
The uninstall log was dropped too early during refresh of repo. Now it's passed properly to the UI.