### PR TITLE
XSLT: Unlock in case of errors

### DIFF
--- a/src/objects/zcl_abapgit_object_xslt.clas.abap
+++ b/src/objects/zcl_abapgit_object_xslt.clas.abap
@@ -15,7 +15,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_XSLT IMPLEMENTATION.
+CLASS zcl_abapgit_object_xslt IMPLEMENTATION.
 
 
   METHOD get.
@@ -146,6 +146,7 @@ CLASS ZCL_ABAPGIT_OBJECT_XSLT IMPLEMENTATION.
         permission_failure    = 5
         OTHERS                = 6 ).
     IF sy-subrc <> 0.
+      lo_xslt->set_changeable( abap_false ). " unlock
       zcx_abapgit_exception=>raise( |Error from XSLT save, { sy-subrc }| ).
     ENDIF.
 
@@ -157,6 +158,7 @@ CLASS ZCL_ABAPGIT_OBJECT_XSLT IMPLEMENTATION.
 *        xtc_not_available = 4  downport/upport, does not exist in 751
         OTHERS            = 5 ).
     IF sy-subrc <> 0.
+      lo_xslt->set_changeable( abap_false ). " unlock
       zcx_abapgit_exception=>raise( |Error from XSLT activate, { sy-subrc }| ).
     ENDIF.
 


### PR DESCRIPTION
If an XSLT object has for example syntax errors, it remains locked and can't be edited:

![image](https://user-images.githubusercontent.com/59966492/107790621-f7e08680-6d20-11eb-86e0-0f691a6fb274.png)

The change unlocks the object in this case.