### PR TITLE
DDIC: Error message in case of "new" versions

### DIFF
--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -362,8 +362,12 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
       EXCEPTIONS
         illegal_input = 1
         OTHERS        = 2.
-    IF sy-subrc <> 0 OR ls_dd01v IS INITIAL.
+    IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+    IF ls_dd01v IS INITIAL.
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     CLEAR: ls_dd01v-as4user,

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -286,14 +286,13 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
 
     lv_name = ms_item-obj_name.
 
-
     SELECT SINGLE * FROM dd04l
       INTO CORRESPONDING FIELDS OF ls_dd04v
       WHERE rollname = lv_name
       AND as4local = 'A'
       AND as4vers = '0000'.
     IF sy-subrc <> 0 OR ls_dd04v IS INITIAL.
-      zcx_abapgit_exception=>raise( 'Not found in DD04L' ).
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     SELECT SINGLE * FROM dd04t

--- a/src/objects/zcl_abapgit_object_enqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_enqu.clas.abap
@@ -161,8 +161,9 @@ CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
+
     IF ls_dd25v IS INITIAL.
-      RETURN. " does not exist in system
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     CLEAR: ls_dd25v-as4user,

--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -165,8 +165,9 @@ CLASS zcl_abapgit_object_shlp IMPLEMENTATION.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
+
     IF ls_dd30v IS INITIAL.
-      RETURN. " does not exist in system
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     CLEAR: ls_dd30v-as4user,

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -964,8 +964,9 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( 'error from DDIF_TABL_GET' ).
     ENDIF.
+
     IF ls_dd02v IS INITIAL.
-      RETURN. " object does not exits
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     CLEAR: ls_dd02v-as4user,

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -10,7 +10,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TTYP IMPLEMENTATION.
+CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -181,7 +181,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TTYP IMPLEMENTATION.
     ENDIF.
 
     IF ls_dd40v IS INITIAL.
-      RETURN. " does not exist in system
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     CLEAR: ls_dd40v-as4user,

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -282,7 +282,7 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
         et_dd28v = lt_dd28v ).
 
     IF ls_dd25v IS INITIAL.
-      RETURN. " does not exist in system
+      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
     ENDIF.
 
     CLEAR: ls_dd25v-as4user,


### PR DESCRIPTION
In case DDIC objects exist as "new" version only , the system will now raise an error message to alert the user that "No active version was found". 

![image](https://user-images.githubusercontent.com/59966492/109522846-b704a380-7a7c-11eb-992d-95a8759feed6.png)

Note: The log will disappear after some navigation and such objects will not be included in the repo view if they only exist locally (until they are activated).

The `, 1` at the end of the messages is the `sy-subrc` value (when serializing in parallel). Should be changed in separate PR. 