### PR TITLE
Post-processing option for custom class serializer

### DIFF
--- a/docs/ref-exits.md
+++ b/docs/ref-exits.md
@@ -71,6 +71,18 @@ Possibility to change the default `ANONYM` ssl id to something system specific.
 Allows for a custom serializer to be used for global classes' CLIF sources. See [#2321](https://github.com/abapGit/abapGit/issues/2321) and [#2491](https://github.com/abapGit/abapGit/pull/2491) for use cases.
 This [example implementation](https://gist.github.com/flaiker/999c8165b89131608b05cd371529fef5) forces the old class serializer to be used for specific packages.
 
+As of [#4953](https://github.com/abapGit/abapGit/pull/4953), the exit offers a post-processing option. First, the exit is called with the optional parameter
+`it_source` set to initial. If you do not return any serialization (`rt_source` is initial), then abapGit will serialize the object as usual and call the
+exit a second time. This time `it_source` contains the complete source and can be modified in the exit as required. To use this option, use following code 
+at the beginning of the exit:
+
+```abap
+" Ignore first call of exit
+IF it_source IS INITIAL.
+  RETURN.
+ENDIF.
+```
+
 ### DESERIALIZE_POSTPROCESS
 
 Can be used for any postprocessing operation for deserialized objects. Since it is a postprocessing step, only logs can be added to II_LOG and one should not terminate the process by raising exception, which may lead to inconsistencies.

--- a/src/objects/oo/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_serializer.clas.abap
@@ -216,6 +216,11 @@ CLASS zcl_abapgit_oo_serializer IMPLEMENTATION.
       CATCH cx_sy_dyn_call_error.
         rt_source = serialize_abap_old( is_class_key ).
     ENDTRY.
+
+    " Call exit again for optional post-processing
+    rt_source = zcl_abapgit_exit=>get_instance( )->custom_serialize_abap_clif(
+      is_class_key = is_class_key
+      it_source    = rt_source ).
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
+CLASS zcl_abapgit_exit IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -156,9 +156,20 @@ CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
 
   METHOD zif_abapgit_exit~custom_serialize_abap_clif.
 
+    " This exit might be called twice per object
+    " 1st call: it_source = initial
+    "    Can be used for serializing complete source
+    "    If source is returned, there will be no second call
+    " 2nd call: it_source = code as serialized by abapGit
+    "    Can be used for post-processing of source
     IF gi_exit IS NOT INITIAL.
       TRY.
-          rt_source = gi_exit->custom_serialize_abap_clif( is_class_key ).
+          rt_source = gi_exit->custom_serialize_abap_clif(
+            is_class_key = is_class_key
+            it_source    = it_source ).
+          IF rt_source IS INITIAL.
+            rt_source = it_source.
+          ENDIF.
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -57,6 +57,7 @@ INTERFACE zif_abapgit_exit
   METHODS custom_serialize_abap_clif
     IMPORTING
       !is_class_key    TYPE seoclskey
+      !it_source       TYPE zif_abapgit_definitions=>ty_string_tt OPTIONAL
     RETURNING
       VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
     RAISING


### PR DESCRIPTION
When using the current exit for serializing classes, you have to code the complete serialization yourself (i.e. reading and formatting the code). 
https://docs.abapgit.org/ref-exits.html#custom_serialize_abap_clif

With this change, you get the option to let abapGit serialize the class first and then post-process the source in the exit. The change is compatible with existing implementations of the exit.

To use the post-processing option, add the following code to the beginning of the exit:

```abap
" Ignore first call of exit
IF it_source IS INITIAL.
  RETURN.
ENDIF.
```

