### PR TITLE
Diff-page: enable refresh functions

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1564,7 +1564,7 @@ function Hotkeys(oKeyMap){
       }
 
       // Or a global function
-      if (window[action]) {
+      if (window[action] && typeof(window[action]) === "function") {
         window[action].call(this);
         return;
       }
@@ -1753,7 +1753,7 @@ Patch.prototype.ID = {
 
 Patch.prototype.ACTION = {
   PATCH_STAGE: "patch_stage",
-  PATCH_REFRESH_LOCAL: "patch_refresh_local"
+  REFRESH_LOCAL: "diff_refresh_local"
 };
 
 Patch.prototype.escape = function(sFileName){
@@ -1884,7 +1884,7 @@ Patch.prototype.registerStagePatch = function registerStagePatch(){
   var elStage = document.querySelector("#" + this.ID.STAGE);
   elStage.addEventListener("click", this.submitPatch.bind(this, this.ACTION.PATCH_STAGE));
 
-  var aRefresh = document.querySelectorAll("[id*=patch_refresh]");
+  var aRefresh = document.querySelectorAll("[id*=diff_refresh]");
   [].forEach.call( aRefresh, function(el) {
     el.addEventListener("click", memoizeScrollPosition(this.submitPatch.bind(this, el.id)).bind(this));
   }.bind(this));
@@ -1895,7 +1895,7 @@ Patch.prototype.registerStagePatch = function registerStagePatch(){
   }.bind(this);
 
   window.refreshLocal = memoizeScrollPosition(function(){
-    this.submitPatch(this.ACTION.PATCH_REFRESH_LOCAL);
+    this.submitPatch(this.ACTION.REFRESH_LOCAL);
   }.bind(this));
 
 };

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -136,7 +136,7 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
         VALUE(rv_is_refrseh) TYPE abap_bool.
     METHODS modify_files_before_diff_calc
       IMPORTING
-        it_diff_files_old TYPE zcl_abapgit_gui_page_diff=>ty_file_diffs
+        it_diff_files_old TYPE ty_file_diffs
       CHANGING
         ct_files          TYPE zif_abapgit_definitions=>ty_stage_tt.
 

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.abap
@@ -90,10 +90,6 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
     METHODS add_to_stage
       RAISING
         zcx_abapgit_exception .
-
-
-
-
     METHODS apply_patch_all
       IMPORTING
         !iv_patch      TYPE string


### PR DESCRIPTION
fixes #4979 

First working version.
Needs more polishing + refactoring. 
How can we enable hotkeys for both Diff and Patch? Interface zif_abapgit_gui_hotkeys cannot be implemented in both classes nor redefined as its method is a class method.

![image](https://user-images.githubusercontent.com/17437789/135340093-578313ca-8569-4fe8-ad63-db5aaddd76a9.png)
