### PR TITLE
Show "data" by object in repo view

### DIFF
--- a/src/data/zcl_abapgit_data_deserializer.clas.abap
+++ b/src/data/zcl_abapgit_data_deserializer.clas.abap
@@ -38,8 +38,9 @@ CLASS zcl_abapgit_data_deserializer DEFINITION
         !iv_name       TYPE tadir-obj_name
         !it_where      TYPE string_table
       RETURNING
-        VALUE(rr_data) TYPE REF TO data .
-
+        VALUE(rr_data) TYPE REF TO data
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -16,11 +16,6 @@ CLASS zcl_abapgit_data_utils DEFINITION
         !is_config         TYPE zif_abapgit_data_config=>ty_config
       RETURNING
         VALUE(rv_filename) TYPE string .
-    CLASS-METHODS get_item
-      IMPORTING
-        !is_config     TYPE zif_abapgit_data_config=>ty_config
-      RETURNING
-        VALUE(rs_item) TYPE zif_abapgit_definitions=>ty_item .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -64,17 +59,6 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
       CATCH cx_root.
         zcx_abapgit_exception=>raise( |Error creating internal table for data serialization| ).
     ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD get_item.
-
-    rs_item-obj_type = is_config-type.
-    rs_item-obj_name = is_config-name.
-
-    SELECT SINGLE devclass FROM tadir INTO rs_item-devclass
-      WHERE pgmid = 'R3TR' AND object = 'TABL' AND obj_name = rs_item-obj_name ##SUBRC_OK.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -8,12 +8,19 @@ CLASS zcl_abapgit_data_utils DEFINITION
       IMPORTING
         !iv_name       TYPE tadir-obj_name
       RETURNING
-        VALUE(rr_data) TYPE REF TO data .
+        VALUE(rr_data) TYPE REF TO data
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS build_filename
       IMPORTING
         !is_config         TYPE zif_abapgit_data_config=>ty_config
       RETURNING
         VALUE(rv_filename) TYPE string .
+    CLASS-METHODS get_item
+      IMPORTING
+        !is_config     TYPE zif_abapgit_data_config=>ty_config
+      RETURNING
+        VALUE(rs_item) TYPE zif_abapgit_definitions=>ty_item .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -34,13 +41,40 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
 
   METHOD build_table_itab.
 
-    DATA lo_structure TYPE REF TO cl_abap_structdescr.
+    DATA lo_type TYPE REF TO cl_abap_typedescr.
+    DATA lo_data TYPE REF TO cl_abap_datadescr.
     DATA lo_table TYPE REF TO cl_abap_tabledescr.
 
-    lo_structure ?= cl_abap_structdescr=>describe_by_name( iv_name ).
+    cl_abap_structdescr=>describe_by_name(
+      EXPORTING
+        p_name         = iv_name
+      RECEIVING
+        p_descr_ref    = lo_type
+      EXCEPTIONS
+        type_not_found = 1 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Table { iv_name } not found for data serialization| ).
+    ENDIF.
+
+    TRY.
+        lo_data ?= lo_type.
 * todo, also add unique key corresponding to the db table, so duplicates cannot be returned
-    lo_table = cl_abap_tabledescr=>create( lo_structure ).
-    CREATE DATA rr_data TYPE HANDLE lo_table.
+        lo_table = cl_abap_tabledescr=>create( lo_data ).
+        CREATE DATA rr_data TYPE HANDLE lo_table.
+      CATCH cx_root.
+        zcx_abapgit_exception=>raise( |Error creating internal table for data serialization| ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD get_item.
+
+    rs_item-obj_type = is_config-type.
+    rs_item-obj_name = is_config-name.
+
+    SELECT SINGLE devclass FROM tadir INTO rs_item-devclass
+      WHERE pgmid = 'R3TR' AND object = 'TABL' AND obj_name = rs_item-obj_name ##SUBRC_OK.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/data/zcl_abapgit_data_utils.clas.testclasses.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.testclasses.abap
@@ -6,7 +6,6 @@ CLASS ltcl_data_utils_test DEFINITION FINAL
   PRIVATE SECTION.
 
     METHODS build_filename FOR TESTING.
-    METHODS get_item FOR TESTING.
 
 ENDCLASS.
 
@@ -29,27 +28,6 @@ CLASS ltcl_data_utils_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_data_utils=>build_filename( ls_config )
       exp = '#nspc#t200.tabu.json' ).
-
-  ENDMETHOD.
-
-  METHOD get_item.
-
-    DATA ls_config TYPE zif_abapgit_data_config=>ty_config.
-
-    ls_config-name = 'T100'.
-    ls_config-type = 'TABU'.
-
-    cl_abap_unit_assert=>assert_equals(
-      act = zcl_abapgit_data_utils=>get_item( ls_config )-obj_type
-      exp = 'TABU' ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = zcl_abapgit_data_utils=>get_item( ls_config )-obj_name
-      exp = 'T100' ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = zcl_abapgit_data_utils=>get_item( ls_config )-devclass
-      exp = 'SDIC' ).
 
   ENDMETHOD.
 

--- a/src/data/zcl_abapgit_data_utils.clas.testclasses.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.testclasses.abap
@@ -6,6 +6,7 @@ CLASS ltcl_data_utils_test DEFINITION FINAL
   PRIVATE SECTION.
 
     METHODS build_filename FOR TESTING.
+    METHODS get_item FOR TESTING.
 
 ENDCLASS.
 
@@ -28,6 +29,27 @@ CLASS ltcl_data_utils_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_data_utils=>build_filename( ls_config )
       exp = '#nspc#t200.tabu.json' ).
+
+  ENDMETHOD.
+
+  METHOD get_item.
+
+    DATA ls_config TYPE zif_abapgit_data_config=>ty_config.
+
+    ls_config-name = 'T100'.
+    ls_config-type = 'TABU'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_data_utils=>get_item( ls_config )-obj_type
+      exp = 'TABU' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_data_utils=>get_item( ls_config )-obj_name
+      exp = 'T100' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_data_utils=>get_item( ls_config )-devclass
+      exp = 'SDIC' ).
 
   ENDMETHOD.
 

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -35,12 +35,14 @@ CLASS zcl_abapgit_serialize DEFINITION
         zcx_abapgit_exception .
   PROTECTED SECTION.
 
-    TYPES: BEGIN OF ty_unsupported_count,
-             obj_type TYPE tadir-object,
-             obj_name TYPE tadir-obj_name,
-             count    TYPE i,
-           END OF ty_unsupported_count,
-           ty_unsupported_count_tt TYPE HASHED TABLE OF ty_unsupported_count WITH UNIQUE KEY obj_type.
+    TYPES:
+      BEGIN OF ty_unsupported_count,
+        obj_type TYPE tadir-object,
+        obj_name TYPE tadir-obj_name,
+        count    TYPE i,
+      END OF ty_unsupported_count .
+    TYPES:
+      ty_unsupported_count_tt TYPE HASHED TABLE OF ty_unsupported_count WITH UNIQUE KEY obj_type .
     TYPES:
       ty_char32 TYPE c LENGTH 32 .
 
@@ -62,6 +64,7 @@ CLASS zcl_abapgit_serialize DEFINITION
     METHODS add_data
       IMPORTING
         !ii_data_config TYPE REF TO zif_abapgit_data_config
+        !io_dot_abapgit TYPE REF TO zcl_abapgit_dot_abapgit
       CHANGING
         !ct_files       TYPE zif_abapgit_definitions=>ty_files_item_tt
       RAISING
@@ -110,13 +113,13 @@ CLASS zcl_abapgit_serialize DEFINITION
         zcx_abapgit_exception .
     METHODS filter_unsupported_objects
       CHANGING
-        !ct_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
+        !ct_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt .
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
+CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
 
   METHOD add_apack.
@@ -150,12 +153,30 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
     LOOP AT lt_files INTO ls_file.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
+
+      zcl_abapgit_file_status=>identify_object(
+        EXPORTING
+          iv_filename = <ls_return>-file-filename
+          iv_path     = <ls_return>-file-path
+          io_dot      = io_dot_abapgit
+        IMPORTING
+          es_item     = <ls_return>-item ).
+
+      <ls_return>-item-obj_type = 'TABU'.
     ENDLOOP.
 
     lt_files = zcl_abapgit_data_factory=>get_serializer( )->serialize( ii_data_config ).
     LOOP AT lt_files INTO ls_file.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
+
+      zcl_abapgit_file_status=>identify_object(
+        EXPORTING
+          iv_filename = <ls_return>-file-filename
+          iv_path     = <ls_return>-file-path
+          io_dot      = io_dot_abapgit
+        IMPORTING
+          es_item     = <ls_return>-item ).
     ENDLOOP.
 
   ENDMETHOD.
@@ -319,6 +340,7 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
     add_data(
       EXPORTING
         ii_data_config = ii_data_config
+        io_dot_abapgit = io_dot_abapgit
       CHANGING
         ct_files       = rt_files ).
 

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -154,7 +154,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
 
-      " Derive object from config filename
+      " Derive object from config filename (namespace + escaping)
       zcl_abapgit_file_status=>identify_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename
@@ -171,7 +171,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
 
-      " Derive object from data filename 
+      " Derive object from data filename (namespace + escaping)
       zcl_abapgit_file_status=>identify_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -154,7 +154,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
 
-      " Derive object from config filename 
+      " Derive object from config filename
       zcl_abapgit_file_status=>identify_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -154,6 +154,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
 
+      " Derive object from config filename 
       zcl_abapgit_file_status=>identify_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename
@@ -170,6 +171,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       APPEND INITIAL LINE TO ct_files ASSIGNING <ls_return>.
       <ls_return>-file = ls_file.
 
+      " Derive object from data filename 
       zcl_abapgit_file_status=>identify_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename


### PR DESCRIPTION
Continuing on #3441

- "data" is now shown as `TABU` `<table>` in the repo view with two files:
  - configuration 
  - table data
- fix dump during serialize in case table does not exist 

![image](https://user-images.githubusercontent.com/59966492/113926838-fe552100-97ec-11eb-92d0-ddf92fd6405f.png)

Closes #4659