### PR TITLE
align use of unescape_url()

### DIFF
--- a/src/repo/zcl_abapgit_repo_online.clas.abap
+++ b/src/repo/zcl_abapgit_repo_online.clas.abap
@@ -140,7 +140,7 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
     rv_name = super->get_name( ).
     IF rv_name IS INITIAL.
       rv_name = zcl_abapgit_url=>name( ms_data-url ).
-      rv_name = cl_http_utility=>if_http_utility~unescape_url( rv_name ).
+      rv_name = cl_http_utility=>unescape_url( rv_name ).
     ENDIF.
   ENDMETHOD.
 


### PR DESCRIPTION
this was the only place where the non-aliased method was called, https://github.com/abapGit/abapGit/search?q=unescape_url