### PR TITLE
Log refactoring

### DIFF
--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -112,14 +112,16 @@ CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
             iv_username = <ls_list>-username
             iv_password = <ls_list>-password ).
 
-          CREATE OBJECT li_log TYPE zcl_abapgit_log.
           CREATE OBJECT li_background TYPE (<ls_list>-method).
 
-          li_background->run(
+          li_log = li_background->run(
             io_repo     = lo_repo
-            ii_log      = li_log
             it_settings = <ls_list>-settings ).
+
         CATCH zcx_abapgit_exception INTO lx_error.
+          IF li_log IS NOT BOUND.
+            CREATE OBJECT li_log TYPE zcl_abapgit_log.
+          ENDIF.
           li_log->add_exception( lx_error ).
       ENDTRY.
 

--- a/src/background/zcl_abapgit_background_pull.clas.abap
+++ b/src/background/zcl_abapgit_background_pull.clas.abap
@@ -39,8 +39,7 @@ CLASS ZCL_ABAPGIT_BACKGROUND_PULL IMPLEMENTATION.
       <ls_overwrite>-decision = zif_abapgit_definitions=>gc_yes.
     ENDLOOP.
 
-    io_repo->deserialize( is_checks = ls_checks
-                          ii_log    = ii_log ).
+    ri_log = io_repo->deserialize( is_checks = ls_checks ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/background/zcl_abapgit_background_push_au.clas.abap
+++ b/src/background/zcl_abapgit_background_push_au.clas.abap
@@ -36,7 +36,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_background_push_au IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_BACKGROUND_PUSH_AU IMPLEMENTATION.
 
 
   METHOD build_comment.
@@ -233,11 +233,13 @@ CLASS zcl_abapgit_background_push_au IMPLEMENTATION.
 
     DATA: ls_files TYPE zif_abapgit_definitions=>ty_stage_files.
 
-    mi_log = ii_log.
+    CREATE OBJECT ri_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Background push log'.
+    mi_log = ri_log.
+
     ls_files = zcl_abapgit_factory=>get_stage_logic( )->get( io_repo ).
 
     IF lines( ls_files-local ) = 0 AND lines( ls_files-remote ) = 0.
-      ii_log->add_info( 'Nothing to stage' ).
+      mi_log->add_info( 'Nothing to stage' ).
       RETURN.
     ENDIF.
 

--- a/src/background/zcl_abapgit_background_push_fi.clas.abap
+++ b/src/background/zcl_abapgit_background_push_fi.clas.abap
@@ -141,11 +141,13 @@ CLASS ZCL_ABAPGIT_BACKGROUND_PUSH_FI IMPLEMENTATION.
           lv_name    TYPE string,
           lv_email   TYPE string.
 
-    mi_log = ii_log.
+    CREATE OBJECT ri_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Background push log'.
+    mi_log = ri_log.
+
     ls_files = zcl_abapgit_factory=>get_stage_logic( )->get( io_repo ).
 
     IF lines( ls_files-local ) = 0 AND lines( ls_files-remote ) = 0.
-      ii_log->add_info( 'Nothing to stage' ).
+      mi_log->add_info( 'Nothing to stage' ).
       RETURN.
     ENDIF.
 

--- a/src/background/zif_abapgit_background.intf.abap
+++ b/src/background/zif_abapgit_background.intf.abap
@@ -19,8 +19,9 @@ INTERFACE zif_abapgit_background
   METHODS run
     IMPORTING
       !io_repo     TYPE REF TO zcl_abapgit_repo_online
-      !ii_log      TYPE REF TO zif_abapgit_log
       !it_settings TYPE ty_settings_tt OPTIONAL
+    RETURNING
+      VALUE(ri_log) TYPE REF TO zif_abapgit_log
     RAISING
       zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -61,7 +61,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS_ACTIVATION IMPLEMENTATION.
 
 
   METHOD activate.
@@ -335,8 +335,7 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
 
     DELETE lt_lines WHERE severity <> 'E'.
 
-    CREATE OBJECT li_log TYPE zcl_abapgit_log.
-    li_log->set_title( 'Activation Errors' ).
+    CREATE OBJECT li_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Activation Errors'.
 
     LOOP AT lt_lines ASSIGNING <ls_line>.
       li_log->add( <ls_line>-line ).

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -512,9 +512,9 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
     DATA li_log TYPE REF TO zif_abapgit_log.
 
-    CREATE OBJECT li_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Object deletion log'.
-
     FIELD-SYMBOLS: <ls_tadir> LIKE LINE OF it_tadir.
+
+    CREATE OBJECT li_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Object deletion log'.
 
     lt_tadir = it_tadir.
 

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -122,9 +122,6 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-    METHODS get_log
-      RETURNING
-        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS refresh_local_object
       IMPORTING
         !iv_obj_type TYPE tadir-object
@@ -524,11 +521,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     rs_settings = ms_data-local_settings.
 
-  ENDMETHOD.
-
-
-  METHOD get_log.
-    ri_log = mi_log.
   ENDMETHOD.
 
 

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -75,8 +75,6 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS refresh
       IMPORTING
         !iv_drop_cache TYPE abap_bool DEFAULT abap_false
-        !iv_drop_log   TYPE abap_bool DEFAULT abap_true
-          PREFERRED PARAMETER iv_drop_cache
       RAISING
         zcx_abapgit_exception .
     METHODS update_local_checksums
@@ -124,11 +122,6 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-    METHODS create_new_log
-      IMPORTING
-        !iv_title     TYPE string OPTIONAL
-      RETURNING
-        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .
@@ -305,14 +298,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     ms_data = is_data.
     mv_request_remote_refresh = abap_true.
-
-  ENDMETHOD.
-
-
-  METHOD create_new_log.
-
-    CREATE OBJECT mi_log TYPE zcl_abapgit_log EXPORTING iv_title = iv_title.
-    ri_log = mi_log.
 
   ENDMETHOD.
 
@@ -649,10 +634,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     mv_request_local_refresh = abap_true.
     reset_remote( ).
-
-    IF iv_drop_log = abap_true.
-      CLEAR mi_log.
-    ENDIF.
 
     IF iv_drop_cache = abap_true.
       CLEAR mt_local.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -68,7 +68,8 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS deserialize
       IMPORTING
         !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
-        !ii_log    TYPE REF TO zif_abapgit_log
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zcl_abapgit_log
       RAISING
         zcx_abapgit_exception .
     METHODS refresh
@@ -331,6 +332,8 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     DATA: lt_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
           lx_error         TYPE REF TO zcx_abapgit_exception.
 
+    CREATE OBJECT ri_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Deserialization log'.
+
     find_remote_dot_abapgit( ).
     find_remote_dot_apack( ).
 
@@ -353,7 +356,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         lt_updated_files = zcl_abapgit_objects=>deserialize(
             io_repo   = me
             is_checks = is_checks
-            ii_log    = ii_log ).
+            ii_log    = ri_log ).
       CATCH zcx_abapgit_exception INTO lx_error.
 * ensure to reset default transport request task
         zcl_abapgit_default_transport=>get_instance( )->reset( ).
@@ -362,7 +365,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     APPEND get_dot_abapgit( )->get_signature( ) TO lt_updated_files.
 
-    CLEAR: mt_local.
+    CLEAR mt_local.
 
     update_local_checksums( lt_updated_files ).
     update_last_deserialize( ).

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -310,9 +310,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
   METHOD create_new_log.
 
-    CREATE OBJECT mi_log TYPE zcl_abapgit_log.
-    mi_log->set_title( iv_title ).
-
+    CREATE OBJECT mi_log TYPE zcl_abapgit_log EXPORTING iv_title = iv_title.
     ri_log = mi_log.
 
   ENDMETHOD.

--- a/src/repo/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/repo/zcl_abapgit_repo_content_list.clas.abap
@@ -233,27 +233,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
 
   METHOD get_log.
-    DATA li_repo_log TYPE REF TO zif_abapgit_log.
-    DATA lt_repo_msg TYPE zif_abapgit_log=>ty_log_outs.
-    DATA lr_repo_msg TYPE REF TO zif_abapgit_log=>ty_log_out.
-
     ri_log = mi_log.
-
-    "add warning and error messages from repo log
-    li_repo_log = mo_repo->get_log( ).
-    IF li_repo_log IS BOUND.
-      lt_repo_msg = li_repo_log->get_messages( ).
-      LOOP AT lt_repo_msg REFERENCE INTO lr_repo_msg WHERE type CA 'EW'.
-        CASE lr_repo_msg->type.
-          WHEN 'E'.
-            ri_log->add_error( lr_repo_msg->text ).
-          WHEN 'W'.
-            ri_log->add_warning( lr_repo_msg->text ).
-          WHEN OTHERS.
-            CONTINUE.
-        ENDCASE.
-      ENDLOOP.
-    ENDIF.
   ENDMETHOD.
 
 

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -78,7 +78,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
 
   METHOD add.
@@ -514,8 +514,6 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
     DATA: lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
     DATA: lx_error TYPE REF TO zcx_abapgit_exception.
 
-    ri_log = io_repo->create_new_log( 'Uninstall Log' ).
-
     IF io_repo->get_local_settings( )-write_protected = abap_true.
       zcx_abapgit_exception=>raise( 'Cannot purge. Local code is write-protected by repo config' ).
     ELSEIF zcl_abapgit_auth=>is_allowed( zif_abapgit_auth=>gc_authorization-uninstall ) = abap_false.
@@ -524,15 +522,9 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( io_repo->get_package( ) ).
 
-    TRY.
-        zcl_abapgit_objects=>delete( it_tadir  = lt_tadir
-                                     is_checks = is_checks
-                                     ii_log    = ri_log ).
-      CATCH zcx_abapgit_exception INTO lx_error.
-        " If uninstall fails, repo needs a refresh to show which objects where deleted and which not
-        io_repo->refresh( iv_drop_log = abap_false ).
-        RAISE EXCEPTION lx_error.
-    ENDTRY.
+    zcl_abapgit_objects=>delete(
+      it_tadir  = lt_tadir
+      is_checks = is_checks ).
 
     delete( io_repo ).
 

--- a/src/repo/zif_abapgit_repo_srv.intf.abap
+++ b/src/repo/zif_abapgit_repo_srv.intf.abap
@@ -57,8 +57,6 @@ INTERFACE zif_abapgit_repo_srv
     IMPORTING
       !io_repo      TYPE REF TO zcl_abapgit_repo
       !is_checks    TYPE zif_abapgit_definitions=>ty_delete_checks
-    RETURNING
-      VALUE(ri_log) TYPE REF TO zif_abapgit_log
     RAISING
       zcx_abapgit_exception .
   METHODS validate_package

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -72,6 +72,7 @@ CLASS zcl_abapgit_gui DEFINITION
     DATA mi_html_processor TYPE REF TO zif_abapgit_gui_html_processor .
     DATA mi_html_viewer TYPE REF TO zif_abapgit_html_viewer .
     DATA mo_html_parts TYPE REF TO zcl_abapgit_html_parts .
+    DATA mi_common_log TYPE REF TO zif_abapgit_log .
 
     METHODS cache_html
       IMPORTING
@@ -303,9 +304,11 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         IF li_gui_error_handler IS BOUND AND li_gui_error_handler->handle_error( ix_exception ) = abap_true.
           " We rerender the current page to display the error box
           render( ).
-        ELSEIF ix_exception->mi_log IS BOUND
-            AND ix_exception->mi_log->get_log_level( ) >= zif_abapgit_log=>c_log_level-warning.
-          zcl_abapgit_log_viewer=>show_log( ix_exception->mi_log ).
+        ELSEIF ix_exception->mi_log IS BOUND.
+          mi_common_log = ix_exception->mi_log.
+          IF mi_common_log->get_log_level( ) >= zif_abapgit_log=>c_log_level-warning.
+            zcl_abapgit_log_viewer=>show_log( mi_common_log ).
+          ENDIF.
         ELSE.
           MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.
         ENDIF.
@@ -476,6 +479,17 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_services~get_html_parts.
     ro_parts = mo_html_parts.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_services~get_log.
+
+    IF iv_create_new = abap_true OR mi_common_log IS NOT BOUND.
+      CREATE OBJECT mi_common_log TYPE zcl_abapgit_log.
+    ENDIF.
+
+    ri_log = mi_common_log.
+
   ENDMETHOD.
 
 

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -303,7 +303,8 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         IF li_gui_error_handler IS BOUND AND li_gui_error_handler->handle_error( ix_exception ) = abap_true.
           " We rerender the current page to display the error box
           render( ).
-        ELSEIF ix_exception->mi_log IS BOUND AND ix_exception->mi_log->get_log_level( ) >= zif_abapgit_log=>c_log_level-warning.
+        ELSEIF ix_exception->mi_log IS BOUND
+            AND ix_exception->mi_log->get_log_level( ) >= zif_abapgit_log=>c_log_level-warning.
           zcl_abapgit_log_viewer=>show_log( ix_exception->mi_log ).
         ELSE.
           MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -304,7 +304,11 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
           " We rerender the current page to display the error box
           render( ).
         ELSE.
-          MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.
+          IF ix_exception->mi_log IS BOUND AND ix_exception->mi_log->count( ) > 0.
+            zcl_abapgit_log_viewer=>show_log( ix_exception->mi_log ).
+          ELSE.
+            MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.
+          ENDIF.
         ENDIF.
 
       CATCH zcx_abapgit_exception cx_sy_move_cast_error INTO lx_exception.

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -303,7 +303,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         IF li_gui_error_handler IS BOUND AND li_gui_error_handler->handle_error( ix_exception ) = abap_true.
           " We rerender the current page to display the error box
           render( ).
-        ELSEIF ix_exception->mi_log IS BOUND AND ix_exception->mi_log->count( ) > 0.
+        ELSEIF ix_exception->mi_log IS BOUND AND ix_exception->mi_log->get_log_level( ) >= zif_abapgit_log=>c_log_level-warning.
           zcl_abapgit_log_viewer=>show_log( ix_exception->mi_log ).
         ELSE.
           MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -303,12 +303,10 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         IF li_gui_error_handler IS BOUND AND li_gui_error_handler->handle_error( ix_exception ) = abap_true.
           " We rerender the current page to display the error box
           render( ).
+        ELSEIF ix_exception->mi_log IS BOUND AND ix_exception->mi_log->count( ) > 0.
+          zcl_abapgit_log_viewer=>show_log( ix_exception->mi_log ).
         ELSE.
-          IF ix_exception->mi_log IS BOUND AND ix_exception->mi_log->count( ) > 0.
-            zcl_abapgit_log_viewer=>show_log( ix_exception->mi_log ).
-          ELSE.
-            MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.
-          ENDIF.
+          MESSAGE ix_exception TYPE 'S' DISPLAY LIKE 'E'.
         ENDIF.
 
       CATCH zcx_abapgit_exception cx_sy_move_cast_error INTO lx_exception.

--- a/src/ui/core/zcl_abapgit_gui_html_processor.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_html_processor.clas.testclasses.abap
@@ -29,6 +29,8 @@ CLASS ltcl_gui_mock IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_gui_services~get_html_parts.
   ENDMETHOD.
+  METHOD zif_abapgit_gui_services~get_log.
+  ENDMETHOD.
 
   METHOD get_asset.
     rs_asset = ms_last_cache_signature.

--- a/src/ui/core/zif_abapgit_gui_services.intf.abap
+++ b/src/ui/core/zif_abapgit_gui_services.intf.abap
@@ -25,4 +25,9 @@ INTERFACE zif_abapgit_gui_services
   METHODS get_html_parts
     RETURNING
       VALUE(ro_parts) TYPE REF TO zcl_abapgit_html_parts .
+  METHODS get_log
+    IMPORTING
+      iv_create_new TYPE abap_bool DEFAULT abap_false
+    RETURNING
+      VALUE(ri_log) TYPE REF TO zif_abapgit_log.
 ENDINTERFACE.

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -20,6 +20,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       END OF  ty_control .
 
     DATA ms_control TYPE ty_control .
+    DATA mi_last_log TYPE REF TO zif_abapgit_log.
 
     METHODS render_content
           ABSTRACT
@@ -269,6 +270,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   METHOD zif_abapgit_gui_error_handler~handle_error.
 
     mx_error = ix_error.
+    mi_last_log = ix_error->mi_log.
     rv_handled = abap_true.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -877,7 +877,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN c_action-stage_refresh.
-        mo_repo->refresh( abap_true ).
+        mo_repo->refresh( iv_drop_cache = abap_true ).
         init_files( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -652,10 +652,6 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-repo_infos.                      " Repo infos
         rs_handled-page  = zcl_abapgit_gui_page_sett_info=>create( lo_repo ).
         rs_handled-state = get_state_settings( ii_event ).
-      WHEN zif_abapgit_definitions=>c_action-repo_log.                        " Repo log
-        li_log = lo_repo->get_log( ).
-        zcl_abapgit_log_viewer=>show_log( li_log ).
-        rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
     ENDCASE.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -355,7 +355,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
           is_checks = ls_checks ).
       CATCH zcx_abapgit_exception INTO lo_error.
         lo_repo->refresh( ). " To see the differences after update
-        raise exception lo_error.
+        RAISE EXCEPTION lo_error.
     ENDTRY.
 
     COMMIT WORK.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -350,12 +350,12 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
     ENDIF.
 
     TRY.
-      zcl_abapgit_repo_srv=>get_instance( )->purge(
-        io_repo   = lo_repo
-        is_checks = ls_checks ).
-    CATCH zcx_abapgit_exception INTO lo_error.
-      lo_repo->refresh( ). " To see the differences after update
-      raise exception lo_error.
+        zcl_abapgit_repo_srv=>get_instance( )->purge(
+          io_repo   = lo_repo
+          is_checks = ls_checks ).
+      CATCH zcx_abapgit_exception INTO lo_error.
+        lo_repo->refresh( ). " To see the differences after update
+        raise exception lo_error.
     ENDTRY.
 
     COMMIT WORK.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -307,6 +307,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
   METHOD purge.
 
     DATA: lt_tadir     TYPE zif_abapgit_definitions=>ty_tadir_tt,
+          lo_error     TYPE REF TO zcx_abapgit_exception,
           lv_answer    TYPE c LENGTH 1,
           lo_repo      TYPE REF TO zcl_abapgit_repo,
           lv_package   TYPE devclass,
@@ -348,9 +349,14 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
                                         )->popup_transport_request( ls_checks-transport-type ).
     ENDIF.
 
-    zcl_abapgit_repo_srv=>get_instance( )->purge(
-      io_repo   = lo_repo
-      is_checks = ls_checks ).
+    TRY.
+      zcl_abapgit_repo_srv=>get_instance( )->purge(
+        io_repo   = lo_repo
+        is_checks = ls_checks ).
+    CATCH zcx_abapgit_exception INTO lo_error.
+      lo_repo->refresh( ). " To see the differences after update
+      raise exception lo_error.
+    ENDTRY.
 
     COMMIT WORK.
 

--- a/src/ui/zcl_abapgit_ui_injector.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.locals_imp.abap
@@ -20,4 +20,7 @@ CLASS lcl_gui_services_dummy IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_gui_services~get_html_parts.
   ENDMETHOD.
+  METHOD zif_abapgit_gui_services~get_log.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -8,13 +8,8 @@ CLASS zcl_abapgit_log DEFINITION
   PROTECTED SECTION.
 
     TYPES:
-      BEGIN OF ty_msg,
-        text TYPE string,
-        type TYPE sy-msgty,
-      END OF ty_msg .
-    TYPES:
       BEGIN OF ty_log, "in order of occurrence
-        msg       TYPE ty_msg,
+        msg       TYPE zif_abapgit_log=>ty_msg,
         rc        TYPE sy-subrc,
         item      TYPE zif_abapgit_definitions=>ty_item,
         exception TYPE REF TO cx_root,
@@ -90,7 +85,7 @@ CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
 
     DATA lx_exc TYPE REF TO cx_root.
     DATA lv_msg TYPE string.
-    lx_exc ?= ix_exc.
+    lx_exc = ix_exc.
     DO.
       lv_msg = lx_exc->get_text( ).
       zif_abapgit_log~add( iv_msg  = lv_msg
@@ -202,21 +197,22 @@ CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
   METHOD zif_abapgit_log~get_status.
 
     DATA lr_log TYPE REF TO ty_log.
-    rv_status = 'S'.
+    rv_status = zif_abapgit_log=>c_status-ok.
     LOOP AT mt_log REFERENCE INTO lr_log.
       CASE lr_log->msg-type.
         WHEN 'E' OR 'A' OR 'X'.
-          rv_status = 'E'. "not okay
+          rv_status = zif_abapgit_log=>c_status-error.
           EXIT.
         WHEN 'W'.
-          rv_status = 'W'. "maybe
+          rv_status = zif_abapgit_log=>c_status-warning.
           CONTINUE.
         WHEN 'S' OR 'I'.
-          IF rv_status <> 'W'.
-            rv_status = 'S'. "okay
+          IF rv_status <> zif_abapgit_log=>c_status-warning.
+            rv_status = zif_abapgit_log=>c_status-ok.
           ENDIF.
           CONTINUE.
         WHEN OTHERS. "unknown
+          rv_status = zif_abapgit_log=>c_status-error. " it is a bug probably, so not OK
           CONTINUE.
       ENDCASE.
     ENDLOOP.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -10,6 +10,12 @@ CLASS zcl_abapgit_log DEFINITION
       IMPORTING
         iv_title TYPE string OPTIONAL.
 
+    CLASS-METHODS from_exception
+      IMPORTING
+        io_x TYPE REF TO cx_root
+      RETURNING
+        VALUE(ro_log) TYPE REF TO zcl_abapgit_log.
+
   PROTECTED SECTION.
 
     TYPES:
@@ -40,6 +46,17 @@ CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
   METHOD constructor.
 
     zif_abapgit_log~set_title( iv_title ).
+
+  ENDMETHOD.
+
+
+  METHOD from_exception.
+
+    CREATE OBJECT ro_log.
+
+    IF io_x IS BOUND.
+      ro_log->zif_abapgit_log~add_exception( io_x ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -248,7 +265,20 @@ CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_log~merge_with.
+
+    DATA lo_log TYPE REF TO zcl_abapgit_log.
+
+    IF ii_log IS BOUND.
+      lo_log ?= ii_log.
+      APPEND LINES OF lo_log->mt_log TO mt_log.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_log~set_title.
     mv_title = iv_title.
+    ri_log = me.
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -241,8 +241,7 @@ CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
           ENDIF.
           CONTINUE.
         WHEN OTHERS. "unknown
-          rv_status = zif_abapgit_log=>c_status-error. " it is a bug probably, so not OK
-          CONTINUE.
+          ASSERT 0 = 1.
       ENDCASE.
     ENDLOOP.
 

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -5,6 +5,11 @@ CLASS zcl_abapgit_log DEFINITION
   PUBLIC SECTION.
 
     INTERFACES zif_abapgit_log .
+
+    METHODS constructor
+      IMPORTING
+        iv_title TYPE string OPTIONAL.
+
   PROTECTED SECTION.
 
     TYPES:
@@ -30,6 +35,13 @@ ENDCLASS.
 
 
 CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    zif_abapgit_log~set_title( iv_title ).
+
+  ENDMETHOD.
 
 
   METHOD get_messages_status.

--- a/src/utils/zcl_abapgit_log.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_log.clas.testclasses.abap
@@ -7,7 +7,9 @@ CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
 
     METHODS:
       setup,
+      from_x FOR TESTING,
       get_status FOR TESTING,
+      merge_with FOR TESTING,
       empty FOR TESTING,
       add FOR TESTING.
 ENDCLASS.
@@ -93,6 +95,62 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = mi_cut->get_status( )
       exp = zif_abapgit_log=>c_status-error ).
+
+  ENDMETHOD.
+
+  METHOD merge_with.
+
+    DATA li_secondary_log LIKE mi_cut.
+    DATA lt_act_msgs TYPE zif_abapgit_log=>ty_log_outs.
+
+    CREATE OBJECT li_secondary_log TYPE zcl_abapgit_log.
+
+    mi_cut->add_success( 'success' ).
+    li_secondary_log->add_warning( 'warn' ).
+    mi_cut->merge_with( li_secondary_log ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->count( )
+      exp = 2 ).
+
+    lt_act_msgs = mi_cut->get_messages( ).
+
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'success'.
+    cl_abap_unit_assert=>assert_subrc( ).
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'warn'.
+    cl_abap_unit_assert=>assert_subrc( ).
+
+  ENDMETHOD.
+
+  METHOD from_x.
+
+    DATA lo_x TYPE REF TO zcx_abapgit_exception.
+    DATA lt_act_msgs TYPE zif_abapgit_log=>ty_log_outs.
+
+    " Uninitialized
+    mi_cut = zcl_abapgit_log=>from_exception( lo_x ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->count( )
+      exp = 0 ).
+
+    " Notmal exception
+    TRY.
+      zcx_abapgit_exception=>raise( 'Error!' ).
+    CATCH zcx_abapgit_exception INTO lo_x.
+      mi_cut = zcl_abapgit_log=>from_exception( lo_x ).
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_bound( mi_cut ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->count( )
+      exp = 1 ).
+
+    lt_act_msgs = mi_cut->get_messages( ).
+
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY type = 'E'.
+    cl_abap_unit_assert=>assert_subrc( ).
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'Error!'.
+    cl_abap_unit_assert=>assert_subrc( ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_log.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_log.clas.testclasses.abap
@@ -136,8 +136,8 @@ CLASS ltcl_test IMPLEMENTATION.
     " Notmal exception
     TRY.
         zcx_abapgit_exception=>raise( 'Error!' ).
-    CATCH zcx_abapgit_exception INTO lo_x.
-      mi_cut = zcl_abapgit_log=>from_exception( lo_x ).
+      CATCH zcx_abapgit_exception INTO lo_x.
+        mi_cut = zcl_abapgit_log=>from_exception( lo_x ).
     ENDTRY.
 
     cl_abap_unit_assert=>assert_bound( mi_cut ).

--- a/src/utils/zcl_abapgit_log.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_log.clas.testclasses.abap
@@ -135,7 +135,7 @@ CLASS ltcl_test IMPLEMENTATION.
 
     " Notmal exception
     TRY.
-      zcx_abapgit_exception=>raise( 'Error!' ).
+        zcx_abapgit_exception=>raise( 'Error!' ).
     CATCH zcx_abapgit_exception INTO lo_x.
       mi_cut = zcl_abapgit_log=>from_exception( lo_x ).
     ENDTRY.

--- a/src/utils/zcl_abapgit_log.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_log.clas.testclasses.abap
@@ -7,6 +7,7 @@ CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
 
     METHODS:
       setup,
+      get_status FOR TESTING,
       empty FOR TESTING,
       add FOR TESTING.
 ENDCLASS.
@@ -55,6 +56,43 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = ls_message-text
       exp = lv_message ).
+
+  ENDMETHOD.
+
+  METHOD get_status.
+
+    DATA lo_x TYPE REF TO zcx_abapgit_exception.
+
+    mi_cut->add_success( 'success' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_status( )
+      exp = zif_abapgit_log=>c_status-ok ).
+
+    mi_cut->add_warning( 'warn' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_status( )
+      exp = zif_abapgit_log=>c_status-warning ).
+
+    mi_cut->add_error( 'err' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_status( )
+      exp = zif_abapgit_log=>c_status-error ).
+
+    mi_cut->clear( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_status( )
+      exp = zif_abapgit_log=>c_status-ok ).
+
+    CREATE OBJECT lo_x EXPORTING msgv1 = 'x'.
+    mi_cut->add_exception( lo_x ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_status( )
+      exp = zif_abapgit_log=>c_status-error ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_log.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_log.clas.testclasses.abap
@@ -9,8 +9,11 @@ CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
       setup,
       from_x FOR TESTING,
       get_status FOR TESTING,
+      get_log_level FOR TESTING,
       merge_with FOR TESTING,
+      merge_with_min_level FOR TESTING,
       empty FOR TESTING,
+      clone FOR TESTING,
       add FOR TESTING.
 ENDCLASS.
 
@@ -122,6 +125,46 @@ CLASS ltcl_test IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD merge_with_min_level.
+
+    DATA li_secondary_log LIKE mi_cut.
+    DATA lt_act_msgs TYPE zif_abapgit_log=>ty_log_outs.
+
+    CREATE OBJECT li_secondary_log TYPE zcl_abapgit_log.
+
+    mi_cut->add_success( 'success' ).
+    li_secondary_log->add_warning( 'warn' ).
+    mi_cut->merge_with(
+      ii_log = li_secondary_log
+      iv_min_level = zif_abapgit_log=>c_log_level-error ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->count( )
+      exp = 1 ).
+
+    lt_act_msgs = mi_cut->get_messages( ).
+
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'success'.
+    cl_abap_unit_assert=>assert_subrc( ).
+
+    " change level to warning
+    mi_cut->merge_with(
+      ii_log = li_secondary_log
+      iv_min_level = zif_abapgit_log=>c_log_level-warning ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->count( )
+      exp = 2 ).
+
+    lt_act_msgs = mi_cut->get_messages( ).
+
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'success'.
+    cl_abap_unit_assert=>assert_subrc( ).
+    READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'warn'.
+    cl_abap_unit_assert=>assert_subrc( ).
+
+  ENDMETHOD.
+
   METHOD from_x.
 
     DATA lo_x TYPE REF TO zcx_abapgit_exception.
@@ -151,6 +194,63 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_subrc( ).
     READ TABLE lt_act_msgs TRANSPORTING NO FIELDS WITH KEY text = 'Error!'.
     cl_abap_unit_assert=>assert_subrc( ).
+
+  ENDMETHOD.
+
+  METHOD get_log_level.
+
+    DATA lo_x TYPE REF TO zcx_abapgit_exception.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_log_level( )
+      exp = zif_abapgit_log=>c_log_level-empty ).
+
+    mi_cut->add_success( 'success' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_log_level( )
+      exp = zif_abapgit_log=>c_log_level-info ).
+
+    mi_cut->add_warning( 'warn' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_log_level( )
+      exp = zif_abapgit_log=>c_log_level-warning ).
+
+    mi_cut->add_error( 'err' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_log_level( )
+      exp = zif_abapgit_log=>c_log_level-error ).
+
+    CREATE OBJECT lo_x EXPORTING msgv1 = 'x'.
+    mi_cut->add_exception( lo_x ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_log_level( )
+      exp = zif_abapgit_log=>c_log_level-error ).
+
+  ENDMETHOD.
+
+  METHOD clone.
+
+    DATA li_clone TYPE REF TO zif_abapgit_log.
+
+    mi_cut->add( 'Hello' ).
+    mi_cut->set_title( 'My log' ).
+
+    li_clone = mi_cut->clone( ).
+
+    mi_cut->add( 'World' ).
+    mi_cut->set_title( 'My log CHANGED' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_clone->count( )
+      exp = 1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_clone->get_title( )
+      exp = 'My log' ).
 
   ENDMETHOD.
 

--- a/src/utils/zif_abapgit_log.intf.abap
+++ b/src/utils/zif_abapgit_log.intf.abap
@@ -87,5 +87,10 @@ INTERFACE zif_abapgit_log
       VALUE(rv_title) TYPE string .
   METHODS set_title
     IMPORTING
-      !iv_title TYPE csequence .
+      !iv_title TYPE csequence
+    RETURNING
+      VALUE(ri_log) TYPE REF TO zif_abapgit_log.
+  METHODS merge_with
+    IMPORTING
+      ii_log TYPE REF TO zif_abapgit_log.
 ENDINTERFACE.

--- a/src/utils/zif_abapgit_log.intf.abap
+++ b/src/utils/zif_abapgit_log.intf.abap
@@ -8,6 +8,14 @@ INTERFACE zif_abapgit_log
       warning TYPE sy-msgty VALUE 'W',
     END OF c_status.
 
+  CONSTANTS:
+    BEGIN OF c_log_level,
+      empty   TYPE i VALUE 0,
+      info    TYPE i VALUE 1,
+      warning TYPE i VALUE 2,
+      error   TYPE i VALUE 3,
+    END OF c_log_level.
+
   TYPES:
     BEGIN OF ty_log_out,
       type      TYPE sy-msgty,
@@ -23,6 +31,7 @@ INTERFACE zif_abapgit_log
     BEGIN OF ty_msg,
       text TYPE string,
       type TYPE sy-msgty,
+      level TYPE i,
     END OF ty_msg .
   TYPES:
     ty_msgs TYPE STANDARD TABLE OF ty_msg
@@ -82,6 +91,9 @@ INTERFACE zif_abapgit_log
   METHODS get_status
     RETURNING
       VALUE(rv_status) TYPE sy-msgty .
+  METHODS get_log_level
+    RETURNING
+      VALUE(rv_level) TYPE i .
   METHODS get_title
     RETURNING
       VALUE(rv_title) TYPE string .
@@ -92,5 +104,12 @@ INTERFACE zif_abapgit_log
       VALUE(ri_log) TYPE REF TO zif_abapgit_log.
   METHODS merge_with
     IMPORTING
-      ii_log TYPE REF TO zif_abapgit_log.
+      ii_log TYPE REF TO zif_abapgit_log
+      iv_min_level TYPE i DEFAULT 0
+    RETURNING
+      VALUE(ri_log) TYPE REF TO zif_abapgit_log.
+  METHODS clone
+    RETURNING
+      VALUE(ri_log) TYPE REF TO zif_abapgit_log.
+
 ENDINTERFACE.

--- a/src/utils/zif_abapgit_log.intf.abap
+++ b/src/utils/zif_abapgit_log.intf.abap
@@ -1,6 +1,12 @@
 INTERFACE zif_abapgit_log
   PUBLIC .
 
+  CONSTANTS:
+    BEGIN OF c_status,
+      ok      TYPE sy-msgty VALUE 'S',
+      error   TYPE sy-msgty VALUE 'E',
+      warning TYPE sy-msgty VALUE 'W',
+    END OF c_status.
 
   TYPES:
     BEGIN OF ty_log_out,

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -107,8 +107,7 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
     DATA lo_serialize TYPE REF TO zcl_abapgit_serialize.
     DATA lt_languages TYPE zif_abapgit_definitions=>ty_languages.
 
-    CREATE OBJECT li_log TYPE zcl_abapgit_log.
-    li_log->set_title( 'Zip Export Log' ).
+    CREATE OBJECT li_log TYPE zcl_abapgit_log EXPORTING iv_title = 'Zip Export Log'.
 
     IF zcl_abapgit_factory=>get_sap_package( iv_package )->exists( ) = abap_false.
       zcx_abapgit_exception=>raise( |Package { iv_package } doesn't exist| ).

--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -27,6 +27,7 @@ CLASS zcx_abapgit_exception DEFINITION
     DATA msgv3 TYPE symsgv READ-ONLY .
     DATA msgv4 TYPE symsgv READ-ONLY .
     DATA mt_callstack TYPE abap_callstack READ-ONLY .
+    DATA mi_log TYPE REF TO zif_abapgit_log READ-ONLY.
 
     "! Raise exception with text
     "! @parameter iv_text | Text
@@ -36,6 +37,7 @@ CLASS zcx_abapgit_exception DEFINITION
       IMPORTING
         !iv_text     TYPE clike
         !ix_previous TYPE REF TO cx_root OPTIONAL
+        !ii_log      TYPE REF TO zif_abapgit_log OPTIONAL
       RAISING
         zcx_abapgit_exception .
     "! Raise exception with T100 message
@@ -57,6 +59,7 @@ CLASS zcx_abapgit_exception DEFINITION
         VALUE(iv_msgv2) TYPE symsgv DEFAULT sy-msgv2
         VALUE(iv_msgv3) TYPE symsgv DEFAULT sy-msgv3
         VALUE(iv_msgv4) TYPE symsgv DEFAULT sy-msgv4
+        !ii_log         TYPE REF TO zif_abapgit_log OPTIONAL
         !ix_previous    TYPE REF TO cx_root OPTIONAL
       RAISING
         zcx_abapgit_exception .
@@ -69,6 +72,7 @@ CLASS zcx_abapgit_exception DEFINITION
       IMPORTING
         !textid   LIKE if_t100_message=>t100key OPTIONAL
         !previous LIKE previous OPTIONAL
+        !ii_log   TYPE REF TO zif_abapgit_log OPTIONAL
         !msgv1    TYPE symsgv OPTIONAL
         !msgv2    TYPE symsgv OPTIONAL
         !msgv3    TYPE symsgv OPTIONAL
@@ -110,7 +114,7 @@ ENDCLASS.
 
 
 
-CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
+CLASS zcx_abapgit_exception IMPLEMENTATION.
 
 
   METHOD constructor ##ADT_SUPPRESS_GENERATION.
@@ -121,6 +125,7 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
     me->msgv2 = msgv2.
     me->msgv3 = msgv3.
     me->msgv4 = msgv4.
+    me->mi_log = ii_log.
 
     CLEAR me->textid.
     IF textid IS INITIAL.
@@ -299,7 +304,9 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
 
     split_text_to_symsg( lv_text ).
 
-    raise_t100( ix_previous = ix_previous ).
+    raise_t100(
+      ii_log      = ii_log
+      ix_previous = ix_previous ).
 
   ENDMETHOD.
 
@@ -321,6 +328,7 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
     RAISE EXCEPTION TYPE zcx_abapgit_exception
       EXPORTING
         textid   = ls_t100_key
+        ii_log   = ii_log
         msgv1    = iv_msgv1
         msgv2    = iv_msgv2
         msgv3    = iv_msgv3

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -432,7 +432,6 @@ INTERFACE zif_abapgit_definitions
       repo_syntax_check             TYPE string VALUE 'repo_syntax_check',
       repo_code_inspector           TYPE string VALUE 'repo_code_inspector',
       repo_open_in_master_lang      TYPE string VALUE 'repo_open_in_master_lang',
-      repo_log                      TYPE string VALUE 'repo_log',
       abapgit_home                  TYPE string VALUE 'abapgit_home',
       zip_import                    TYPE string VALUE 'zip_import',
       zip_export                    TYPE string VALUE 'zip_export',


### PR DESCRIPTION
to #2821

This might need some reviewing and testing. I will yet adjust repo class itself to remove unnecesary methods.

@larshp But it already demonstrates what I was talking about in #2821. So in essence:

1) `zcx` may optionally receive a log instance
2) Example of usage is in `zcl_abapgit_objects=>delete` - all handling on it's way is removed and it bubbles up till ...
3) ... the GUI catches the exception and checks of log is there, and show is. (yet to do the `gui_page` error rendering feature - I didn't touch it)
4) the log class got 2 new features (not used in the code though yet): `merge_with` and `from_exception`. The first will be very useful to merge logs created in different parts of the code (e.g. mass serialization). The second is for converting one sception to a log, shell we decide to choose log as a main way to communicate with user
5) added some UTs for the log

UPD:
6) log can also `clone`, and `merge_with( min_level )`, where level is severity of message

The rest of changes are more or less unifications of log usage in various places (needs testing)