### PR TITLE
Refactor filename logic

### DIFF
--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -1,0 +1,121 @@
+CLASS zcl_abapgit_filename_logic DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CONSTANTS:
+      BEGIN OF c_package_file,
+        obj_name  TYPE c LENGTH 7 VALUE 'package',
+        sep1      TYPE c LENGTH 1 VALUE '.',
+        obj_type  TYPE c LENGTH 4 VALUE 'devc',
+        sep2      TYPE c LENGTH 1 VALUE '.',
+        extension TYPE c LENGTH 3 VALUE 'xml',
+      END OF c_package_file.
+
+    CLASS-METHODS file_to_object
+      IMPORTING
+        !iv_filename TYPE string
+        !iv_path     TYPE string
+        !iv_devclass TYPE devclass OPTIONAL
+        !io_dot      TYPE REF TO zcl_abapgit_dot_abapgit
+      EXPORTING
+        !es_item     TYPE zif_abapgit_definitions=>ty_item
+        !ev_is_xml   TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS object_to_file
+      IMPORTING
+        !is_item           TYPE zif_abapgit_definitions=>ty_item
+        !iv_ext            TYPE string
+        !iv_extra          TYPE clike OPTIONAL
+      RETURNING
+        VALUE(rv_filename) TYPE string .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_filename_logic IMPLEMENTATION.
+
+
+  METHOD file_to_object.
+
+    DATA:
+      lv_name TYPE string,
+      lv_type TYPE string,
+      lv_ext  TYPE string.
+
+    " Guess object type and name
+    SPLIT to_upper( iv_filename ) AT '.' INTO lv_name lv_type lv_ext.
+
+    " Handle namespaces
+    REPLACE ALL OCCURRENCES OF '#' IN lv_name WITH '/'.
+    REPLACE ALL OCCURRENCES OF '#' IN lv_type WITH '/'.
+    REPLACE ALL OCCURRENCES OF '#' IN lv_ext WITH '/'.
+
+    " The counter part to this logic must be maintained in OBJECT_TO_FILE
+    IF lv_type = to_upper( c_package_file-obj_type ).
+      " Try to get a unique package name for DEVC by using the path
+      ASSERT lv_name = to_upper( c_package_file-obj_name ).
+      lv_name = zcl_abapgit_folder_logic=>get_instance( )->path_to_package(
+        iv_top                  = iv_devclass
+        io_dot                  = io_dot
+        iv_create_if_not_exists = abap_false
+        iv_path                 = iv_path ).
+    ELSE.
+      " Get original object name
+      lv_name = cl_http_utility=>unescape_url( lv_name ).
+    ENDIF.
+
+    CLEAR es_item.
+    es_item-obj_type = lv_type.
+    es_item-obj_name = lv_name.
+    ev_is_xml        = boolc( lv_ext = to_upper( c_package_file-extension ) AND strlen( lv_type ) = 4 ).
+
+  ENDMETHOD.
+
+
+  METHOD object_to_file.
+
+    DATA lv_obj_name TYPE string.
+
+    lv_obj_name = is_item-obj_name.
+
+    " The counter part to this logic must be maintained in FILE_TO_OBJECT
+    IF is_item-obj_type = to_upper( c_package_file-obj_type ).
+      " Packages have a fixed filename so that the repository can be installed to a different
+      " package(-hierarchy) on the client and not show up as a different package in the repo.
+      lv_obj_name = c_package_file-obj_name.
+    ELSE.
+      " Some characters in object names cause problems when identifying the object later
+      " -> we escape these characters here
+      " cl_http_utility=>escape_url doesn't do dots but escapes slash which we use for namespaces
+      " -> we escape just some selected characters
+      REPLACE ALL OCCURRENCES OF `%` IN lv_obj_name WITH '%25'.
+      REPLACE ALL OCCURRENCES OF `#` IN lv_obj_name WITH '%23'.
+      REPLACE ALL OCCURRENCES OF `.` IN lv_obj_name WITH '%2e'.
+      REPLACE ALL OCCURRENCES OF `=` IN lv_obj_name WITH '%3d'.
+      REPLACE ALL OCCURRENCES OF `?` IN lv_obj_name WITH '%3f'.
+      REPLACE ALL OCCURRENCES OF `<` IN lv_obj_name WITH '%3c'.
+      REPLACE ALL OCCURRENCES OF `>` IN lv_obj_name WITH '%3e'.
+    ENDIF.
+
+    IF iv_extra IS INITIAL.
+      CONCATENATE lv_obj_name '.' is_item-obj_type INTO rv_filename.
+    ELSE.
+      CONCATENATE lv_obj_name '.' is_item-obj_type '.' iv_extra INTO rv_filename.
+    ENDIF.
+
+    IF iv_ext IS NOT INITIAL.
+      CONCATENATE rv_filename '.' iv_ext INTO rv_filename.
+    ENDIF.
+
+    " handle namespaces
+    REPLACE ALL OCCURRENCES OF '/' IN rv_filename WITH '#'.
+    TRANSLATE rv_filename TO LOWER CASE.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.testclasses.abap
@@ -1,0 +1,255 @@
+CLASS ltcl_run_checks DEFINITION DEFERRED.
+CLASS zcl_abapgit_filename_logic DEFINITION LOCAL FRIENDS ltcl_run_checks.
+
+CLASS ltcl_run_checks DEFINITION FOR TESTING RISK LEVEL HARMLESS
+  DURATION SHORT FINAL.
+
+  PRIVATE SECTION.
+    DATA mo_dot TYPE REF TO zcl_abapgit_dot_abapgit.
+
+    METHODS:
+      setup,
+      file_to_object FOR TESTING RAISING zcx_abapgit_exception,
+      object_to_file FOR TESTING RAISING zcx_abapgit_exception,
+      file_to_object_pack FOR TESTING RAISING zcx_abapgit_exception,
+      object_to_file_pack FOR TESTING RAISING zcx_abapgit_exception.
+
+ENDCLASS.
+
+CLASS ltcl_run_checks IMPLEMENTATION.
+
+  METHOD setup.
+
+    " Assume for unit tests that starting folder is /src/ with prefix logic
+    mo_dot = zcl_abapgit_dot_abapgit=>build_default( ).
+
+  ENDMETHOD.
+
+  METHOD file_to_object.
+
+    DATA ls_item TYPE zif_abapgit_definitions=>ty_item.
+    DATA lv_is_xml TYPE abap_bool.
+
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'zprogram.prog.abap'
+        iv_path     = '/src/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item
+        ev_is_xml   = lv_is_xml ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'PROG'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZPROGRAM'
+      act = ls_item-obj_name ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_false
+      act = lv_is_xml ).
+
+    " Subpackage
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'zprogram.prog.abap'
+        iv_path     = '/src/subpack/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item
+        ev_is_xml   = lv_is_xml ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'PROG'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZPROGRAM'
+      act = ls_item-obj_name ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_false
+      act = lv_is_xml ).
+
+    " XML
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'zprogram.prog.xml'
+        iv_path     = '/src/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item
+        ev_is_xml   = lv_is_xml ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'PROG'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZPROGRAM'
+      act = ls_item-obj_name ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_true
+      act = lv_is_xml ).
+
+    " With special characters
+    zcl_abapgit_filename_logic=>file_to_object(
+     EXPORTING
+       iv_filename = 'ztest%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3dvc.prog.abap'
+       iv_path     = '/src/'
+       iv_devclass = '$PACK'
+       io_dot      = mo_dot
+     IMPORTING
+       es_item     = ls_item
+       ev_is_xml   = lv_is_xml ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'PROG'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZTEST=========================VC'
+      act = ls_item-obj_name ).
+
+    zcl_abapgit_filename_logic=>file_to_object(
+     EXPORTING
+       iv_filename = 'zmime_%3c%3e_%3f.w3mi.jpg'
+       iv_path     = '/src/'
+       iv_devclass = '$PACK'
+       io_dot      = mo_dot
+     IMPORTING
+       es_item     = ls_item
+       ev_is_xml   = lv_is_xml ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'W3MI'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZMIME_<>_?'
+      act = ls_item-obj_name ).
+
+  ENDMETHOD.
+
+  METHOD object_to_file.
+
+    DATA ls_item TYPE zif_abapgit_definitions=>ty_item.
+    DATA lv_filename TYPE string.
+
+    ls_item-obj_type = 'PROG'.
+    ls_item-obj_name = 'ZPROGRAM'.
+
+    lv_filename = zcl_abapgit_filename_logic=>object_to_file(
+      is_item = ls_item
+      iv_ext  = 'abap' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'zprogram.prog.abap'
+      act = lv_filename ).
+
+    " With namespace
+    ls_item-obj_type = 'PROG'.
+    ls_item-obj_name = '/TEST/ZPROGRAM'.
+
+    lv_filename = zcl_abapgit_filename_logic=>object_to_file(
+      is_item = ls_item
+      iv_ext  = 'abap' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = '#test#zprogram.prog.abap'
+      act = lv_filename ).
+
+    " With extra extension
+    ls_item-obj_type = 'CLAS'.
+    ls_item-obj_name = 'ZCLASS'.
+
+    lv_filename = zcl_abapgit_filename_logic=>object_to_file(
+      is_item  = ls_item
+      iv_ext   = 'abap'
+      iv_extra = 'testclasses' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'zclass.clas.testclasses.abap'
+      act = lv_filename ).
+
+    " With special characters
+    ls_item-obj_type = 'PROG'.
+    ls_item-obj_name = 'ZTEST=========================VC'.
+
+    lv_filename = zcl_abapgit_filename_logic=>object_to_file(
+      is_item  = ls_item
+      iv_ext   = 'abap' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ztest%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3d%3dvc.prog.abap'
+      act = lv_filename ).
+
+    ls_item-obj_type = 'W3MI'.
+    ls_item-obj_name = 'ZMIME_<>_?'.
+
+    lv_filename = zcl_abapgit_filename_logic=>object_to_file(
+      is_item  = ls_item
+      iv_ext   = 'jpg' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'zmime_%3c%3e_%3f.w3mi.jpg'
+      act = lv_filename ).
+
+  ENDMETHOD.
+
+  METHOD file_to_object_pack.
+
+    DATA ls_item TYPE zif_abapgit_definitions=>ty_item.
+
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'package.devc.xml'
+        iv_path     = '/src/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'DEVC'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = '$PACK'
+      act = ls_item-obj_name ).
+
+    " Subpackage
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'package.devc.xml'
+        iv_path     = '/src/subpack/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'DEVC'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = '$PACK_SUBPACK'
+      act = ls_item-obj_name ).
+
+  ENDMETHOD.
+
+  METHOD object_to_file_pack.
+
+    DATA ls_item TYPE zif_abapgit_definitions=>ty_item.
+    DATA lv_filename TYPE string.
+
+    ls_item-obj_type = 'DEVC'.
+    ls_item-obj_name = 'ZPACKAGE'.
+
+    lv_filename = zcl_abapgit_filename_logic=>object_to_file(
+      is_item = ls_item
+      iv_ext  = 'xml' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'package.devc.xml'
+      act = lv_filename ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.xml
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_FILENAME_LOGIC</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Filename Logic</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -155,7 +155,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       <ls_return>-file = ls_file.
 
       " Derive object from config filename (namespace + escaping)
-      zcl_abapgit_file_status=>identify_object(
+      zcl_abapgit_filename_logic=>file_to_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename
           iv_path     = <ls_return>-file-path
@@ -172,7 +172,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       <ls_return>-file = ls_file.
 
       " Derive object from data filename (namespace + escaping)
-      zcl_abapgit_file_status=>identify_object(
+      zcl_abapgit_filename_logic=>file_to_object(
         EXPORTING
           iv_filename = <ls_return>-file-filename
           iv_path     = <ls_return>-file-path

--- a/src/ui/zcl_abapgit_gui_page_sett_info.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_info.clas.abap
@@ -500,7 +500,7 @@ CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
 
         IF <ls_remote>-filename IS NOT INITIAL AND lv_ignored = abap_false.
           TRY.
-              zcl_abapgit_file_status=>identify_object(
+              zcl_abapgit_filename_logic=>file_to_object(
                 EXPORTING
                   iv_filename = <ls_remote>-filename
                   iv_path     = <ls_remote>-path

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -119,7 +119,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
 
   METHOD build_menu.
@@ -247,7 +247,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
     LOOP AT it_files-remote INTO ls_remote WHERE filename IS NOT INITIAL.
       TRY.
-          zcl_abapgit_file_status=>identify_object(
+          zcl_abapgit_filename_logic=>file_to_object(
             EXPORTING
               iv_filename = ls_remote-filename
               iv_path     = ls_remote-path
@@ -313,7 +313,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
         lo_dot = mo_repo->get_dot_abapgit( ).
         LOOP AT it_files-remote ASSIGNING <ls_remote> WHERE filename IS NOT INITIAL.
-          zcl_abapgit_file_status=>identify_object(
+          zcl_abapgit_filename_logic=>file_to_object(
             EXPORTING
               iv_filename = <ls_remote>-filename
               iv_path     = <ls_remote>-path
@@ -587,7 +587,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
       ASSERT sy-subrc = 0.
 
       TRY.
-          zcl_abapgit_file_status=>identify_object(
+          zcl_abapgit_filename_logic=>file_to_object(
             EXPORTING
               iv_filename = <ls_remote>-filename
               iv_path     = <ls_remote>-path


### PR DESCRIPTION
Combines `zcl_abapgit_file_status=>identify_object` and `zcl_abapgit_object_files=>filename` into new class `zcl_abapgit_filename_logic`. This class provides `file_to_object` and `object_to_file` conversion logic similar to what `zcl_abapgit_folder_logic` does for packages and git folders. 

Also includes unit tests which were missing for the old methods.