### PR TITLE
Don't show github note at password dialog on non-github repos

### DIFF
--- a/src/zabapgit_password_dialog.prog.abap
+++ b/src/zabapgit_password_dialog.prog.abap
@@ -51,6 +51,7 @@ CLASS lcl_password_dialog DEFINITION FINAL.
 
   PRIVATE SECTION.
     CLASS-DATA gv_confirm TYPE abap_bool.
+    CLASS-DATA gv_show_note TYPE abap_bool.
     CLASS-METHODS enrich_title_by_hostname
       IMPORTING
         iv_repo_url TYPE string.
@@ -64,9 +65,14 @@ CLASS lcl_password_dialog IMPLEMENTATION.
     CLEAR p_pass.
     p_url      = iv_repo_url.
     p_user     = cv_user.
-    p_cmnt     = 'GitHub requires using personal tokens (since 8/2021)'.
     gv_confirm = abap_false.
 
+    IF iv_repo_url CP '*github.com*'.
+      p_cmnt = 'GitHub requires using personal tokens (since 8/2021)'.
+      gv_show_note = abap_true.
+    ELSE.
+      gv_show_note = abap_false.
+    ENDIF.
 
     enrich_title_by_hostname( iv_repo_url ).
 
@@ -101,6 +107,14 @@ CLASS lcl_password_dialog IMPLEMENTATION.
         screen-input       = '0'.
         screen-intensified = '1'.
         screen-display_3d  = '0'.
+        MODIFY SCREEN.
+      ENDIF.
+      IF screen-name = 'P_CMNT' OR screen-name = 'S_CMNT'.
+        IF gv_show_note = abap_true.
+          screen-output = '1'.
+        ELSE.
+          screen-output = '0'.
+        ENDIF.
         MODIFY SCREEN.
       ENDIF.
       IF screen-name = 'P_PASS'.

--- a/src/zabapgit_password_dialog.prog.abap
+++ b/src/zabapgit_password_dialog.prog.abap
@@ -111,9 +111,11 @@ CLASS lcl_password_dialog IMPLEMENTATION.
       ENDIF.
       IF screen-name = 'P_CMNT' OR screen-name = 'S_CMNT'.
         IF gv_show_note = abap_true.
-          screen-output = '1'.
+          screen-active    = '1'.
+          screen-invisible = '0'.
         ELSE.
-          screen-output = '0'.
+          screen-active    = '0'.
+          screen-invisible = '1'.
         ENDIF.
         MODIFY SCREEN.
       ENDIF.


### PR DESCRIPTION
Github
![image](https://user-images.githubusercontent.com/15635498/135770280-c0ce6ff2-3c6d-4718-9305-9e804dca67f1.png)

Non github
![2021-10-03_23h19_13](https://user-images.githubusercontent.com/15635498/135770291-11b74b44-f58f-4a7d-a07a-c4f66f8deaab.png)

Hmmm, there are still those ugly empty lines at the bottom ... is it possible to get rid of them too ? I'm not a big expert in sel screens :(

