### PR TITLE
refactor, remove bcs and solix usage

### DIFF
--- a/src/ui/zcl_abapgit_frontend_services.clas.abap
+++ b/src/ui/zcl_abapgit_frontend_services.clas.abap
@@ -12,15 +12,17 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_frontend_services IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_FRONTEND_SERVICES IMPLEMENTATION.
 
 
   METHOD zif_abapgit_frontend_services~file_download.
 
-    DATA:
-      lt_rawdata  TYPE solix_tab.
+    TYPES ty_hex TYPE x LENGTH 200.
+    DATA lt_rawdata TYPE STANDARD TABLE OF ty_hex WITH EMPTY KEY.
 
-    lt_rawdata = cl_bcs_convert=>xstring_to_solix( iv_xstr ).
+    zcl_abapgit_convert=>xstring_to_bintab(
+      EXPORTING iv_xstr   = iv_xstr
+      IMPORTING et_bintab = lt_rawdata ).
 
     cl_gui_frontend_services=>gui_download(
       EXPORTING

--- a/src/ui/zcl_abapgit_frontend_services.clas.abap
+++ b/src/ui/zcl_abapgit_frontend_services.clas.abap
@@ -18,7 +18,7 @@ CLASS ZCL_ABAPGIT_FRONTEND_SERVICES IMPLEMENTATION.
   METHOD zif_abapgit_frontend_services~file_download.
 
     TYPES ty_hex TYPE x LENGTH 200.
-    DATA lt_rawdata TYPE STANDARD TABLE OF ty_hex WITH EMPTY KEY.
+    DATA lt_rawdata TYPE STANDARD TABLE OF ty_hex WITH DEFAULT KEY.
 
     zcl_abapgit_convert=>xstring_to_bintab(
       EXPORTING iv_xstr   = iv_xstr

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -73,7 +73,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_zip IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
 
   METHOD encode_files.
@@ -299,45 +299,9 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
 
   METHOD save_binstring_to_localfile.
 
-    DATA lt_rawdata TYPE solix_tab.
-
-    lt_rawdata = cl_bcs_convert=>xstring_to_solix( iv_binstring ).
-
-    cl_gui_frontend_services=>gui_download(
-      EXPORTING
-        bin_filesize              = xstrlen( iv_binstring )
-        filename                  = iv_filename
-        filetype                  = 'BIN'
-      CHANGING
-        data_tab                  = lt_rawdata
-      EXCEPTIONS
-        file_write_error          = 1
-        no_batch                  = 2
-        gui_refuse_filetransfer   = 3
-        invalid_type              = 4
-        no_authority              = 5
-        unknown_error             = 6
-        header_not_allowed        = 7
-        separator_not_allowed     = 8
-        filesize_not_allowed      = 9
-        header_too_long           = 10
-        dp_error_create           = 11
-        dp_error_send             = 12
-        dp_error_write            = 13
-        unknown_dp_error          = 14
-        access_denied             = 15
-        dp_out_of_memory          = 16
-        disk_full                 = 17
-        dp_timeout                = 18
-        file_not_found            = 19
-        dataprovider_exception    = 20
-        control_flush_error       = 21
-        not_supported_by_gui      = 22
-        error_no_gui              = 23
-        OTHERS                    = 24 ).
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from gui_download' ).
-    ENDIF.
+    zcl_abapgit_ui_factory=>get_frontend_services( )->file_download(
+      iv_path = iv_filename
+      iv_xstr = iv_binstring ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
this removes a usage of `cl_bcs_convert=>xstring_to_solix`, plus `solix_tab`, replacing with builtin and existing functionality
