### PR TITLE
SOTS: Fix error during deserialize

### DIFF
--- a/src/objects/zcl_abapgit_object_sots.clas.abap
+++ b/src/objects/zcl_abapgit_object_sots.clas.abap
@@ -87,7 +87,8 @@ CLASS zcl_abapgit_object_sots IMPLEMENTATION.
       WHEN 3.
         zcx_abapgit_exception=>raise( |Enter a permitted object type| ).
       WHEN 4.
-        zcx_abapgit_exception=>raise( |The concept will be created in the non-original system| ).
+        "The concept will be created in the non-original system (not an error)
+        RETURN.
       WHEN 5.
         zcx_abapgit_exception=>raise( |Invalid alias| ).
       WHEN 6.


### PR DESCRIPTION
Error "The concept will be created in the non-original system" (`SOTR_MESS  137`) 

![image](https://user-images.githubusercontent.com/59966492/112045202-e02fc580-8b4a-11eb-87db-8ea706e7bda5.png)

It's not an error (see function `SOTR_STRING_CREATE_CONCEPT`) and has been removed.