### PR TITLE
PARA: Unlock in case of errors

### DIFF
--- a/src/objects/zcl_abapgit_object_para.clas.abap
+++ b/src/objects/zcl_abapgit_object_para.clas.abap
@@ -6,11 +6,26 @@ CLASS zcl_abapgit_object_para DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    METHODS unlock
+      IMPORTING
+        !iv_paramid TYPE memoryid .
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_object_para IMPLEMENTATION.
+
+
+  METHOD unlock.
+
+    CALL FUNCTION 'RS_ACCESS_PERMISSION'
+      EXPORTING
+        mode         = 'FREE'
+        object       = iv_paramid
+        object_class = 'PARA'.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -54,12 +69,14 @@ CLASS zcl_abapgit_object_para IMPLEMENTATION.
     SELECT COUNT(*) FROM cross
       WHERE ( type = 'P' OR type = 'Q' ) AND name = lv_paramid.
     IF sy-subrc = 0.
+      unlock( lv_paramid ).
       zcx_abapgit_exception=>raise( 'PARA: Parameter is still used' ).
     ELSE.
       SELECT COUNT(*) FROM dd04l BYPASSING BUFFER
         WHERE memoryid = lv_paramid
         AND as4local = 'A'.
       IF sy-subrc = 0.
+        unlock( lv_paramid ).
         zcx_abapgit_exception=>raise( 'PARA: Parameter is still used' ).
       ENDIF.
     ENDIF.
@@ -89,14 +106,11 @@ CLASS zcl_abapgit_object_para IMPLEMENTATION.
             type      = 'CR'.
       ENDIF.
     ELSE.
+      unlock( lv_paramid ).
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    CALL FUNCTION 'RS_ACCESS_PERMISSION'
-      EXPORTING
-        mode         = 'FREE'
-        object       = lv_paramid
-        object_class = 'PARA'.
+    unlock( lv_paramid ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
If a PARA object cannot be deleted, it remains locked.

![image](https://user-images.githubusercontent.com/59966492/108289384-5318db80-715c-11eb-8b26-31f0953b2012.png)

The change unlocks the object in this case.