### PR TITLE
Refactor "Object to Files" to html form

### DIFF
--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -205,9 +205,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       iv_txt = 'Object to Files'
       iv_act = zif_abapgit_definitions=>c_action-zip_object
     )->add(
-      iv_txt = 'Test Changed by'
-      iv_act = zif_abapgit_definitions=>c_action-changed_by
-    )->add(
       iv_txt = 'Debug Info'
       iv_act = zif_abapgit_definitions=>c_action-go_debuginfo ).
 

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -202,7 +202,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       iv_txt = 'Transport to ZIP'
       iv_act = zif_abapgit_definitions=>c_action-zip_transport
     )->add(
-      iv_txt = 'Object to ZIP'
+      iv_txt = 'Object to Files'
       iv_act = zif_abapgit_definitions=>c_action-zip_object
     )->add(
       iv_txt = 'Test Changed by'

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -202,7 +202,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       iv_txt = 'Transport to ZIP'
       iv_act = zif_abapgit_definitions=>c_action-zip_transport
     )->add(
-      iv_txt = 'Object to Files'
+      iv_txt = 'Object to ZIP'
       iv_act = zif_abapgit_definitions=>c_action-zip_object
     )->add(
       iv_txt = 'Test Changed by'

--- a/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
@@ -1,0 +1,73 @@
+CLASS zcl_abapgit_gui_page_ex_object DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_page
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS constructor
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION.
+
+  PROTECTED SECTION.
+    METHODS render_content REDEFINITION.
+  PRIVATE SECTION.
+    DATA mo_form_data TYPE REF TO zcl_abapgit_string_map.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
+  METHOD constructor.
+    super->constructor( ).
+
+    CREATE OBJECT mo_form_data.
+    ms_control-page_title = 'Export Object as ZIP'.
+  ENDMETHOD.
+
+  METHOD render_content.
+    DATA lo_form TYPE REF TO zcl_abapgit_html_form.
+
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    lo_form = zcl_abapgit_html_form=>create( ).
+
+    lo_form->text(
+      iv_name     = 'object_type'
+      iv_required = abap_true
+      iv_upper_case = abap_true
+      iv_side_action = 'choose-object-type'
+      iv_label = 'Object Type'
+    ).
+
+    lo_form->command(
+      iv_label    = 'Save'
+      iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
+      iv_action   = 'save' ).
+    lo_form->command(
+      iv_label  = 'Back'
+      iv_action = 'go-back' ).
+
+    ri_html->add( lo_form->render( mo_form_data ) ).
+  ENDMETHOD.
+
+  METHOD zif_abapgit_gui_event_handler~on_event.
+    CASE ii_event->mv_action.
+      WHEN 'go-back'.
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
+      WHEN 'choose-object-type'.
+        mo_form_data->set(
+          iv_key = 'object_type'
+          iv_val = zcl_abapgit_ui_factory=>get_popups( )->popup_search_help( 'TADIR-OBJECT' ) ).
+        IF mo_form_data->get( 'object_type' ) IS NOT INITIAL.
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+        ELSE.
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
+        ENDIF.
+    ENDCASE.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
@@ -1,33 +1,50 @@
 CLASS zcl_abapgit_gui_page_ex_object DEFINITION
   PUBLIC
-  INHERITING FROM zcl_abapgit_gui_page
+  INHERITING FROM zcl_abapgit_gui_component
   FINAL
-  CREATE PUBLIC.
+  CREATE PRIVATE.
 
   PUBLIC SECTION.
+    INTERFACES zif_abapgit_gui_event_handler.
+    INTERFACES zif_abapgit_gui_renderable.
+
+    CLASS-METHODS create
+      RETURNING
+        VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
+      RAISING
+        zcx_abapgit_exception.
     METHODS constructor
       RAISING
         zcx_abapgit_exception.
 
-    METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION.
-
   PROTECTED SECTION.
-    METHODS render_content REDEFINITION.
   PRIVATE SECTION.
     CONSTANTS:
       BEGIN OF c_id,
         object_type TYPE string VALUE 'object_type',
+        object_name TYPE string VALUE 'object_name',
       END OF c_id.
 
     CONSTANTS:
       BEGIN OF c_event,
         go_back            TYPE string VALUE 'go-back',
-        save               TYPE string VALUE 'save',
+        export             TYPE string VALUE 'export',
         choose_object_type TYPE string VALUE 'choose-object-type',
       END OF c_event.
 
 
+    DATA mo_form TYPE REF TO zcl_abapgit_html_form.
     DATA mo_form_data TYPE REF TO zcl_abapgit_string_map.
+    DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map.
+    DATA mo_form_util TYPE REF TO zcl_abapgit_html_form_utils.
+
+    METHODS get_form_schema
+      RETURNING
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form.
+
+    METHODS export_object
+      RAISING
+        zcx_abapgit_exception.
 ENDCLASS.
 
 
@@ -35,45 +52,60 @@ ENDCLASS.
 CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
   METHOD constructor.
     super->constructor( ).
-
+    CREATE OBJECT mo_validation_log.
     CREATE OBJECT mo_form_data.
-    ms_control-page_title = 'Export Object as ZIP'.
+    mo_form = get_form_schema( ).
+    mo_form_util = zcl_abapgit_html_form_utils=>create( mo_form ).
   ENDMETHOD.
 
-  METHOD render_content.
+  METHOD create.
 
-    DATA lo_form TYPE REF TO zcl_abapgit_html_form.
+    DATA lo_component TYPE REF TO zcl_abapgit_gui_page_ex_object.
+    CREATE OBJECT lo_component.
 
-    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-    lo_form = zcl_abapgit_html_form=>create( ).
+    ri_page = zcl_abapgit_gui_page_hoc=>create(
+      iv_page_title      = 'Export Object to Files'
+      ii_child_component = lo_component ).
 
-    lo_form->text(
+  ENDMETHOD.
+
+  METHOD get_form_schema.
+
+    ro_form = zcl_abapgit_html_form=>create( iv_form_id = 'export-object-to-files' ).
+
+    ro_form->text(
+      iv_label       = 'Object Type'
       iv_name        = c_id-object_type
       iv_required    = abap_true
       iv_upper_case  = abap_true
       iv_side_action = c_event-choose_object_type
-      iv_label       = 'Object Type' ).
+    )->text(
+      iv_label       = 'Object Name'
+      iv_name        = c_id-object_name
+      iv_required    = abap_true
+      iv_upper_case  = abap_true
+    )->command(
+      iv_label       = 'Export'
+      iv_cmd_type    = zif_abapgit_html_form=>c_cmd_type-input_main
+      iv_action      = c_event-export
+    )->command(
+      iv_label       = 'Back'
+      iv_action      = c_event-go_back ).
 
-    lo_form->command(
-      iv_label    = 'Save'
-      iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
-      iv_action   = c_event-save ).
-
-    lo_form->command(
-      iv_label  = 'Back'
-      iv_action = c_event-go_back ).
-
-    ri_html->add( lo_form->render( mo_form_data ) ).
   ENDMETHOD.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
+    mo_form_data = mo_form_util->normalize( ii_event->form_data( ) ).
     CASE ii_event->mv_action.
       WHEN c_event-go_back.
 
         rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
 
-      WHEN c_event-save.
+      WHEN c_event-export.
 
+        export_object( ).
+        MESSAGE 'Object successfully exported' TYPE 'S'.
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
       WHEN c_event-choose_object_type.
 
         mo_form_data->set(
@@ -87,6 +119,30 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
         ENDIF.
 
     ENDCASE.
+  ENDMETHOD.
+
+
+  METHOD export_object.
+    DATA lv_object_type TYPE trobjtype.
+    DATA lv_object_name TYPE sobj_name.
+
+    lv_object_type = mo_form_data->get( c_id-object_type ).
+    lv_object_name = mo_form_data->get( c_id-object_name ).
+
+    zcl_abapgit_zip=>export_object(
+      iv_object_type = lv_object_type
+      iv_object_name = lv_object_name ).
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_gui_renderable~render.
+    gui_services( )->register_event_handler( me ).
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    ri_html->add( mo_form->render(
+      io_values         = mo_form_data
+      io_validation_log = mo_validation_log ) ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
@@ -14,6 +14,19 @@ CLASS zcl_abapgit_gui_page_ex_object DEFINITION
   PROTECTED SECTION.
     METHODS render_content REDEFINITION.
   PRIVATE SECTION.
+    CONSTANTS:
+      BEGIN OF c_id,
+        object_type TYPE string VALUE 'object_type',
+      END OF c_id.
+
+    CONSTANTS:
+      BEGIN OF c_event,
+        go_back            TYPE string VALUE 'go-back',
+        save               TYPE string VALUE 'save',
+        choose_object_type TYPE string VALUE 'choose-object-type',
+      END OF c_event.
+
+
     DATA mo_form_data TYPE REF TO zcl_abapgit_string_map.
 ENDCLASS.
 
@@ -28,45 +41,51 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD render_content.
+
     DATA lo_form TYPE REF TO zcl_abapgit_html_form.
 
-
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-
     lo_form = zcl_abapgit_html_form=>create( ).
 
     lo_form->text(
-      iv_name     = 'object_type'
-      iv_required = abap_true
-      iv_upper_case = abap_true
-      iv_side_action = 'choose-object-type'
-      iv_label = 'Object Type'
-    ).
+      iv_name        = c_id-object_type
+      iv_required    = abap_true
+      iv_upper_case  = abap_true
+      iv_side_action = c_event-choose_object_type
+      iv_label       = 'Object Type' ).
 
     lo_form->command(
       iv_label    = 'Save'
       iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
-      iv_action   = 'save' ).
+      iv_action   = c_event-save ).
+
     lo_form->command(
       iv_label  = 'Back'
-      iv_action = 'go-back' ).
+      iv_action = c_event-go_back ).
 
     ri_html->add( lo_form->render( mo_form_data ) ).
   ENDMETHOD.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
     CASE ii_event->mv_action.
-      WHEN 'go-back'.
+      WHEN c_event-go_back.
+
         rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
-      WHEN 'choose-object-type'.
+
+      WHEN c_event-save.
+
+      WHEN c_event-choose_object_type.
+
         mo_form_data->set(
           iv_key = 'object_type'
           iv_val = zcl_abapgit_ui_factory=>get_popups( )->popup_search_help( 'TADIR-OBJECT' ) ).
+
         IF mo_form_data->get( 'object_type' ) IS NOT INITIAL.
           rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
         ELSE.
           rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
         ENDIF.
+
     ENDCASE.
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_ex_object.clas.abap
@@ -59,18 +59,15 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD create.
-
     DATA lo_component TYPE REF TO zcl_abapgit_gui_page_ex_object.
     CREATE OBJECT lo_component.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Export Object to Files'
       ii_child_component = lo_component ).
-
   ENDMETHOD.
 
   METHOD get_form_schema.
-
     ro_form = zcl_abapgit_html_form=>create( iv_form_id = 'export-object-to-files' ).
 
     ro_form->text(
@@ -91,11 +88,11 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
     )->command(
       iv_label       = 'Back'
       iv_action      = c_event-go_back ).
-
   ENDMETHOD.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
     mo_form_data = mo_form_util->normalize( ii_event->form_data( ) ).
+
     CASE ii_event->mv_action.
       WHEN c_event-go_back.
 
@@ -106,6 +103,7 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
         export_object( ).
         MESSAGE 'Object successfully exported' TYPE 'S'.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
+
       WHEN c_event-choose_object_type.
 
         mo_form_data->set(
@@ -117,7 +115,6 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
         ELSE.
           rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
         ENDIF.
-
     ENDCASE.
   ENDMETHOD.
 
@@ -132,7 +129,6 @@ CLASS zcl_abapgit_gui_page_ex_object IMPLEMENTATION.
     zcl_abapgit_zip=>export_object(
       iv_object_type = lv_object_type
       iv_object_name = lv_object_name ).
-
   ENDMETHOD.
 
   METHOD zif_abapgit_gui_renderable~render.

--- a/src/ui/zcl_abapgit_gui_page_ex_object.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_ex_object.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_EX_OBJECT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Export Object</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -560,9 +560,6 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
   METHOD other_utilities.
 
     CASE ii_event->mv_action.
-      WHEN zif_abapgit_definitions=>c_action-changed_by.
-        zcl_abapgit_services_basis=>test_changed_by( ).
-        rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
       WHEN zif_abapgit_definitions=>c_action-performance_test.
         zcl_abapgit_services_basis=>run_performance_test( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -141,7 +141,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
+CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -802,8 +802,10 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         zcl_abapgit_transport_mass=>run( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
       WHEN zif_abapgit_definitions=>c_action-zip_object.                      " Export object as ZIP
-        zcl_abapgit_zip=>export_object( ).
-        rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
+        " zcl_abapgit_zip=>export_object( ).
+        " rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
+        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_ex_object.
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
     ENDCASE.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -802,8 +802,6 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         zcl_abapgit_transport_mass=>run( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
       WHEN zif_abapgit_definitions=>c_action-zip_object.                      " Export object as ZIP
-        " zcl_abapgit_zip=>export_object( ).
-        " rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
         CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_ex_object.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
     ENDCASE.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -802,7 +802,7 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         zcl_abapgit_transport_mass=>run( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
       WHEN zif_abapgit_definitions=>c_action-zip_object.                      " Export object as ZIP
-        CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_ex_object.
+        rs_handled-page  = zcl_abapgit_gui_page_ex_object=>create( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
     ENDCASE.
 

--- a/src/ui/zcl_abapgit_html_form_utils.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_form_utils.clas.testclasses.abap
@@ -50,9 +50,6 @@ CLASS ltcl_popups_mock IMPLEMENTATION.
   METHOD zif_abapgit_popups~popup_folder_logic.
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~popup_object.
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~popup_package_export.
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -721,38 +721,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
   ENDMETHOD.
 
-
-  METHOD zif_abapgit_popups~popup_object.
-
-    DATA: lt_fields      TYPE TABLE OF sval.
-    DATA: lv_object_type TYPE spo_value.
-    DATA: lv_object_name TYPE spo_value.
-
-    CLEAR: rs_tadir-object, rs_tadir-obj_name.
-
-    add_field( EXPORTING iv_tabname   = 'TADIR'
-                         iv_fieldname = 'OBJECT'
-                         iv_fieldtext = 'Type'
-               CHANGING ct_fields     = lt_fields ).
-
-    add_field( EXPORTING iv_tabname   = 'TADIR'
-                         iv_fieldname = 'OBJ_NAME'
-                         iv_fieldtext = 'Name'
-               CHANGING ct_fields     = lt_fields ).
-
-    _popup_3_get_values( EXPORTING iv_popup_title    = 'Object'
-                                   iv_no_value_check = abap_true
-                         IMPORTING ev_value_1        = lv_object_type
-                                   ev_value_2        = lv_object_name
-                         CHANGING  ct_fields         = lt_fields ).
-
-    rs_tadir = zcl_abapgit_factory=>get_tadir( )->read_single(
-      iv_object   = to_upper( lv_object_type )
-      iv_obj_name = to_upper( lv_object_name ) ).
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_popups~popup_package_export.
 
     DATA: lt_fields       TYPE TABLE OF sval.

--- a/src/ui/zcl_abapgit_services_basis.clas.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.abap
@@ -11,9 +11,6 @@ CLASS zcl_abapgit_services_basis DEFINITION
         VALUE(rv_package)  TYPE devclass
       RAISING
         zcx_abapgit_exception.
-    CLASS-METHODS test_changed_by
-      RAISING
-        zcx_abapgit_exception.
     CLASS-METHODS run_performance_test
       RAISING
         zcx_abapgit_exception.
@@ -195,26 +192,5 @@ CLASS zcl_abapgit_services_basis IMPLEMENTATION.
           iv_text     = lx_salv_error->get_text( )
           ix_previous = lx_salv_error ).
     ENDTRY.
-  ENDMETHOD.
-
-
-  METHOD test_changed_by.
-
-    DATA ls_tadir TYPE zif_abapgit_definitions=>ty_tadir.
-    DATA ls_item  TYPE zif_abapgit_definitions=>ty_item.
-    DATA lv_user  TYPE xubname.
-
-    ls_tadir = zcl_abapgit_ui_factory=>get_popups( )->popup_object( ).
-    IF ls_tadir IS INITIAL.
-      RETURN.
-    ENDIF.
-
-    ls_item-obj_type = ls_tadir-object.
-    ls_item-obj_name = ls_tadir-obj_name.
-
-    lv_user = zcl_abapgit_objects=>changed_by( ls_item ).
-
-    MESSAGE lv_user TYPE 'S'.
-
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_services_basis.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.testclasses.abap
@@ -350,10 +350,6 @@ CLASS ltcl_popups_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~popup_object.
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~popup_package_export.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
@@ -44,10 +44,6 @@ CLASS ltcl_abapgit_popups_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~popup_object.
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~popup_package_export.
 
   ENDMETHOD.

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -37,11 +37,6 @@ INTERFACE zif_abapgit_popups
       VALUE(rv_folder_logic) TYPE string
     RAISING
       zcx_abapgit_exception .
-  METHODS popup_object
-    RETURNING
-      VALUE(rs_tadir) TYPE zif_abapgit_definitions=>ty_tadir
-    RAISING
-      zcx_abapgit_exception .
   METHODS create_branch_popup
     IMPORTING
       !iv_source_branch_name TYPE string

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -482,7 +482,6 @@ INTERFACE zif_abapgit_definitions
       change_order_by               TYPE string VALUE 'change_order_by',
       goto_message                  TYPE string VALUE 'goto_message',
       direction                     TYPE string VALUE 'direction',
-      changed_by                    TYPE string VALUE 'changed_by',
       documentation                 TYPE string VALUE 'documentation',
       changelog                     TYPE string VALUE 'changelog',
     END OF c_action.


### PR DESCRIPTION
closes #4619

requires #4626 for the search help to work correctly

goal is to get rid of `popup_object`, it's still used in `zcl_abapgit_services_basis->test_changed_by`, not quite sure how to approach it in scope of this PR.