### PR TITLE
WEBI: Fix changed_by, is_active, exists

### DIFF
--- a/src/objects/zcl_abapgit_object_webi.clas.abap
+++ b/src/objects/zcl_abapgit_object_webi.clas.abap
@@ -317,7 +317,13 @@ CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown. " todo
+
+    SELECT SINGLE changedby FROM vepheader INTO rv_user
+      WHERE vepname = ms_item-obj_name AND version = 'A'.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_webi.clas.abap
+++ b/src/objects/zcl_abapgit_object_webi.clas.abap
@@ -422,7 +422,7 @@ CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
 
     rv_bool = cl_ws_md_vif_root=>check_existence_by_vif_name(
       name      = lv_name
-      i_version = sews_c_vif_version-active ).
+      i_version = sews_c_vif_version-all ).
 
   ENDMETHOD.
 
@@ -503,7 +503,10 @@ CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
         version_not_found = 1
         webi_not_exist    = 2
         OTHERS            = 3.
-    IF sy-subrc <> 0.
+    IF sy-subrc = 1.
+      " no active version
+      RETURN.
+    ELSEIF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 


### PR DESCRIPTION
- `changed_by` was missing
- `is_active` did not work due to an exception
- `exists` was checking only for active version

Before:
![image](https://user-images.githubusercontent.com/59966492/140421287-39d4f841-b465-49f2-a74b-c2b7e83046b9.png)

After:
![image](https://user-images.githubusercontent.com/59966492/140439273-89d39da5-5d1a-4947-b20b-91aa56a79c7e.png)
