### PR TITLE
Diff: Improve beacons

### DIFF
--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -175,16 +175,13 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
           lt_regex TYPE zif_abapgit_definitions=>ty_string_tt,
           lv_regex LIKE LINE OF lt_regex.
 
-*    APPEND '^\s*(CLASS|FORM|MODULE|REPORT|METHOD)\s' TO lt_regex.
-*    APPEND '^\s*START-OF-' TO lt_regex.
-*    APPEND '^\s*INITIALIZATION(\s|\.)' TO lt_regex.
-
     APPEND '^\s*(CLASS|FORM|MODULE|REPORT|METHOD|INTERFACE|FUNCTION)\s' TO lt_regex.
     APPEND '^\s*(CLASS|INTERFACE|FUNCTION|TYPE)-POOL\s' TO lt_regex.
     APPEND '^\s*(START|END)-OF-SELECTION(\s|\.)' TO lt_regex.
     APPEND '^\s*INITIALIZATION(\s|\.)' TO lt_regex.
     APPEND '^\s*(TOP-OF-PAGE|END-OF-PAGE)(\s|\.)' TO lt_regex.
     APPEND '^\s*AT\s*(SELECTION-SCREEN|LINE-SELECTION|USER-COMMAND|PF\d+)(\s|\.)' TO lt_regex.
+    APPEND '^\s*(DEFINE|ENHANCEMENT)\s' TO lt_regex.
 
     LOOP AT lt_regex INTO lv_regex.
       CREATE OBJECT lo_regex


### PR DESCRIPTION
Add a few modularization statements to beacon detection to `create_regex_set`. Mostly relevant for longer programs with list events.