### PR TITLE
Fix jump to objects with special characters

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -675,6 +675,7 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-jump.                          " Open object editor
         ls_item-obj_type = ii_event->query( )->get( 'TYPE' ).
         ls_item-obj_name = ii_event->query( )->get( 'NAME' ).
+        ls_item-obj_name = cl_http_utility=>unescape_url( |{ ls_item-obj_name }| ).
 
         li_html_viewer = zcl_abapgit_ui_factory=>get_html_viewer( ).
 


### PR DESCRIPTION
Fixes jump to an object in case the object name contains escaped characters