### PR TITLE
Naming of class constants - Part 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![CI](https://github.com/abapGit/abapGit/workflows/CI/badge.svg)
 [![Slack](https://abapgit-slackinviter.herokuapp.com/badge.svg)](https://abapgit-slackinviter.herokuapp.com/)
-[![abap package version](https://img.shields.io/endpoint?url=https://shield.abap.space/version-shield-json/github/abapGit/abapGit/src/zif_abapgit_version.intf.abap/gc_abap_version&label=version)](https://github.com/abapGit/abapGit/blob/main/src/zif_abapgit_version.intf.abap)
+[![abap package version](https://img.shields.io/endpoint?url=https://shield.abap.space/version-shield-json/github/abapGit/abapGit/src/zif_abapgit_version.intf.abap/c_abap_version&label=version)](https://github.com/abapGit/abapGit/blob/main/src/zif_abapgit_version.intf.abap)
 
 # <img src="docs/img/logo.svg" height="40" alt="abapGit logo">
 

--- a/ci/deploy-release-tag.sh
+++ b/ci/deploy-release-tag.sh
@@ -2,7 +2,7 @@
 echo "Detecting version change ..."
 
 VERSION_FILE=src/zif_abapgit_version.intf.abap
-VERSION_CONSTANT=gc_abap_version
+VERSION_CONSTANT=c_abap_version
 
 git diff-tree --no-commit-id --name-only -r HEAD | grep $VERSION_FILE > /dev/null 2>&1
 if [ $? -ne 0 ]; then

--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -217,7 +217,7 @@ CLASS zcl_abapgit_http IMPLEMENTATION.
 
 * bitbucket require agent prefix = "git/"
 * also see https://github.com/abapGit/abapGit/issues/1432
-    rv_agent = |git/2.0 (abapGit { zif_abapgit_version=>gc_abap_version })|.
+    rv_agent = |git/2.0 (abapGit { zif_abapgit_version=>c_abap_version })|.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -84,7 +84,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -110,7 +110,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     ri_html->add( ri_html->icon( 'git-alt' ) ).
     ri_html->add( ri_html->icon( 'abapgit' ) ).
     ri_html->add( '</div>' ).
-    ri_html->add( |<div class="version">{ zif_abapgit_version=>gc_abap_version }</div>| ).
+    ri_html->add( |<div class="version">{ zif_abapgit_version=>c_abap_version }</div>| ).
     ri_html->add( '</td>' ).
 
     ri_html->add( '<td id="debug-output" class="w40"></td>' ).

--- a/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -167,8 +167,8 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
     ri_html->add( '<h2>Environment</h2>' ).
 
     ri_html->add( |<table>| ).
-    ri_html->add( |<tr><td>abapGit version:</td><td>{ zif_abapgit_version=>gc_abap_version }</td></tr>| ).
-    ri_html->add( |<tr><td>XML version:    </td><td>{ zif_abapgit_version=>gc_xml_version }</td></tr>| ).
+    ri_html->add( |<tr><td>abapGit version:</td><td>{ zif_abapgit_version=>c_abap_version }</td></tr>| ).
+    ri_html->add( |<tr><td>XML version:    </td><td>{ zif_abapgit_version=>c_xml_version }</td></tr>| ).
     ri_html->add( |<tr><td>GUI version:    </td><td>{ lv_gui_version }</td></tr>| ).
     ri_html->add( |<tr><td>APACK version:  </td><td>{
                   zcl_abapgit_apack_migration=>c_apack_interface_version }</td></tr>| ).

--- a/src/xml/zcl_abapgit_xml.clas.abap
+++ b/src/xml/zcl_abapgit_xml.clas.abap
@@ -44,7 +44,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_XML IMPLEMENTATION.
+CLASS zcl_abapgit_xml IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -59,7 +59,7 @@ CLASS ZCL_ABAPGIT_XML IMPLEMENTATION.
     DATA: lv_version TYPE string.
     DATA: lv_file    TYPE string.
 
-    lv_version = |abapGit version: { zif_abapgit_version=>gc_abap_version }|.
+    lv_version = |abapGit version: { zif_abapgit_version=>c_abap_version }|.
     IF mv_filename IS NOT INITIAL.
       lv_file = |File: { mv_filename }|.
     ENDIF.
@@ -124,7 +124,7 @@ CLASS ZCL_ABAPGIT_XML IMPLEMENTATION.
                                                 name = c_abapgit_tag ).
     li_version = li_element->if_ixml_node~get_attributes(
       )->get_named_item_ns( c_attr_version ).
-    IF li_version->get_value( ) <> zif_abapgit_version=>gc_xml_version.
+    IF li_version->get_value( ) <> zif_abapgit_version=>c_xml_version.
       display_version_mismatch( ).
     ENDIF.
 

--- a/src/xml/zcl_abapgit_xml.clas.testclasses.abap
+++ b/src/xml/zcl_abapgit_xml.clas.testclasses.abap
@@ -48,7 +48,7 @@ CLASS ltcl_xml IMPLEMENTATION.
     DATA lv_xml TYPE string.
 
     lv_xml = |<?xml version="1.0"?>|
-          && |<{ mo_xml->c_abapgit_tag } { mo_xml->c_attr_version }="{ zif_abapgit_version=>gc_xml_version }">|
+          && |<{ mo_xml->c_abapgit_tag } { mo_xml->c_attr_version }="{ zif_abapgit_version=>c_xml_version }">|
           && iv_xml
           && |</{ mo_xml->c_abapgit_tag }>|.
 
@@ -97,7 +97,7 @@ CLASS ltcl_xml IMPLEMENTATION.
 
 
     lv_xml = |<?xml version="1.0"?>|
-          && |<{ mo_xml->c_abapgit_tag } { mo_xml->c_attr_version }="{ zif_abapgit_version=>gc_xml_version }">|
+          && |<{ mo_xml->c_abapgit_tag } { mo_xml->c_attr_version }="{ zif_abapgit_version=>c_xml_version }">|
           && |<open_tag>|
           && |</{ mo_xml->c_abapgit_tag }>|.
 

--- a/src/xml/zcl_abapgit_xml_output.clas.abap
+++ b/src/xml/zcl_abapgit_xml_output.clas.abap
@@ -123,7 +123,7 @@ CLASS zcl_abapgit_xml_output IMPLEMENTATION.
 
     li_git = mi_xml_doc->create_element( c_abapgit_tag ).
     li_git->set_attribute( name = c_attr_version
-                           value = zif_abapgit_version=>gc_xml_version ).
+                           value = zif_abapgit_version=>c_xml_version ).
     IF NOT is_metadata IS INITIAL.
       li_git->set_attribute( name  = c_attr_serializer
                              value = is_metadata-class ).

--- a/src/zcl_abapgit_news.clas.abap
+++ b/src/zcl_abapgit_news.clas.abap
@@ -124,7 +124,7 @@ CLASS zcl_abapgit_news IMPLEMENTATION.
     lv_url          = lo_repo_online->get_url( ).
 
     IF zcl_abapgit_url=>is_abapgit_repo( lv_url ) = abap_true.
-      lv_version = zif_abapgit_version=>gc_abap_version. " TODO refactor
+      lv_version = zif_abapgit_version=>c_abap_version. " TODO refactor
     ELSE.
 
       lo_apack = io_repo->get_dot_apack( ).

--- a/src/zif_abapgit_version.intf.abap
+++ b/src/zif_abapgit_version.intf.abap
@@ -1,7 +1,7 @@
 INTERFACE zif_abapgit_version
   PUBLIC .
 
-  CONSTANTS gc_xml_version TYPE string VALUE 'v1.0.0' ##NO_TEXT.
-  CONSTANTS gc_abap_version TYPE string VALUE '1.110.0' ##NO_TEXT.
+  CONSTANTS c_xml_version TYPE string VALUE 'v1.0.0' ##NO_TEXT.
+  CONSTANTS c_abap_version TYPE string VALUE '1.110.0' ##NO_TEXT.
 
 ENDINTERFACE.


### PR DESCRIPTION
Ref #4945

After this there's only `zif_abapgit_object=>gc_step_id` left to change to `c_step_id` which touches all serializer classes. Needs to be timed well. Then we can turn on the lint rule.