### PR TITLE
FUGR/PROG: Keep field text in case of masking

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -834,7 +834,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 
         IF <ls_field>-from_dict = abap_true AND
            <ls_field>-modific   <> 'F' AND
-           <ls_field>-modific   <> 'M'.
+           <ls_field>-modific   <> 'X'.
           CLEAR <ls_field>-text.
         ENDIF.
       ENDLOOP.


### PR DESCRIPTION
If masking is used with a dynpro field, then the text (mask) must not be cleared.

Closes #5071