### PR TITLE
Optimize performance of switching branches

### DIFF
--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -509,7 +509,10 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    lo_repo->select_commit( space ).
+    IF lo_repo->get_selected_commit( ) IS NOT INITIAL.
+      lo_repo->select_commit( space ).
+    ENDIF.
+
     lo_repo->select_branch( ls_branch-name ).
     COMMIT WORK AND WAIT.
 


### PR DESCRIPTION
When switching branches, if you have a checked out commit it is also reset. This reset is expensive and I think it can be skipped if no commit was selected previously.

![image](https://user-images.githubusercontent.com/5097067/108597411-344b5c80-7389-11eb-9d98-34d8853881b7.png)
