### PR TITLE
Rendering of XML when result is empty

### DIFF
--- a/src/xml/zcl_abapgit_xml_output.clas.abap
+++ b/src/xml/zcl_abapgit_xml_output.clas.abap
@@ -115,7 +115,8 @@ CLASS zcl_abapgit_xml_output IMPLEMENTATION.
       li_abap ?= mi_xml_doc->get_root( )->get_first_child( ).
       mi_xml_doc->get_root( )->remove_child( li_abap ).
       IF li_abap IS INITIAL.
-        li_abap = build_asx_node( ).
+        " Nothing was added to XML output so return an empty string
+        RETURN.
       ENDIF.
     ELSE.
       li_abap = mi_raw.


### PR DESCRIPTION
It is possible that a serializer doesn't return anything meaning it doesn't add anything to the XML output stream. Instead of an XML without any "ABAP data" (see #4564, #4569), this change will now return an empty file. 

Todo: remove build_asx_node

Closes #4562, #4564, and #4569