### PR TITLE
Fix syntax check warnings

### DIFF
--- a/src/utils/zcl_abapgit_path.clas.abap
+++ b/src/utils/zcl_abapgit_path.clas.abap
@@ -1,6 +1,6 @@
 CLASS zcl_abapgit_path DEFINITION
-  PUBLIC
-  CREATE PUBLIC .
+  PUBLIC FINAL
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
 
@@ -26,8 +26,6 @@ CLASS zcl_abapgit_path DEFINITION
     CLASS-METHODS get_filename_from_syspath
       IMPORTING iv_path            TYPE string
       RETURNING VALUE(rv_filename) TYPE string.
-
-  PRIVATE SECTION.
 
 ENDCLASS.
 

--- a/src/zlib/zcl_abapgit_zlib_convert.clas.abap
+++ b/src/zlib/zcl_abapgit_zlib_convert.clas.abap
@@ -1,6 +1,6 @@
 CLASS zcl_abapgit_zlib_convert DEFINITION
-  PUBLIC
-  CREATE PUBLIC .
+  PUBLIC FINAL
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
 
@@ -21,8 +21,6 @@ CLASS zcl_abapgit_zlib_convert DEFINITION
         !iv_int       TYPE i
       RETURNING
         VALUE(rv_hex) TYPE xstring.
-
-  PRIVATE SECTION.
 
 ENDCLASS.
 


### PR DESCRIPTION
Fixes two warnings
`For technical reasons, the statement "PROTECTED SECTION" or "PRIVATE SECTION" must exist in non-final global classes.`