### PR TITLE
Deserialize: Commit changes before activation

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -66,6 +66,9 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
 
   METHOD activate.
 
+    " Make sure that all changes are committed since any activation error will lead to a rollback
+    COMMIT WORK AND WAIT.
+
     IF use_new_activation_logic( ) = abap_true.
       activate_new( iv_ddic ).
     ELSE.

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -388,6 +388,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
   METHOD deserialize_program.
 
     DATA: lv_exists      TYPE abap_bool,
+          lt_empty_src   LIKE it_source,
           lv_progname    TYPE reposrc-progname,
           ls_tpool       LIKE LINE OF it_tpool,
           lv_title       TYPE rglif-title,
@@ -457,14 +458,13 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 * to the current user which avoids the check
           zcx_abapgit_exception=>raise( |Delete function group and pull again, { is_progdir-name } (EU522)| ).
         ELSE.
-          zcx_abapgit_exception=>raise( |PROG { is_progdir-name }, updating error: { sy-msgid } { sy-msgno }| ).
+          zcx_abapgit_exception=>raise_t100( ).
         ENDIF.
       ENDIF.
 
       zcl_abapgit_language=>restore_login_language( ).
     ELSEIF strlen( is_progdir-name ) > 30.
 * function module RPY_PROGRAM_INSERT cannot handle function group includes
-
       " special treatment for extensions
       " if the program name exceeds 30 characters it is not a usual
       " ABAP program but might be some extension, which requires the internal
@@ -479,12 +479,24 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
         zcx_abapgit_exception=>raise( 'error from INSERT REPORT .. EXTENSION TYPE' ).
       ENDIF.
     ELSE.
-      INSERT REPORT is_progdir-name
-        FROM it_source
-        STATE 'I'
-        PROGRAM TYPE is_progdir-subc.
+      CALL FUNCTION 'RPY_PROGRAM_INSERT'
+        EXPORTING
+          development_class = iv_package
+          program_name      = is_progdir-name
+          program_type      = is_progdir-subc
+          title_string      = lv_title
+          save_inactive     = 'I'
+          suppress_dialog   = abap_true
+        TABLES
+          source_extended   = it_source
+        EXCEPTIONS
+          already_exists    = 1
+          cancelled         = 2
+          name_not_allowed  = 3
+          permission_error  = 4
+          OTHERS            = 5.
       IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( 'error from INSERT REPORT' ).
+        zcx_abapgit_exception=>raise_t100( ).
       ENDIF.
     ENDIF.
 


### PR DESCRIPTION
Some objects (like `prog` or `intf`) are deserialized as inactive objects i.e. uncommitted changes. Usually, these changes are committed to the database after the activation process (end of the session). However, if there are any errors during activation, an exception is raised which will automatically do a `rollback work`. 

This change will make sure that inactive objects are preserved even if the activation fails. One can then analyze the inactive objects, make necessary corrections, and activate them manually.

Closes #4500

PS: `insert report ... state 'I'` is not sufficient since such inactive code won't be recognized by ABAP editors. Even for new programs, at least some active code must exist or you get "Program does not exist" error (the system checks the `trdir` view which has a condition `r3state = 'A'`). Therefore, the standard function `RPY_PROGRAM_INSERT` is used to create the initial inactive program. 