### PR TITLE
Fix runtime error when force staging a removed object

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -323,7 +323,7 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
           IF ls_item IS INITIAL.
             CONTINUE.
           ENDIF.
-          APPEND <ls_local>-item TO lt_items.
+          APPEND ls_item TO lt_items.
         ENDLOOP.
 
         SORT lt_items BY obj_type obj_name.


### PR DESCRIPTION
Got a GETWA_NOT_ASSIGNED in ZCL_ABAPGIT_GUI_PAGE_STAGE====CP when trying to force stage an object to remove.