### PR TITLE
Page patch: fix mixed-up tooltips

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -59,8 +59,8 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
         refresh_local TYPE string VALUE `Refresh Local`,
       END OF c_action_texts,
       BEGIN OF c_action_titles,
-        refresh_all   TYPE string VALUE `Refresh all local objects, without refreshing the remote`,
-        refresh_local TYPE string VALUE `Complete refresh of all objects, local and remote`,
+        refresh_local TYPE string VALUE `Refresh all local objects, without refreshing the remote`,
+        refresh_all   TYPE string VALUE `Complete refresh of all objects, local and remote`,
       END OF c_action_titles.
 
     DATA mv_unified TYPE abap_bool VALUE abap_true ##NO_TEXT.


### PR DESCRIPTION
Refresh local and refresh all tooltips were mixed-up.