### PR TITLE
Refactor "Change Remote" to html form

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_ch_remote.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ch_remote.clas.abap
@@ -38,9 +38,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE IMPLEMENTATION.
   METHOD constructor.
 
     super->constructor( ).
-
     mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
-
     ms_control-page_title = 'Change Remote'.
 
   ENDMETHOD.
@@ -53,7 +51,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE IMPLEMENTATION.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
     CREATE OBJECT lo_map.
-
 
     lo_form = zcl_abapgit_html_form=>create( ).
 
@@ -69,7 +66,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE IMPLEMENTATION.
       iv_label    = 'Save'
       iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
       iv_action   = c_event-save ).
-
     lo_form->command(
       iv_label  = 'Back'
       iv_action = c_event-go_back ).

--- a/src/ui/zcl_abapgit_gui_page_ch_remote.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ch_remote.clas.abap
@@ -1,0 +1,73 @@
+CLASS zcl_abapgit_gui_page_ch_remote DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_page
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+
+    METHODS render_content
+        REDEFINITION .
+  PRIVATE SECTION.
+    CONSTANTS:
+      BEGIN OF c_event,
+        go_back TYPE string VALUE 'go_back',
+        save    TYPE string VALUE 'save',
+      END OF c_event .
+    DATA mv_key TYPE zif_abapgit_persistence=>ty_repo-key .
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( ).
+
+    mv_key = iv_key.
+    ms_control-page_title = 'Change Remote'.
+
+  ENDMETHOD.
+
+
+  METHOD render_content.
+
+    DATA lo_form TYPE REF TO zcl_abapgit_html_form.
+    DATA lo_map TYPE REF TO zcl_abapgit_string_map.
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+    CREATE OBJECT lo_map.
+
+
+    lo_form = zcl_abapgit_html_form=>create( ).
+
+    lo_form->text(
+      iv_name     = 'REMOTE'
+      iv_required = abap_true
+      iv_label    = 'Remote' ).
+    lo_map->set(
+      iv_key = 'REMOTE'
+      iv_val = 'sdf' ).
+
+    lo_form->command(
+      iv_label    = 'Save Settings'
+      iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
+      iv_action   = c_event-save ).
+
+    lo_form->command(
+      iv_label  = 'Back'
+      iv_action = c_event-go_back ).
+
+    ri_html->add( lo_form->render( lo_map ) ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_ch_remote.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ch_remote.clas.abap
@@ -57,7 +57,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE IMPLEMENTATION.
     lo_form->text(
       iv_name     = c_remote_field
       iv_required = abap_true
-      iv_label    = 'Remote' ).
+      iv_label = 'New GIT Repository URL'
+      iv_hint  = 'HTTPS address of the repository' ).
     lo_map->set(
       iv_key = c_remote_field
       iv_val = mo_repo->get_url( ) ).
@@ -84,8 +85,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE IMPLEMENTATION.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
 
       WHEN c_event-save.
-        lv_url = ii_event->form_data( )->get( c_remote_field ).
+        lv_url = condense( ii_event->form_data( )->get( c_remote_field ) ).
         ASSERT NOT lv_url IS INITIAL.
+
+        zcl_abapgit_repo_srv=>get_instance( )->validate_url( lv_url ).
+
         mo_repo->set_url( lv_url ).
         COMMIT WORK.
 

--- a/src/ui/zcl_abapgit_gui_page_ch_remote.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_ch_remote.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_CH_REMOTE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>GUI - Change Remote</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -141,7 +141,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_router IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -582,15 +582,18 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
     lv_key = ii_event->query( )->get( 'KEY' ).
 
     CASE ii_event->mv_action.
-      WHEN zif_abapgit_definitions=>c_action-repo_remote_attach.            " Remote attach
+      WHEN zif_abapgit_definitions=>c_action-repo_remote_attach.
         zcl_abapgit_services_repo=>remote_attach( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
-      WHEN zif_abapgit_definitions=>c_action-repo_remote_detach.            " Remote detach
+      WHEN zif_abapgit_definitions=>c_action-repo_remote_detach.
         zcl_abapgit_services_repo=>remote_detach( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
-      WHEN zif_abapgit_definitions=>c_action-repo_remote_change.            " Remote change
-        zcl_abapgit_services_repo=>remote_change( lv_key ).
-        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+      WHEN zif_abapgit_definitions=>c_action-repo_remote_change.
+*       zcl_abapgit_services_repo=>remote_change( lv_key ).
+        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_ch_remote
+          EXPORTING
+            iv_key = lv_key.
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
     ENDCASE.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -589,7 +589,6 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         zcl_abapgit_services_repo=>remote_detach( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-repo_remote_change.
-*       zcl_abapgit_services_repo=>remote_change( lv_key ).
         CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_ch_remote
           EXPORTING
             iv_key = lv_key.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -46,11 +46,6 @@ CLASS zcl_abapgit_services_repo DEFINITION
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS remote_change
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception .
     CLASS-METHODS refresh_local_checksums
       IMPORTING
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -93,7 +88,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD check_package.
@@ -445,37 +440,6 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     lo_repo->select_branch( ls_popup-branch_name ).
 
     ls_loc = lo_repo->get_local_settings( ). " Just in case ... if switch affects LS state
-    ls_loc-display_name = ls_popup-display_name.
-    lo_repo->set_local_settings( ls_loc ).
-
-    COMMIT WORK.
-
-  ENDMETHOD.
-
-
-  METHOD remote_change.
-
-    DATA: ls_popup TYPE zif_abapgit_popups=>ty_popup,
-          ls_loc   TYPE zif_abapgit_persistence=>ty_repo-local_settings,
-          lo_repo  TYPE REF TO zcl_abapgit_repo_online.
-
-    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
-    ls_loc = lo_repo->get_local_settings( ).
-
-    ls_popup = zcl_abapgit_ui_factory=>get_popups( )->repo_popup(
-      iv_title          = 'Change repo remote ...'
-      iv_url            = lo_repo->get_url( )
-      iv_package        = lo_repo->get_package( )
-      iv_display_name   = ls_loc-display_name
-      iv_freeze_package = abap_true ).
-    IF ls_popup-cancel = abap_true.
-      RAISE EXCEPTION TYPE zcx_abapgit_cancel.
-    ENDIF.
-
-    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
-    lo_repo->set_url( ls_popup-url ).
-    lo_repo->select_branch( ls_popup-branch_name ).
-
     ls_loc-display_name = ls_popup-display_name.
     lo_repo->set_local_settings( ls_loc ).
 


### PR DESCRIPTION
refactor the "Change Remote" SAP GUI native popup, to a new abapGit HML page using HTML forms

this removes one use of `zcl_abapgit_ui_factory=>get_popups( )->repo_popup(`, which we want to get rid of
