### PR TITLE
FUGR: Clear TEXT when referring to dictionary to avoid unnecessary diffs when data element text changes

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -831,6 +831,11 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
             CLEAR <ls_field>-foreignkey.
           ENDIF.
         ENDIF.
+
+        IF <ls_field>-from_dict = abap_true AND
+           <ls_field>-modific   <> 'F'.
+          CLEAR <ls_field>-text.
+        ENDIF.
       ENDLOOP.
 
       LOOP AT lt_containers ASSIGNING <ls_container>.


### PR DESCRIPTION
In a Dynpro screen, when a field is referring to a data element and text is taken from dictionary, no need to serialize the text as it is always taken from dictionary. If the text is included then it will show unnecessary diffs when data element text changes. This is observed during S/4HANA migration. 

It is tested with custom data element  which is used in a table for which table maintenance is created. After table maintenance is generated, data element text is changed and table maintenance shows changed text automatically.

**Data Element before Change**:

![image](https://user-images.githubusercontent.com/29766214/134796513-14ef5240-7cf4-4afd-a9b4-3e5c9ffac2db.png)

**Table:**

![image](https://user-images.githubusercontent.com/29766214/134796532-f2d65f7e-7203-408f-becf-1de368270324.png)

Table Maintenance: For all values except 'F', text is always taken from Dictionary.

![image](https://user-images.githubusercontent.com/29766214/134796550-79521c57-ecd1-4969-8510-5dee1d45d558.png)

![image](https://user-images.githubusercontent.com/29766214/134796596-f12c2b4f-f8f4-4f93-989b-91410f3f84ac.png)

![image](https://user-images.githubusercontent.com/29766214/134796628-91c278dd-d99e-4cbe-9384-f522d3f2ed22.png)

**Before changes:**

![image](https://user-images.githubusercontent.com/29766214/134796704-9a6e7238-7ff3-40c5-b82b-37a03b1f811d.png)

**After Changes:** 

Data element text changed from 'Material' to 'Article'

![image](https://user-images.githubusercontent.com/29766214/134796747-ad1f8090-0e88-4587-93c9-42e082aad6e6.png)

abapGit shows diffs for data element which is expected and no changes against the table maintenance function group. Also, SM30 shows the changed text i.e Article

![image](https://user-images.githubusercontent.com/29766214/134796771-3b04e978-39a0-4151-a568-e0a733929c54.png)

![image](https://user-images.githubusercontent.com/29766214/134796815-89ff602e-b254-4130-ae17-3609ed2e3436.png)

The above is tested for all values of 1, 2, 3, 4 and V which shows correct text from dictionary.








