### PR TITLE
WDCA: Clear parameter descriptions

### DIFF
--- a/src/objects/zcl_abapgit_object_wdca.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdca.clas.abap
@@ -121,6 +121,10 @@ CLASS ZCL_ABAPGIT_OBJECT_WDCA IMPLEMENTATION.
       lx_err    TYPE REF TO cx_wd_configuration,
       lv_name   TYPE wdy_md_object_name.
 
+    FIELD-SYMBOLS:
+      <ls_data>        LIKE LINE OF et_data,
+      <ls_appl_params> LIKE LINE OF <ls_data>-appl_params.
+
     CLEAR: es_outline, et_data.
 
     ls_key = ms_item-obj_name.
@@ -154,6 +158,13 @@ CLASS ZCL_ABAPGIT_OBJECT_WDCA IMPLEMENTATION.
                es_outline-changedon.
 
         et_data = lo_cfg->read_data( ).
+
+        " Clear descriptions since they are release and language-specific
+        LOOP AT et_data ASSIGNING <ls_data>.
+          LOOP AT <ls_data>-appl_params ASSIGNING <ls_appl_params>.
+            CLEAR <ls_appl_params>-description.
+          ENDLOOP.
+        ENDLOOP.
 
       CATCH cx_wd_configuration INTO lx_err.
         zcx_abapgit_exception=>raise( 'WDCA, read error:' && lx_err->get_text( ) ).


### PR DESCRIPTION
Fixes diffs because of parameters that are different between releases or languages (or because SAP change it)

Example:

![image](https://user-images.githubusercontent.com/59966492/122076242-00de8300-cdfb-11eb-8694-b4a7df7dc9d4.png)
