### PR TITLE
user exit: wall messages

### DIFF
--- a/docs/ref-exits.md
+++ b/docs/ref-exits.md
@@ -68,3 +68,11 @@ Can be used to modify local and remote files before calculating diff status. Use
 ![diff sample](./img/deployment_diff_difference_sample.png)
 
 The exit also receives a repo meta data snapshot (`zif_abapgit_persistence=>ty_repo`) to identify the repo and it's attributes in the current system (e.g. package). This can be used to enable/disable the exit for specific repos.
+
+### WALL_MESSAGE_LIST
+
+Can be used to add a message at list level
+
+### WALL_MESSAGE_REPO
+
+Can be used to add a message at repo level

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -584,6 +584,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     render_header_bar( ri_html ).
+
+    zcl_abapgit_exit=>get_instance( )->wall_message_list( ri_html ).
+
     render_table( ii_html     = ri_html
                   it_overview = mt_overview ).
 

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -191,7 +191,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -798,6 +798,10 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
           iv_interactive_branch = abap_true ) ).
 
         ri_html->add( zcl_abapgit_gui_chunk_lib=>render_news( io_news = lo_news ) ).
+
+        zcl_abapgit_exit=>get_instance( )->wall_message_repo(
+          is_repo_meta = mo_repo->ms_data
+          ii_html      = ri_html ).
 
         CREATE OBJECT lo_browser
           EXPORTING

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -208,4 +208,26 @@ CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~wall_message_list.
+
+    TRY.
+        gi_exit->wall_message_list( ii_html ).
+      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~wall_message_repo.
+
+    TRY.
+        gi_exit->wall_message_repo(
+          is_repo_meta = is_repo_meta
+          ii_html      = ii_html ).
+      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+    ENDTRY.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -12,27 +12,43 @@ INTERFACE zif_abapgit_exit
   TYPES:
     ty_ci_repos TYPE TABLE OF ty_ci_repo .
 
-  METHODS change_local_host
+  METHODS adjust_display_commit_url
+    IMPORTING
+      !iv_repo_url    TYPE csequence
+      !iv_repo_name   TYPE csequence
+      !iv_repo_key    TYPE csequence
+      !iv_commit_hash TYPE zif_abapgit_definitions=>ty_sha1
     CHANGING
-      !ct_hosts TYPE ty_icm_sinfo2_tt .
+      !cv_display_url TYPE csequence
+    RAISING
+      zcx_abapgit_exception .
   METHODS allow_sap_objects
     RETURNING
       VALUE(rv_allowed) TYPE abap_bool .
-  METHODS change_proxy_url
-    IMPORTING
-      !iv_repo_url  TYPE csequence
+  METHODS change_local_host
     CHANGING
-      !cv_proxy_url TYPE string .
-  METHODS change_proxy_port
-    IMPORTING
-      !iv_repo_url   TYPE csequence
-    CHANGING
-      !cv_proxy_port TYPE string .
+      !ct_hosts TYPE ty_icm_sinfo2_tt .
   METHODS change_proxy_authentication
     IMPORTING
       !iv_repo_url             TYPE csequence
     CHANGING
       !cv_proxy_authentication TYPE abap_bool .
+  METHODS change_proxy_port
+    IMPORTING
+      !iv_repo_url   TYPE csequence
+    CHANGING
+      !cv_proxy_port TYPE string .
+  METHODS change_proxy_url
+    IMPORTING
+      !iv_repo_url  TYPE csequence
+    CHANGING
+      !cv_proxy_url TYPE string .
+  METHODS change_tadir
+    IMPORTING
+      !iv_package TYPE devclass
+      !ii_log     TYPE REF TO zif_abapgit_log
+    CHANGING
+      !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt .
   METHODS create_http_client
     IMPORTING
       !iv_url          TYPE string
@@ -40,19 +56,6 @@ INTERFACE zif_abapgit_exit
       VALUE(ri_client) TYPE REF TO if_http_client
     RAISING
       zcx_abapgit_exception .
-  METHODS http_client
-    IMPORTING
-      !iv_url    TYPE string
-      !ii_client TYPE REF TO if_http_client .
-  METHODS change_tadir
-    IMPORTING
-      !iv_package TYPE devclass
-      !ii_log     TYPE REF TO zif_abapgit_log
-    CHANGING
-      !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt .
-  METHODS get_ssl_id
-    RETURNING
-      VALUE(rv_ssl_id) TYPE ssfapplssl .
   METHODS custom_serialize_abap_clif
     IMPORTING
       !is_class_key    TYPE seoclskey
@@ -69,22 +72,26 @@ INTERFACE zif_abapgit_exit
       !iv_object   TYPE tadir-object
     CHANGING
       !ct_ci_repos TYPE ty_ci_repos .
-  METHODS adjust_display_commit_url
+  METHODS get_ssl_id
+    RETURNING
+      VALUE(rv_ssl_id) TYPE ssfapplssl .
+  METHODS http_client
     IMPORTING
-      !iv_repo_url    TYPE csequence
-      !iv_repo_name   TYPE csequence
-      !iv_repo_key    TYPE csequence
-      !iv_commit_hash TYPE zif_abapgit_definitions=>ty_sha1
-    CHANGING
-      !cv_display_url TYPE csequence
-    RAISING
-      zcx_abapgit_exception .
+      !iv_url    TYPE string
+      !ii_client TYPE REF TO if_http_client .
   METHODS pre_calculate_repo_status
     IMPORTING
-      is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
     CHANGING
-      !ct_local  TYPE zif_abapgit_definitions=>ty_files_item_tt
-      !ct_remote TYPE zif_abapgit_definitions=>ty_files_tt
+      !ct_local     TYPE zif_abapgit_definitions=>ty_files_item_tt
+      !ct_remote    TYPE zif_abapgit_definitions=>ty_files_tt
     RAISING
       zcx_abapgit_exception .
+  METHODS wall_message_list
+    IMPORTING
+      ii_html TYPE REF TO zif_abapgit_html .
+  METHODS wall_message_repo
+    IMPORTING
+      is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+      ii_html      TYPE REF TO zif_abapgit_html .
 ENDINTERFACE.


### PR DESCRIPTION
closes #4530

passes the `html` interface to the exit, so it can add messages/links/whatever as required

formatting is inherited from whatever is the state of the `html` interface