### PR TITLE
LinkHints/Hotkeys: Unify activation

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1393,11 +1393,7 @@ LinkHints.prototype.handleKey = function(event){
     return;
   }
 
-  var activeElement = (document.activeElement && document.activeElement) || {};
-
-  // link hints are disabled for input and textareas for obvious reasons.
-  // Maybe we must add other types here in the future
-  if (event.key === this.linkHintHotKey && activeElement.type !== "text" && activeElement.type !== "number" && activeElement.nodeName !== "TEXTAREA") {
+  if (event.key === this.linkHintHotKey && Hotkeys.isHotkeyCallPossible()) {
 
     // on user hide hints, close an opened dropdown too
     if (this.areHintsDisplayed && this.activatedDropdown) this.closeActivatedDropdown();
@@ -1626,7 +1622,7 @@ Hotkeys.prototype.onkeydown = function(oEvent){
     return;
   }
 
-  if (!this.isHotkeyCallPossible()){
+  if (!Hotkeys.isHotkeyCallPossible()){
     return;
   }
 
@@ -1639,7 +1635,7 @@ Hotkeys.prototype.onkeydown = function(oEvent){
   }
 };
 
-Hotkeys.prototype.isHotkeyCallPossible = function(){
+Hotkeys.isHotkeyCallPossible = function(){
 
   var activeElementType = ((document.activeElement && document.activeElement.nodeName) || "");
   var activeElementReadOnly = ((document.activeElement && document.activeElement.readOnly) || false);


### PR DESCRIPTION
Use hotkey activation logic also for link hints. Previously it was possble to activate link hints on some input fields (e.g. search on stage page). This is now fixed.