### PR TITLE
Commit page: limit comment input length

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -288,15 +288,20 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
 
   METHOD get_form_schema.
 
+    DATA: lv_commitmsg_comment_length TYPE i.
+
     ro_form = zcl_abapgit_html_form=>create(
       iv_form_id   = 'commit-form'
       iv_help_page = 'https://docs.abapgit.org/guide-stage-commit.html' ).
+
+    lv_commitmsg_comment_length =  mo_settings->get_commitmsg_comment_length( ).
 
     ro_form->text(
       iv_name        = c_id-comment
       iv_label       = 'Comment'
       iv_required    = abap_true
-      iv_max         = mo_settings->get_commitmsg_comment_length( )
+      iv_max         = lv_commitmsg_comment_length
+      iv_placeholder = |Add a mandatory comment with max { lv_commitmsg_comment_length } characters|
     )->textarea(
       iv_name        = c_id-body
       iv_label       = 'Body'

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -717,7 +717,10 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
 
   METHOD render_field_text.
 
-    DATA lv_type TYPE string.
+    DATA:
+      lv_type      TYPE string,
+      lv_maxlength TYPE string.
+
 
     ii_html->add( |<label for="{ is_field-name }"{ is_attr-hint }>{ is_field-label }{ is_attr-required }</label>| ).
 
@@ -737,9 +740,13 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
       lv_type = 'text'.
     ENDIF.
 
+    IF is_field-max > 0.
+      lv_maxlength = |maxlength={ is_field-max }|.
+    ENDIF.
+
     ii_html->add( |<input type="{ lv_type }" name="{ is_field-name }" id="{ is_field-name }"|
                && | value="{ is_attr-value }" { is_field-dblclick }{ is_attr-placeholder }|
-               && |{ is_attr-readonly }{ is_attr-autofocus }>| ).
+               && |{ is_attr-readonly }{ is_attr-autofocus } { lv_maxlength }>| ).
 
     IF is_field-side_action IS NOT INITIAL.
       ii_html->add( '</div>' ).


### PR DESCRIPTION
Currently it's possible to input more characters than allowed.
![grafik](https://user-images.githubusercontent.com/17437789/140088006-8e713673-f59f-41d1-acac-aef9d1ffd49b.png)

+ As comment length is limited, we should only allow inputs up to that limit to increase UX
+ placeholder message 
![grafik](https://user-images.githubusercontent.com/17437789/140088072-5b5a4b6c-100a-4077-ace3-400c010416e0.png)
