### PR TITLE
Change abapgit font to 72

### DIFF
--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -6,7 +6,7 @@
   --theme-background-color: #E8E8E8;
   --theme-container-background-color: #f2f2f2;
   --theme-container-border-color: lightgrey;
-  --theme-primary-font: Arial,Helvetica,sans-serif;
+  --theme-primary-font: "72", Arial, Helvetica, sans-serif;
   --theme-primary-font-color: #333333;
   --theme-primary-font-color-reduced: #ccc;
   --theme-font-size: 12pt;


### PR DESCRIPTION
This changes the default abapgit font to the SAP-approved 72 font which is probably optimized for uppercase letters.

https://experience.sap.com/72/

![image](https://user-images.githubusercontent.com/5097067/136270485-48ace8fa-c2d5-418c-9a59-835654db8af6.png)
![image](https://user-images.githubusercontent.com/5097067/136270537-de8461d8-3cfb-4296-93f7-7e18883c97b3.png)
![image](https://user-images.githubusercontent.com/5097067/136270522-4f948bb2-7fd7-46fa-b799-6541a119fe1c.png)
![image](https://user-images.githubusercontent.com/5097067/136270542-278b9981-7f09-4723-bfa6-1462a8ca9965.png)
