### PR TITLE
SXCI: Inactive classic BAdIs

### DIFF
--- a/src/objects/zcl_abapgit_object_sxci.clas.abap
+++ b/src/objects/zcl_abapgit_object_sxci.clas.abap
@@ -171,6 +171,11 @@ CLASS zcl_abapgit_object_sxci IMPLEMENTATION.
 
   METHOD zif_abapgit_object~is_active.
     rv_active = is_active( ).
+
+    " SAP does not list classic BAdIs properly as inactive object
+    IF rv_active = abap_true.
+      SELECT SINGLE active FROM sxc_attr INTO rv_active WHERE imp_name = ms_item-obj_name.
+    ENDIF.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sxci.clas.abap
+++ b/src/objects/zcl_abapgit_object_sxci.clas.abap
@@ -172,7 +172,7 @@ CLASS zcl_abapgit_object_sxci IMPLEMENTATION.
   METHOD zif_abapgit_object~is_active.
     rv_active = is_active( ).
 
-    "Note: SAP does not show inactive classic BAdIs as "Inactive objects" in SE80 
+    "Note: SAP does not show inactive classic BAdIs as "Inactive objects" in SE80
     "Therefore, rv_active will always be true. The implementation state (runtime
     "behaviour of the BAdI) will be serialized as part of the XML
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_sxci.clas.abap
+++ b/src/objects/zcl_abapgit_object_sxci.clas.abap
@@ -22,7 +22,10 @@ CLASS zcl_abapgit_object_sxci IMPLEMENTATION.
 
   METHOD zif_abapgit_object~changed_by.
 
-    rv_user = c_user_unknown.
+    SELECT SINGLE uname FROM sxc_attr INTO rv_user WHERE imp_name = ms_item-obj_name.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_sxci.clas.abap
+++ b/src/objects/zcl_abapgit_object_sxci.clas.abap
@@ -172,10 +172,9 @@ CLASS zcl_abapgit_object_sxci IMPLEMENTATION.
   METHOD zif_abapgit_object~is_active.
     rv_active = is_active( ).
 
-    " SAP does not list classic BAdIs properly as inactive object
-    IF rv_active = abap_true.
-      SELECT SINGLE active FROM sxc_attr INTO rv_active WHERE imp_name = ms_item-obj_name.
-    ENDIF.
+    "Note: SAP does not show inactive classic BAdIs as "Inactive objects" in SE80 
+    "Therefore, rv_active will always be true. The implementation state (runtime
+    "behaviour of the BAdI) will be serialized as part of the XML
   ENDMETHOD.
 
 
@@ -281,8 +280,7 @@ CLASS zcl_abapgit_object_sxci IMPLEMENTATION.
            ls_classic_badi_implementation-implementation_data-atime,
            ls_classic_badi_implementation-implementation_data-uname,
            ls_classic_badi_implementation-implementation_data-udate,
-           ls_classic_badi_implementation-implementation_data-utime,
-           ls_classic_badi_implementation-implementation_data-active.
+           ls_classic_badi_implementation-implementation_data-utime.
 
     io_xml->add( iv_name = 'SXCI'
                  ig_data = ls_classic_badi_implementation ).


### PR DESCRIPTION
Seriallizes the implementation state of the classic BAdI:

![image](https://user-images.githubusercontent.com/59966492/135915465-edc8510b-4692-4997-b3f6-15de2bfa1cf9.png)

Local: inactive
Remote: active

![image](https://user-images.githubusercontent.com/59966492/135915484-0a3b0321-7edf-44c4-9a76-e0437485896f.png)

Also determines "Last Changed By". 

Closes #4958