### PR TITLE
AVAR: Unlock after deserialize

### DIFF
--- a/src/objects/zcl_abapgit_object_avar.clas.abap
+++ b/src/objects/zcl_abapgit_object_avar.clas.abap
@@ -141,6 +141,7 @@ CLASS ZCL_ABAPGIT_OBJECT_AVAR IMPLEMENTATION.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Error saving AVAR { ms_item-obj_name }| ).
     ENDIF.
+    lo_aab->dequeue( ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_avar.clas.abap
+++ b/src/objects/zcl_abapgit_object_avar.clas.abap
@@ -105,7 +105,8 @@ CLASS ZCL_ABAPGIT_OBJECT_AVAR IMPLEMENTATION.
       EXCEPTIONS
         no_authorization = 1 ).
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |No authorization for { ls_is-object } { ls_is-name }| ).
+      lo_aab->dequeue( ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
     LOOP AT lt_ids INTO ls_is.
@@ -117,15 +118,12 @@ CLASS ZCL_ABAPGIT_OBJECT_AVAR IMPLEMENTATION.
         EXCEPTIONS
           no_authorization     = 1
           id_not_exists        = 2
-          id_not_transportable = 3 ).
-      CASE sy-subrc.
-        WHEN 1.
-          zcx_abapgit_exception=>raise( |No authorization for { ls_is-object } { ls_is-name }| ).
-        WHEN 2.
-          zcx_abapgit_exception=>raise( |{ ls_is-object } { ls_is-name } does not exist| ).
-        WHEN 3.
-          zcx_abapgit_exception=>raise( |{ ls_is-object } { ls_is-name } must be transportable| ).
-      ENDCASE.
+          id_not_transportable = 3
+          OTHERS               = 4 ).
+      IF sy-subrc <> 0.
+        lo_aab->dequeue( ).
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
     ENDLOOP.
 
     tadir_insert( iv_package ).
@@ -139,7 +137,8 @@ CLASS ZCL_ABAPGIT_OBJECT_AVAR IMPLEMENTATION.
         no_changes_found      = 5
         cts_error             = 6 ).
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error saving AVAR { ms_item-obj_name }| ).
+      lo_aab->dequeue( ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
     lo_aab->dequeue( ).
 


### PR DESCRIPTION
Save was not sufficient to remove locks. It needed explicit dequeue.

![image](https://user-images.githubusercontent.com/59966492/109209325-6689ff00-7779-11eb-8841-cf8218435580.png)
