### PR TITLE
Update ajson wf to run for origin repo only

### DIFF
--- a/.github/workflows/ajson_mirror.yaml
+++ b/.github/workflows/ajson_mirror.yaml
@@ -6,8 +6,10 @@ on:
     - cron: '0 0 * * 1'
 
 jobs:
-  run:
-
+  pr_ajson_changes:
+    # Origin repo only
+    if: github.repository == 'abapGit/abapGit'
+    
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +28,6 @@ jobs:
         git status
     - name: Open PR
       uses: peter-evans/create-pull-request@v3
-      if: github.repository == 'abapGit/abapGit'
       with:
         title: ajson, Automatic Update
         branch: automatic/ajson


### PR DESCRIPTION
Problem: the workflow keeps running on forks, and thus produces some unnecessary communication
Didn't test to be honest, but should work
Also changed the name of the job to be more specific