### PR TITLE
zcl_abapgit_exit: add IF gi_exit IS NOT INITIAL.

### DIFF
--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -3,10 +3,12 @@ CLASS zcl_abapgit_exit DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-    CLASS-METHODS: get_instance RETURNING VALUE(ri_exit) TYPE REF TO zif_abapgit_exit.
 
-    INTERFACES: zif_abapgit_exit.
+    INTERFACES zif_abapgit_exit .
 
+    CLASS-METHODS get_instance
+      RETURNING
+        VALUE(ri_exit) TYPE REF TO zif_abapgit_exit .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -15,7 +17,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_exit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -34,147 +36,173 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
   METHOD zif_abapgit_exit~adjust_display_commit_url.
 
-    TRY.
-        gi_exit->adjust_display_commit_url(
-          EXPORTING
-            iv_repo_url           = iv_repo_url
-            iv_repo_name          = iv_repo_name
-            iv_repo_key           = iv_repo_key
-            iv_commit_hash        = iv_commit_hash
-          CHANGING
-            cv_display_url        = cv_display_url ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->adjust_display_commit_url(
+            EXPORTING
+              iv_repo_url           = iv_repo_url
+              iv_repo_name          = iv_repo_name
+              iv_repo_key           = iv_repo_key
+              iv_commit_hash        = iv_commit_hash
+            CHANGING
+              cv_display_url        = cv_display_url ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~allow_sap_objects.
 
-    TRY.
-        rv_allowed = gi_exit->allow_sap_objects( ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          rv_allowed = gi_exit->allow_sap_objects( ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~change_local_host.
 
-    TRY.
-        gi_exit->change_local_host( CHANGING ct_hosts = ct_hosts ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->change_local_host( CHANGING ct_hosts = ct_hosts ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~change_proxy_authentication.
 
-    TRY.
-        gi_exit->change_proxy_authentication(
-          EXPORTING
-            iv_repo_url             = iv_repo_url
-          CHANGING
-            cv_proxy_authentication = cv_proxy_authentication ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->change_proxy_authentication(
+            EXPORTING
+              iv_repo_url             = iv_repo_url
+            CHANGING
+              cv_proxy_authentication = cv_proxy_authentication ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~change_proxy_port.
 
-    TRY.
-        gi_exit->change_proxy_port(
-          EXPORTING
-            iv_repo_url   = iv_repo_url
-          CHANGING
-            cv_proxy_port = cv_proxy_port ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->change_proxy_port(
+            EXPORTING
+              iv_repo_url   = iv_repo_url
+            CHANGING
+              cv_proxy_port = cv_proxy_port ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~change_proxy_url.
 
-    TRY.
-        gi_exit->change_proxy_url(
-          EXPORTING
-            iv_repo_url  = iv_repo_url
-          CHANGING
-            cv_proxy_url = cv_proxy_url ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->change_proxy_url(
+            EXPORTING
+              iv_repo_url  = iv_repo_url
+            CHANGING
+              cv_proxy_url = cv_proxy_url ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~change_tadir.
 
-    TRY.
-        gi_exit->change_tadir(
-          EXPORTING
-            iv_package = iv_package
-            ii_log     = ii_log
-          CHANGING
-            ct_tadir   = ct_tadir ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->change_tadir(
+            EXPORTING
+              iv_package = iv_package
+              ii_log     = ii_log
+            CHANGING
+              ct_tadir   = ct_tadir ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~create_http_client.
 
-    TRY.
-        ri_client = gi_exit->create_http_client( iv_url ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          ri_client = gi_exit->create_http_client( iv_url ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~custom_serialize_abap_clif.
-    TRY.
-        rt_source = gi_exit->custom_serialize_abap_clif( is_class_key ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          rt_source = gi_exit->custom_serialize_abap_clif( is_class_key ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
+
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~deserialize_postprocess.
 
-    TRY.
-        gi_exit->deserialize_postprocess( is_step = is_step
-                                          ii_log  = ii_log ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->deserialize_postprocess( is_step = is_step
+                                            ii_log  = ii_log ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~get_ci_tests.
 
-    TRY.
-        gi_exit->get_ci_tests(
-          EXPORTING
-            iv_object   = iv_object
-          CHANGING
-            ct_ci_repos = ct_ci_repos ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->get_ci_tests(
+            EXPORTING
+              iv_object   = iv_object
+            CHANGING
+              ct_ci_repos = ct_ci_repos ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~get_ssl_id.
 
-    TRY.
-        rv_ssl_id = gi_exit->get_ssl_id( ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          rv_ssl_id = gi_exit->get_ssl_id( ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
     IF rv_ssl_id IS INITIAL.
       rv_ssl_id = 'ANONYM'.
@@ -185,59 +213,69 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
   METHOD zif_abapgit_exit~http_client.
 
-    TRY.
-        gi_exit->http_client(
-          iv_url    = iv_url
-          ii_client = ii_client ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->http_client(
+            iv_url    = iv_url
+            ii_client = ii_client ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~on_event.
 
-    TRY.
-        rs_handled = gi_exit->on_event( ii_event ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          rs_handled = gi_exit->on_event( ii_event ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~pre_calculate_repo_status.
 
-    TRY.
-        gi_exit->pre_calculate_repo_status(
-          EXPORTING
-            is_repo_meta = is_repo_meta
-          CHANGING
-            ct_local  = ct_local
-            ct_remote = ct_remote ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->pre_calculate_repo_status(
+            EXPORTING
+              is_repo_meta = is_repo_meta
+            CHANGING
+              ct_local  = ct_local
+              ct_remote = ct_remote ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~wall_message_list.
 
-    TRY.
-        gi_exit->wall_message_list( ii_html ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->wall_message_list( ii_html ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_exit~wall_message_repo.
 
-    TRY.
-        gi_exit->wall_message_repo(
-          is_repo_meta = is_repo_meta
-          ii_html      = ii_html ).
-      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-    ENDTRY.
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->wall_message_repo(
+            is_repo_meta = is_repo_meta
+            ii_html      = ii_html ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_exit.clas.xml
+++ b/src/zcl_abapgit_exit.clas.xml
@@ -5,7 +5,7 @@
    <VSEOCLASS>
     <CLSNAME>ZCL_ABAPGIT_EXIT</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>Default exit</DESCRIPT>
+    <DESCRIPT>abapGit - Default exit</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>


### PR DESCRIPTION
Adds a check to only call `gi_exit` method if its not initial

A: This will probably make it a very small bit faster
B: for unit/integration testing, easier transpiling, can avoid implementing the `cx_sy_ref_is_initial` and `cx_sy_dyn_call_illegal_method` exceptions for now