### PR TITLE
use fewer DDIC types

### DIFF
--- a/src/persist/zcl_abapgit_persistence_db.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_db.clas.abap
@@ -3,8 +3,8 @@ CLASS zcl_abapgit_persistence_db DEFINITION
   CREATE PRIVATE .
 
   PUBLIC SECTION.
-    CONSTANTS c_tabname TYPE tabname VALUE 'ZABAPGIT' ##NO_TEXT.
-    CONSTANTS c_lock TYPE viewname VALUE 'EZABAPGIT' ##NO_TEXT.
+    CONSTANTS c_tabname TYPE c LENGTH 30 VALUE 'ZABAPGIT' ##NO_TEXT.
+    CONSTANTS c_lock TYPE c LENGTH 30 VALUE 'EZABAPGIT' ##NO_TEXT.
 
     CONSTANTS:
       c_type_settings   TYPE zif_abapgit_persistence=>ty_type VALUE 'SETTINGS' ##NO_TEXT,

--- a/src/syntax/zcl_abapgit_syntax_css.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_css.clas.abap
@@ -66,10 +66,11 @@ CLASS zcl_abapgit_syntax_css DEFINITION
     CLASS-METHODS class_constructor .
     METHODS constructor .
   PROTECTED SECTION.
+    TYPES: ty_token TYPE c LENGTH 1.
 
     TYPES: BEGIN OF ty_keyword,
              keyword TYPE string,
-             token   TYPE char1,
+             token   TYPE ty_token,
            END OF ty_keyword.
 
     CLASS-DATA gt_keywords TYPE HASHED TABLE OF ty_keyword WITH UNIQUE KEY keyword.
@@ -79,7 +80,7 @@ CLASS zcl_abapgit_syntax_css DEFINITION
     CLASS-METHODS insert_keywords
       IMPORTING
         iv_keywords TYPE string
-        iv_token    TYPE char1.
+        iv_token    TYPE ty_token.
     CLASS-METHODS is_keyword
       IMPORTING iv_chunk      TYPE string
       RETURNING VALUE(rv_yes) TYPE abap_bool.

--- a/src/syntax/zcl_abapgit_syntax_js.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_js.clas.abap
@@ -36,10 +36,11 @@ CLASS zcl_abapgit_syntax_js DEFINITION
     CLASS-METHODS class_constructor .
     METHODS constructor .
   PROTECTED SECTION.
+    TYPES: ty_token TYPE c LENGTH 1.
 
     TYPES: BEGIN OF ty_keyword,
              keyword TYPE string,
-             token   TYPE char1,
+             token   TYPE ty_token,
            END OF ty_keyword.
 
     CLASS-DATA gt_keywords TYPE HASHED TABLE OF ty_keyword WITH UNIQUE KEY keyword.
@@ -49,7 +50,7 @@ CLASS zcl_abapgit_syntax_js DEFINITION
     CLASS-METHODS insert_keywords
       IMPORTING
         iv_keywords TYPE string
-        iv_token    TYPE char1.
+        iv_token    TYPE ty_token.
     CLASS-METHODS is_keyword
       IMPORTING iv_chunk      TYPE string
       RETURNING VALUE(rv_yes) TYPE abap_bool.


### PR DESCRIPTION
use built-in types instead of DDIC types

this is a prerequisite for running unit tests standalone, plus these ddic references are not really needed