### PR TITLE
lint config: avoid use of BOOLE_D

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -114,7 +114,7 @@
         "^flag$", "^char12$", "^char10$", "^char70$", "^char4$", "^sydatum$", "^syuzeit$",
         "^syst_title$", "^sychar70$", "^char30$", "^char50$",
         "^numc2$", "^sap_bool$", "^SYCHAR10$", "^sylangu$",
-        "^cl_blue_wb_utility$",
+        "^cl_blue_wb_utility$", "^boole_d$",
         "^cl_srvd_wb_object_data$",
         "^cl_wb_object_operator_factory$",
         "^cx_wb_object_operation_error$",


### PR DESCRIPTION
this updates the abaplint configuration to give errors if data element BOOLE_D is used