### PR TITLE
Fix pull behavior

### DIFF
--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -95,7 +95,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD check_package.
@@ -267,9 +267,7 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     IF iv_reset_all IS INITIAL.
       DELETE lt_decision
         WHERE action = zif_abapgit_objects=>c_deserialize_action-add
-           OR action = zif_abapgit_objects=>c_deserialize_action-update
-           OR action = zif_abapgit_objects=>c_deserialize_action-delete
-           OR action = zif_abapgit_objects=>c_deserialize_action-delete_add.
+           OR action = zif_abapgit_objects=>c_deserialize_action-update.
     ENDIF.
 
     " Ask user what to do


### PR DESCRIPTION
Issue: objects with mixed status are ignored on pull

To recreate: 
- clone ajson - https://github.com/sbcgua/ajson
- switch to filtering branch
- pull
- switch back to master
- pull - nothing happens, although it is intuitively should just pull

![2021-10-02_18h56_39](https://user-images.githubusercontent.com/15635498/135724012-6a11e106-7161-4618-bc1c-1a9888b370fb.png)

Adjusted the logic so that delete-like actions are not defaulted to "no". Popup is raised instead (existing logic)
