### PR TITLE
GET_REPO_SHOW dont lookup empty key

### DIFF
--- a/src/persist/zcl_abapgit_persistence_user.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_user.clas.abap
@@ -268,6 +268,10 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_USER IMPLEMENTATION.
 
     rv_key = ms_user-repo_show.
 
+    IF rv_key IS INITIAL.
+      RETURN.
+    ENDIF.
+
     " Check if repo exists
     TRY.
         lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( rv_key ).


### PR DESCRIPTION
if the key is empty, dont try looking it up

this will improve performance a bit