### PR TITLE
TABL: CLEAR dd05m-leng

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -1010,6 +1010,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     DELETE lt_dd08v WHERE noinherit = 'N'.
     LOOP AT lt_dd05m ASSIGNING <ls_dd05m>.
       CLEAR <ls_dd05m>-tabname.
+	  CLEAR <ls_dd05m>-leng.
       lv_index = sy-tabix.
       READ TABLE lt_dd08v WITH KEY fieldname = <ls_dd05m>-fieldname TRANSPORTING NO FIELDS.
       IF sy-subrc <> 0.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -1010,7 +1010,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     DELETE lt_dd08v WHERE noinherit = 'N'.
     LOOP AT lt_dd05m ASSIGNING <ls_dd05m>.
       CLEAR <ls_dd05m>-tabname.
-	  CLEAR <ls_dd05m>-leng.
+      CLEAR <ls_dd05m>-leng.
       lv_index = sy-tabix.
       READ TABLE lt_dd08v WITH KEY fieldname = <ls_dd05m>-fieldname TRANSPORTING NO FIELDS.
       IF sy-subrc <> 0.


### PR DESCRIPTION
In S/4HANA system, some of the data element lengths changed. Example: MATNR length changed from 18 characters to 40 characters. It would show as diff when this repo is pulled into S/4HANA. dd05m-leng is for information only hence, cleared it to avoid diffs.