### PR TITLE
overview page, dont display ".git"

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -301,6 +301,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
       lv_check_link      TYPE string,
       lv_text            TYPE string,
       lv_settings_link   TYPE string.
+    DATA lv_new_length TYPE i.
 
     FIELD-SYMBOLS: <ls_overview> LIKE LINE OF it_overview.
 
@@ -339,7 +340,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
         REPLACE FIRST OCCURRENCE OF 'https://' IN lv_text WITH ''.
         REPLACE FIRST OCCURRENCE OF 'http://' IN lv_text WITH ''.
         IF lv_text CP '*.git'.
-          REPLACE REGEX '\.git$' IN lv_text WITH ''.
+          lv_new_length = strlen( lv_text ) - 4.
+          lv_text  = lv_text(lv_new_length).
         ENDIF.
         ii_html->add( |<td>{ ii_html->a(
           iv_txt   = lv_text

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -115,7 +115,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
 
 
   METHOD apply_filter.
@@ -338,6 +338,9 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
         lv_text = <ls_overview>-url.
         REPLACE FIRST OCCURRENCE OF 'https://' IN lv_text WITH ''.
         REPLACE FIRST OCCURRENCE OF 'http://' IN lv_text WITH ''.
+        IF lv_text CP '*.git'.
+          REPLACE REGEX '\.git$' IN lv_text WITH ''.
+        ENDIF.
         ii_html->add( |<td>{ ii_html->a(
           iv_txt   = lv_text
           iv_title = <ls_overview>-url
@@ -430,6 +433,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
     ii_html->add( |</tbody>| ).
 
   ENDMETHOD.
+
 
   METHOD render_table_header.
 


### PR DESCRIPTION
dont display ".git" in the urls in the overview page, to save a bit more horizontal space

also see #4539