### PR TITLE
zcl_abapgit_time, rounding not needed

### DIFF
--- a/src/utils/zcl_abapgit_time.clas.abap
+++ b/src/utils/zcl_abapgit_time.clas.abap
@@ -33,7 +33,7 @@ CLASS ZCL_ABAPGIT_TIME IMPLEMENTATION.
 
     CONSTANTS lc_epoch TYPE timestamp VALUE '19700101000000'.
     DATA lv_time TYPE timestamp.
-    DATA lv_seconds TYPE tzntstmpl.
+    DATA lv_seconds TYPE i.
 
     GET TIME STAMP FIELD lv_time.
 
@@ -41,8 +41,7 @@ CLASS ZCL_ABAPGIT_TIME IMPLEMENTATION.
       tstmp1 = lv_time
       tstmp2 = lc_epoch ).
 
-    rv_time = round( val = lv_seconds
-                     dec = 0 ).
+    rv_time = lv_seconds.
     CONDENSE rv_time.
     rv_time+11 = '+000000'.
 


### PR DESCRIPTION
changed the type to an integer, then the rounding is not needed

minor change, more simple code