### PR TITLE
Tweak HTTP error messages

### DIFF
--- a/src/http/zcl_abapgit_http_client.clas.abap
+++ b/src/http/zcl_abapgit_http_client.clas.abap
@@ -48,22 +48,24 @@ CLASS zcl_abapgit_http_client IMPLEMENTATION.
       WHEN 200.
         RETURN. " Success, OK
       WHEN 302.
-        zcx_abapgit_exception=>raise( 'Resource access temporarily redirected. Check the URL (HTTP 302)' ).
+        zcx_abapgit_exception=>raise( 'Resource access temporarily redirected (HTTP 302). Check the URL' ).
       WHEN 401.
-        zcx_abapgit_exception=>raise( 'Unauthorized access to resource. Check your credentials (HTTP 401)' ).
+        zcx_abapgit_exception=>raise( 'Unauthorized access to resource (HTTP 401). Check your credentials' ).
       WHEN 403.
         zcx_abapgit_exception=>raise( 'Access to resource forbidden (HTTP 403)' ).
       WHEN 404.
-        zcx_abapgit_exception=>raise( 'Resource not found. Check the URL (HTTP 404)' ).
+        zcx_abapgit_exception=>raise( 'Resource not found (HTTP 404). Check the URL' ).
       WHEN 407.
-        zcx_abapgit_exception=>raise( 'Proxy authentication required. Check your credentials (HTTP 407)' ).
+        zcx_abapgit_exception=>raise( 'Proxy authentication required (HTTP 407). Check your credentials' ).
       WHEN 408.
         zcx_abapgit_exception=>raise( 'Request timeout (HTTP 408)' ).
       WHEN 415.
         zcx_abapgit_exception=>raise( 'Unsupported media type (HTTP 415)' ).
+      WHEN 422.
+        zcx_abapgit_exception=>raise( 'Unprocessable entity (HTTP 422). Check the URL (it might have to end with ".git")' ).
       WHEN OTHERS.
         lv_text = mi_client->response->get_cdata( ).
-        zcx_abapgit_exception=>raise( |{ lv_text } (HTTP { lv_code })| ).
+        zcx_abapgit_exception=>raise( |(HTTP { lv_code }) { lv_text }| ).
     ENDCASE.
 
   ENDMETHOD.

--- a/src/http/zcl_abapgit_http_client.clas.abap
+++ b/src/http/zcl_abapgit_http_client.clas.abap
@@ -62,7 +62,7 @@ CLASS zcl_abapgit_http_client IMPLEMENTATION.
       WHEN 415.
         zcx_abapgit_exception=>raise( 'Unsupported media type (HTTP 415)' ).
       WHEN 422.
-        zcx_abapgit_exception=>raise( 'Unprocessable entity (HTTP 422). Check the URL (it might have to end with ".git")' ).
+        zcx_abapgit_exception=>raise( 'Unprocessable entity (HTTP 422). Check, if URL has to end with ".git"' ).
       WHEN OTHERS.
         lv_text = mi_client->response->get_cdata( ).
         zcx_abapgit_exception=>raise( |(HTTP { lv_code }) { lv_text }| ).


### PR DESCRIPTION
- Minor changes to error texts: error first, helpful comment after
- Add HTTP 422 which can happen on gitlab if you ommit ".git" in the URL