### PR TITLE
Delete child number from SICF node

### DIFF
--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -588,6 +588,7 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
     CLEAR ls_icfservice-icf_mandt.
     CLEAR ls_icfservice-icfnodguid.
     CLEAR ls_icfservice-icfparguid.
+    CLEAR ls_icfservice-icfchildno.
     CLEAR ls_icfservice-icf_user.
     CLEAR ls_icfservice-icf_cclnt.
     CLEAR ls_icfservice-icf_mclnt.


### PR DESCRIPTION
Clear the calculated field `ICFCHILDNO` to avoid differences between systems
![image](https://user-images.githubusercontent.com/56556686/135408086-953c5f5c-8df0-4db0-a3d6-8ec7f0d9a43c.png)

This field just calculate all child nodes for the node
![image](https://user-images.githubusercontent.com/56556686/135408222-3877dbdd-c409-4776-a9c2-9956b0a1433d.png)
