### PR TITLE
ENHO: Split code into separate files

### DIFF
--- a/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_enho_hook DEFINITION PUBLIC.
   PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES: BEGIN OF ty_spaces,
-        full_name TYPE string.
+             full_name TYPE string.
     TYPES: spaces TYPE STANDARD TABLE OF i WITH DEFAULT KEY,
            END OF ty_spaces.
 

--- a/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
@@ -10,25 +10,76 @@ CLASS zcl_abapgit_object_enho_hook DEFINITION PUBLIC.
   PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES: BEGIN OF ty_spaces,
-             full_name TYPE string.
+        full_name TYPE string.
     TYPES: spaces TYPE STANDARD TABLE OF i WITH DEFAULT KEY,
            END OF ty_spaces.
 
     TYPES: ty_spaces_tt TYPE STANDARD TABLE OF ty_spaces WITH DEFAULT KEY.
 
+    CONSTANTS c_tag_file TYPE string VALUE 'FILE:*' ##NO_TEXT.
+    CONSTANTS c_tag_name TYPE string VALUE '"NAME:*' ##NO_TEXT.
+    CONSTANTS c_enhancement TYPE string VALUE 'ENHANCEMENT 0 *.' ##NO_TEXT.
+    CONSTANTS c_endenhancement TYPE string VALUE 'ENDENHANCEMENT.' ##NO_TEXT.
+
     DATA: ms_item TYPE zif_abapgit_definitions=>ty_item.
     DATA: mo_files TYPE REF TO zcl_abapgit_objects_files.
 
+    METHODS add_sources
+      CHANGING
+        !ct_enhancements TYPE enh_hook_impl_it
+      RAISING
+        zcx_abapgit_exception .
+    METHODS read_sources
+      CHANGING
+        !ct_enhancements TYPE enh_hook_impl_it
+      RAISING
+        zcx_abapgit_exception .
     METHODS hook_impl_deserialize
-      IMPORTING it_spaces TYPE ty_spaces_tt
-      CHANGING  ct_impl   TYPE enh_hook_impl_it
-      RAISING   zcx_abapgit_exception.
-
+      IMPORTING
+        !it_spaces TYPE ty_spaces_tt
+      CHANGING
+        !ct_impl   TYPE enh_hook_impl_it
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
+
+
+  METHOD add_sources.
+
+    DATA lv_source TYPE string.
+    DATA lv_file TYPE n LENGTH 4.
+
+    FIELD-SYMBOLS <ls_enhancement> LIKE LINE OF ct_enhancements.
+
+    LOOP AT ct_enhancements ASSIGNING <ls_enhancement>.
+      lv_file = sy-tabix.
+
+      " Add full name as comment and enhancement statements
+      lv_source = c_enhancement.
+      REPLACE '*' IN lv_source WITH ms_item-obj_name.
+      INSERT lv_source INTO <ls_enhancement>-source INDEX 1.
+
+      lv_source = c_tag_name.
+      REPLACE '*' IN lv_source WITH <ls_enhancement>-full_name.
+      INSERT lv_source INTO <ls_enhancement>-source INDEX 1.
+
+      APPEND c_endenhancement TO <ls_enhancement>-source.
+
+      mo_files->add_abap( iv_extra = lv_file
+                          it_abap  = <ls_enhancement>-source ).
+
+      " Store file name in source field
+      CLEAR <ls_enhancement>-source.
+      lv_source = c_tag_file.
+      REPLACE '*' IN lv_source WITH lv_file.
+      INSERT lv_source INTO TABLE <ls_enhancement>-source.
+    ENDLOOP.
+
+  ENDMETHOD.
 
 
   METHOD constructor.
@@ -62,6 +113,30 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD read_sources.
+
+    DATA lv_source TYPE string.
+    DATA lv_file TYPE string.
+
+    FIELD-SYMBOLS <ls_enhancement> LIKE LINE OF ct_enhancements.
+
+    LOOP AT ct_enhancements ASSIGNING <ls_enhancement>.
+      READ TABLE <ls_enhancement>-source INTO lv_source INDEX 1.
+      IF sy-subrc = 0 AND lv_source CP c_tag_file.
+        SPLIT lv_source AT ':' INTO lv_source lv_file.
+        <ls_enhancement>-source = mo_files->read_abap( iv_extra = lv_file ).
+        READ TABLE <ls_enhancement>-source INTO lv_source INDEX 1.
+        IF sy-subrc = 0 AND lv_source CP c_tag_name.
+          " Remove enhancement statements and comment with name
+          DELETE <ls_enhancement>-source FROM 1 TO 2.
+          DELETE <ls_enhancement>-source INDEX lines( <ls_enhancement>-source ).
+        ENDIF.
+      ENDIF.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_object_enho~deserialize.
 
     DATA: lv_shorttext       TYPE string,
@@ -89,6 +164,8 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
     " todo: kept for compatibility, remove after grace period #3680
     hook_impl_deserialize( EXPORTING it_spaces = lt_spaces
                            CHANGING ct_impl    = lt_enhancements ).
+
+    read_sources( CHANGING ct_enhancements = lt_enhancements ).
 
     lv_enhname = ms_item-obj_name.
     lv_package = iv_package.
@@ -162,6 +239,8 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
       CLEAR: <ls_enhancement>-extid,
              <ls_enhancement>-id.
     ENDLOOP.
+
+    add_sources( CHANGING ct_enhancements = lt_enhancements ).
 
     ii_xml->add( iv_name = 'TOOL'
                  ig_data = ii_enh_tool->get_tool( ) ).

--- a/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
@@ -63,9 +63,12 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
     FIELD-SYMBOLS <ls_enhancement> LIKE LINE OF ct_enhancements.
 
     LOOP AT ct_enhancements ASSIGNING <ls_enhancement>.
+      " Use hash as filename since full_name is very long
       CLEAR ls_file.
       ls_file-name = <ls_enhancement>-full_name.
-      ls_file-file = substring( val = zcl_abapgit_hash=>sha1_string( <ls_enhancement>-full_name ) len = 8 ).
+      ls_file-file = substring(
+        val = zcl_abapgit_hash=>sha1_string( <ls_enhancement>-full_name )
+        len = 8 ).
       INSERT ls_file INTO TABLE ct_files.
 
       " Add full name as comment and put code between enhancement statements

--- a/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
@@ -51,12 +51,13 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
   METHOD add_sources.
 
     DATA lv_source TYPE string.
-    DATA lv_file TYPE n LENGTH 4.
+    DATA lv_file TYPE string.
 
     FIELD-SYMBOLS <ls_enhancement> LIKE LINE OF ct_enhancements.
 
     LOOP AT ct_enhancements ASSIGNING <ls_enhancement>.
-      lv_file = sy-tabix.
+      lv_file = zcl_abapgit_hash=>sha1_string( <ls_enhancement>-full_name ).
+      lv_file = lv_file(8).
 
       " Add full name as comment and enhancement statements
       lv_source = c_enhancement.

--- a/src/utils/zcl_abapgit_hash.clas.abap
+++ b/src/utils/zcl_abapgit_hash.clas.abap
@@ -17,7 +17,6 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
-
     CLASS-METHODS sha1_commit
       IMPORTING
         !iv_data       TYPE xstring
@@ -25,7 +24,6 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
-
     CLASS-METHODS sha1_tree
       IMPORTING
         !iv_data       TYPE xstring
@@ -33,7 +31,6 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
-
     CLASS-METHODS sha1_tag
       IMPORTING
         !iv_data       TYPE xstring
@@ -41,7 +38,6 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
-
     CLASS-METHODS sha1_blob
       IMPORTING
         !iv_data       TYPE xstring
@@ -49,11 +45,16 @@ CLASS zcl_abapgit_hash DEFINITION
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
-
-
     CLASS-METHODS sha1_raw
       IMPORTING
         !iv_data       TYPE xstring
+      RETURNING
+        VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS sha1_string
+      IMPORTING
+        !iv_data       TYPE string
       RETURNING
         VALUE(rv_sha1) TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
@@ -64,7 +65,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HASH IMPLEMENTATION.
+CLASS zcl_abapgit_hash IMPLEMENTATION.
 
 
   METHOD adler32.
@@ -157,6 +158,28 @@ CLASS ZCL_ABAPGIT_HASH IMPLEMENTATION.
           lx_error TYPE REF TO cx_abap_message_digest.
     TRY.
         cl_abap_hmac=>calculate_hmac_for_raw(
+      EXPORTING
+        if_key        = lv_key
+        if_data       = iv_data
+      IMPORTING
+        ef_hmacstring = lv_hash ).
+      CATCH cx_abap_message_digest INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
+    ENDTRY.
+
+    rv_sha1 = lv_hash.
+    TRANSLATE rv_sha1 TO LOWER CASE.
+
+  ENDMETHOD.
+
+
+  METHOD sha1_string.
+
+    DATA: lv_hash  TYPE string,
+          lv_key   TYPE xstring,
+          lx_error TYPE REF TO cx_abap_message_digest.
+    TRY.
+        cl_abap_hmac=>calculate_hmac_for_char(
       EXPORTING
         if_key        = lv_key
         if_data       = iv_data


### PR DESCRIPTION
Similar to class enhancements where enhanced methods are stored as individual files, this change separates the code for implicit enhancements (type `HOOK_IMPL`) into abap-files.

This makes the code more readable (instead of being embedded and escaped into XML) and allows for linting.

Note: The solution can still deserialize the old format but will serialize enhancements in the new format.


Old format:

![image](https://user-images.githubusercontent.com/59966492/133307056-e64476ee-93de-496e-96fa-50aae5668e84.png)

New format:

![image](https://user-images.githubusercontent.com/59966492/133307085-97fd2337-cfdb-45c5-ad07-a5505caed558.png)

![image](https://user-images.githubusercontent.com/59966492/133307095-5009362a-7c34-4b58-9948-38a26d08003e.png)

