### PR TITLE
Repo page - inform on bottom if only changes are shown

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -845,6 +845,15 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                                        iv_render_transports = mv_are_changes_recorded_in_tr ) ).
           ENDLOOP.
 
+          IF mv_changes_only = abap_true.
+            ri_html->add( `<tfoot><tr><td colspan="5">` ).
+            ri_html->add( `(Only changes are shown. ` ).
+            ri_html->add( ri_html->a(
+              iv_txt   = |Show All|
+              iv_act   = |{ c_actions-toggle_changes }| ) ).
+            ri_html->add( `)</td></tr></tfoot>` ).
+          ENDIF.
+
           ri_html->add( '</table>' ).
         ENDIF.
 


### PR DESCRIPTION
See https://github.com/abapGit/abapGit/pull/4997#issuecomment-934133610

Adds the same info about the "only show changes" filter on the main page
![image](https://user-images.githubusercontent.com/5097067/136026473-d1f58241-6f7c-4796-bf8f-e80225ccf89c.png)
