### PR TITLE
Improve reuse of HTML viewer

### DIFF
--- a/src/ui/zcl_abapgit_html_viewer_gui.clas.abap
+++ b/src/ui/zcl_abapgit_html_viewer_gui.clas.abap
@@ -7,7 +7,10 @@ CLASS zcl_abapgit_html_viewer_gui DEFINITION
 
     INTERFACES zif_abapgit_html_viewer .
 
-    METHODS constructor .
+    METHODS constructor
+      IMPORTING
+        !io_container           TYPE REF TO cl_gui_container DEFAULT cl_gui_container=>screen0
+        !iv_disable_query_table TYPE abap_bool DEFAULT abap_true .
   PROTECTED SECTION.
 
     DATA mo_html_viewer TYPE REF TO cl_gui_html_viewer .
@@ -36,8 +39,8 @@ CLASS zcl_abapgit_html_viewer_gui IMPLEMENTATION.
 
     CREATE OBJECT mo_html_viewer
       EXPORTING
-        query_table_disabled = abap_true
-        parent               = cl_gui_container=>screen0.
+        query_table_disabled = iv_disable_query_table
+        parent               = io_container.
 
     ls_event-eventid    = zif_abapgit_html_viewer=>m_id_sapevent.
     ls_event-appl_event = abap_true.

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -1,7 +1,6 @@
 CLASS zcl_abapgit_ui_factory DEFINITION
   PUBLIC
   CREATE PRIVATE
-
   GLOBAL FRIENDS zcl_abapgit_ui_injector .
 
   PUBLIC SECTION.

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -1,6 +1,7 @@
 CLASS zcl_abapgit_ui_factory DEFINITION
   PUBLIC
   CREATE PRIVATE
+
   GLOBAL FRIENDS zcl_abapgit_ui_injector .
 
   PUBLIC SECTION.
@@ -33,8 +34,11 @@ CLASS zcl_abapgit_ui_factory DEFINITION
       RETURNING
         VALUE(ri_fe_serv) TYPE REF TO zif_abapgit_frontend_services .
     CLASS-METHODS get_html_viewer
+      IMPORTING
+        !io_container           TYPE REF TO cl_gui_container DEFAULT cl_gui_container=>screen0
+        !iv_disable_query_table TYPE abap_bool DEFAULT abap_true
       RETURNING
-        VALUE(ri_viewer) TYPE REF TO zif_abapgit_html_viewer .
+        VALUE(ri_viewer)        TYPE REF TO zif_abapgit_html_viewer .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -49,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
+CLASS zcl_abapgit_ui_factory IMPLEMENTATION.
 
 
   METHOD get_asset_manager.
@@ -181,7 +185,10 @@ CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
   METHOD get_html_viewer.
 
     IF gi_html_viewer IS NOT BOUND.
-      CREATE OBJECT gi_html_viewer TYPE zcl_abapgit_html_viewer_gui.
+      CREATE OBJECT gi_html_viewer TYPE zcl_abapgit_html_viewer_gui
+        EXPORTING
+          io_container           = io_container
+          iv_disable_query_table = iv_disable_query_table.
     ENDIF.
 
     ri_viewer = gi_html_viewer.


### PR DESCRIPTION
Adding optional parameters to allow reuse of HTML viewer in subscreens and allow testing of query parameter table (potential replacement of `zcl_abapgit_html_action_util=>parse...`).