### PR TITLE
git transport: move constants to method

### DIFF
--- a/src/git/zcl_abapgit_git_transport.clas.abap
+++ b/src/git/zcl_abapgit_git_transport.clas.abap
@@ -52,13 +52,6 @@ CLASS zcl_abapgit_git_transport DEFINITION
         receive TYPE string VALUE 'receive',                  "#EC NOTEXT
         upload  TYPE string VALUE 'upload',                   "#EC NOTEXT
       END OF c_service .
-    CONSTANTS:
-      BEGIN OF c_smart_response_check,
-        BEGIN OF get_refs,
-          content_regex TYPE string VALUE '^[0-9a-f]{4}#',
-          content_type  TYPE string VALUE 'application/x-git-<service>-pack-advertisement',
-        END OF get_refs,
-      END OF c_smart_response_check .
 
     CLASS-METHODS check_report_status
       IMPORTING
@@ -106,7 +99,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_git_transport IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GIT_TRANSPORT IMPLEMENTATION.
 
 
   METHOD branches.
@@ -129,6 +122,9 @@ CLASS zcl_abapgit_git_transport IMPLEMENTATION.
 
   METHOD branch_list.
 
+    CONSTANTS lc_content_regex TYPE string VALUE '^[0-9a-f]{4}#'.
+    CONSTANTS lc_content_type  TYPE string VALUE 'application/x-git-<service>-pack-advertisement'.
+
     DATA: lv_data TYPE string.
     DATA: lv_expected_content_type TYPE string.
 
@@ -136,12 +132,12 @@ CLASS zcl_abapgit_git_transport IMPLEMENTATION.
       iv_url     = iv_url
       iv_service = iv_service ).
 
-    lv_expected_content_type = c_smart_response_check-get_refs-content_type.
+    lv_expected_content_type = lc_content_type.
     REPLACE '<service>' IN lv_expected_content_type WITH iv_service.
 
     eo_client->check_smart_response(
         iv_expected_content_type = lv_expected_content_type
-        iv_content_regex         = c_smart_response_check-get_refs-content_regex ).
+        iv_content_regex         = lc_content_regex ).
 
     lv_data = eo_client->get_cdata( ).
 


### PR DESCRIPTION
the constants are only used locally in the method, the definitions have been moved to the method instead of the private section of the class