### PR TITLE
ajson mirror: only run for abapGit/abapGit

### DIFF
--- a/.github/workflows/ajson_mirror.yaml
+++ b/.github/workflows/ajson_mirror.yaml
@@ -26,6 +26,7 @@ jobs:
         git status
     - name: Open PR
       uses: peter-evans/create-pull-request@v3
+      if: github.repository == 'abapGit/abapGit'
       with:
         title: ajson, Automatic Update
         body: |


### PR DESCRIPTION
its not needed to run it in forks