### PR TITLE
Filter code inspection/syntax check

### DIFF
--- a/src/zcl_abapgit_code_inspector.clas.abap
+++ b/src/zcl_abapgit_code_inspector.clas.abap
@@ -39,9 +39,10 @@ CLASS zcl_abapgit_code_inspector DEFINITION
         VALUE(rv_skip) TYPE abap_bool.
   PRIVATE SECTION.
 
-    DATA mv_success TYPE abap_bool .
+    TYPES:
+      ty_run_mode TYPE c LENGTH 1 .
 
-    TYPES: ty_run_mode TYPE c LENGTH 1.
+    DATA mv_success TYPE abap_bool .
     CONSTANTS:
       BEGIN OF co_run_mode,
         run_with_popup   TYPE ty_run_mode VALUE 'P',
@@ -53,8 +54,8 @@ CLASS zcl_abapgit_code_inspector DEFINITION
       END OF co_run_mode .
     DATA mo_inspection TYPE REF TO cl_ci_inspection .
     DATA mv_name TYPE sci_objs .
-    DATA mv_run_mode TYPE c LENGTH 1 .
-
+    DATA:
+      mv_run_mode TYPE c LENGTH 1 .
 
     METHODS create_objectset
       RETURNING
@@ -68,21 +69,23 @@ CLASS zcl_abapgit_code_inspector DEFINITION
         zcx_abapgit_exception .
     METHODS create_inspection
       IMPORTING
-        io_set               TYPE REF TO cl_ci_objectset
-        io_variant           TYPE REF TO cl_ci_checkvariant
+        !io_set              TYPE REF TO cl_ci_objectset
+        !io_variant          TYPE REF TO cl_ci_checkvariant
       RETURNING
         VALUE(ro_inspection) TYPE REF TO cl_ci_inspection
       RAISING
         zcx_abapgit_exception .
-
     METHODS decide_run_mode
       RETURNING
-        VALUE(rv_run_mode) TYPE ty_run_mode.
+        VALUE(rv_run_mode) TYPE ty_run_mode .
+    METHODS filter_inspection
+      CHANGING
+        !ct_list TYPE scit_alvlist .
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_CODE_INSPECTOR IMPLEMENTATION.
+CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
 
 
   METHOD cleanup.
@@ -259,6 +262,14 @@ CLASS ZCL_ABAPGIT_CODE_INSPECTOR IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD filter_inspection.
+
+    " Remove findings in LSVIM* includes which are part of generated maintenance screens
+    DELETE ct_list WHERE sobjtype = 'PROG' AND sobjname CP 'LSVIM*'.
+
+  ENDMETHOD.
+
+
   METHOD run_inspection.
 
     io_inspection->run(
@@ -273,6 +284,8 @@ CLASS ZCL_ABAPGIT_CODE_INSPECTOR IMPLEMENTATION.
     ENDIF.
 
     io_inspection->plain_list( IMPORTING p_list = rt_list ).
+
+    filter_inspection( CHANGING ct_list = rt_list ).
 
     SORT rt_list BY objtype objname test code sobjtype sobjname line col.
 

--- a/src/zcl_abapgit_code_inspector.clas.abap
+++ b/src/zcl_abapgit_code_inspector.clas.abap
@@ -39,10 +39,10 @@ CLASS zcl_abapgit_code_inspector DEFINITION
         VALUE(rv_skip) TYPE abap_bool.
   PRIVATE SECTION.
 
-    TYPES:
-      ty_run_mode TYPE c LENGTH 1 .
-
     DATA mv_success TYPE abap_bool .
+
+    TYPES: ty_run_mode TYPE c LENGTH 1.
+
     CONSTANTS:
       BEGIN OF co_run_mode,
         run_with_popup   TYPE ty_run_mode VALUE 'P',
@@ -54,8 +54,7 @@ CLASS zcl_abapgit_code_inspector DEFINITION
       END OF co_run_mode .
     DATA mo_inspection TYPE REF TO cl_ci_inspection .
     DATA mv_name TYPE sci_objs .
-    DATA:
-      mv_run_mode TYPE c LENGTH 1 .
+    DATA mv_run_mode TYPE c LENGTH 1 .
 
     METHODS create_objectset
       RETURNING


### PR DESCRIPTION
In case of generated maintenance screens, the code inspection/syntax check include findings in SAP code (`LSVIM*` includes):

![image](https://user-images.githubusercontent.com/59966492/132954820-262d8d28-beef-4a31-8be7-9abc13409ad4.png)

This change suppresses those findings.