### PR TITLE
Refactor: Jump to Object Logic

### DIFF
--- a/src/objects/core/zcl_abapgit_gui_jumper.clas.abap
+++ b/src/objects/core/zcl_abapgit_gui_jumper.clas.abap
@@ -1,0 +1,173 @@
+CLASS zcl_abapgit_gui_jumper DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_gui_jumper.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    METHODS jump_tr
+      IMPORTING
+        !is_item       TYPE zif_abapgit_definitions=>ty_item
+      RETURNING
+        VALUE(rv_exit) TYPE abap_bool.
+
+    METHODS jump_wb
+      IMPORTING
+        !is_item       TYPE zif_abapgit_definitions=>ty_item
+        !iv_new_window TYPE abap_bool
+      RETURNING
+        VALUE(rv_exit) TYPE abap_bool.
+
+    METHODS jump_wb_line
+      IMPORTING
+        !is_item         TYPE zif_abapgit_definitions=>ty_item
+        !iv_sub_obj_name TYPE zif_abapgit_definitions=>ty_item-obj_name
+        !iv_sub_obj_type TYPE zif_abapgit_definitions=>ty_item-obj_type
+        !iv_line_number  TYPE i
+        !iv_new_window   TYPE abap_bool
+      RETURNING
+        VALUE(rv_exit)   TYPE abap_bool.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_jumper IMPLEMENTATION.
+
+
+  METHOD jump_tr.
+
+    DATA:
+      lv_e071_object   TYPE e071-object,
+      lv_e071_obj_name TYPE e071-obj_name.
+
+    lv_e071_object   = is_item-obj_type.
+    lv_e071_obj_name = is_item-obj_name.
+
+    CALL FUNCTION 'TR_OBJECT_JUMP_TO_TOOL'
+      EXPORTING
+        iv_action         = 'SHOW'
+        iv_pgmid          = 'R3TR'
+        iv_object         = lv_e071_object
+        iv_obj_name       = lv_e071_obj_name
+      EXCEPTIONS
+        jump_not_possible = 1
+        OTHERS            = 2.
+
+    rv_exit = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.
+
+
+  METHOD jump_wb.
+
+    CALL FUNCTION 'RS_TOOL_ACCESS'
+      EXPORTING
+        operation           = 'SHOW'
+        object_name         = is_item-obj_name
+        object_type         = is_item-obj_type
+        devclass            = is_item-devclass
+        in_new_window       = iv_new_window
+      EXCEPTIONS
+        not_executed        = 1
+        invalid_object_type = 2
+        OTHERS              = 3.
+
+    rv_exit = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.
+
+
+  METHOD jump_wb_line.
+
+    IF iv_line_number IS NOT INITIAL AND iv_sub_obj_type IS NOT INITIAL AND iv_sub_obj_name IS NOT INITIAL.
+
+      " For the line navigation we have to supply the sub object type (iv_sub_obj_type).
+      " If we use is_item-obj_type it navigates only to the object.
+      CALL FUNCTION 'RS_TOOL_ACCESS'
+        EXPORTING
+          operation           = 'SHOW'
+          object_name         = is_item-obj_name
+          object_type         = iv_sub_obj_type
+          devclass            = is_item-devclass
+          include             = iv_sub_obj_name
+          position            = iv_line_number
+          in_new_window       = iv_new_window
+        EXCEPTIONS
+          not_executed        = 1
+          invalid_object_type = 2
+          OTHERS              = 3.
+
+      rv_exit = boolc( sy-subrc = 0 ).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_jumper~jump.
+
+    " Try all generic jump options
+
+    " 1) ADT Jump
+    rv_exit = zif_abapgit_gui_jumper~jump_adt(
+      is_item         = is_item
+      iv_sub_obj_name = iv_sub_obj_name
+      iv_line_number  = iv_line_number ).
+
+    IF rv_exit = abap_true.
+      RETURN.
+    ENDIF.
+
+    " 2) WB Jump with Line Number
+    rv_exit = jump_wb_line(
+      is_item         = is_item
+      iv_sub_obj_name = iv_sub_obj_name
+      iv_sub_obj_type = iv_sub_obj_type
+      iv_line_number  = iv_line_number
+      iv_new_window   = iv_new_window ).
+
+    IF rv_exit = abap_true.
+      RETURN.
+    ENDIF.
+
+    " 3) WB Jump without Line Number
+    rv_exit = jump_wb(
+      is_item       = is_item
+      iv_new_window = iv_new_window ).
+
+    IF rv_exit = abap_true.
+      RETURN.
+    ENDIF.
+
+    " 4) Transport Tool Jump
+    rv_exit = jump_tr( is_item ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_jumper~jump_adt.
+
+    " Open object in ADT (if enabled)
+
+    DATA lv_adt_jump_enabled TYPE abap_bool.
+
+    lv_adt_jump_enabled = zcl_abapgit_persist_factory=>get_settings( )->read( )->get_adt_jump_enabled( ).
+
+    IF lv_adt_jump_enabled = abap_true.
+      zcl_abapgit_adt_link=>jump(
+        iv_obj_name     = is_item-obj_name
+        iv_obj_type     = is_item-obj_type
+        iv_sub_obj_name = iv_sub_obj_name
+        iv_line_number  = iv_line_number ).
+
+      rv_exit = abap_true.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/objects/core/zcl_abapgit_gui_jumper.clas.xml
+++ b/src/objects/core/zcl_abapgit_gui_jumper.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_JUMPER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI Jump</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -295,23 +295,11 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD jump_adt.
 
-    DATA: lv_adt_link TYPE string,
-          lx_error    TYPE REF TO cx_root.
-
-    TRY.
-
-        lv_adt_link = zcl_abapgit_adt_link=>generate(
-          iv_obj_name     = iv_obj_name
-          iv_obj_type     = iv_obj_type
-          iv_sub_obj_name = iv_sub_obj_name
-          iv_line_number  = iv_line_number ).
-
-        zcl_abapgit_ui_factory=>get_frontend_services( )->execute( iv_document = lv_adt_link ).
-
-      CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise( iv_text = 'ADT Jump Error'
-                                      ix_previous = lx_error ).
-    ENDTRY.
+    zcl_abapgit_adt_link=>jump(
+      iv_obj_name     = iv_obj_name
+      iv_obj_type     = iv_obj_type
+      iv_sub_obj_name = iv_sub_obj_name
+      iv_line_number  = iv_line_number ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -830,8 +830,8 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
   METHOD render_diff_head.
 
-    DATA: ls_stats    TYPE zif_abapgit_definitions=>ty_count,
-          lv_adt_link TYPE string.
+    DATA: ls_stats TYPE zif_abapgit_definitions=>ty_count,
+          lv_link  TYPE string.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
@@ -859,14 +859,14 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     IF NOT ( is_diff-lstate = zif_abapgit_definitions=>c_state-unchanged AND
              is_diff-rstate = zif_abapgit_definitions=>c_state-added ) AND
          NOT is_diff-lstate = zif_abapgit_definitions=>c_state-deleted.
-      lv_adt_link = ri_html->a(
+      lv_link = ri_html->a(
         iv_txt = |{ is_diff-path }{ is_diff-filename }|
         iv_typ = zif_abapgit_html=>c_action_type-sapevent
         iv_act = |jump?TYPE={ is_diff-obj_type }&NAME={ is_diff-obj_name }| ).
     ENDIF.
 
-    IF lv_adt_link IS NOT INITIAL.
-      ri_html->add( |<span class="diff_name">{ lv_adt_link }</span>| ).
+    IF lv_link IS NOT INITIAL.
+      ri_html->add( |<span class="diff_name">{ lv_link }</span>| ).
     ELSE.
       ri_html->add( |<span class="diff_name">{ is_diff-path }{ is_diff-filename }</span>| ).
     ENDIF.

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -38,6 +38,9 @@ CLASS zcl_abapgit_ui_factory DEFINITION
         !iv_disable_query_table TYPE abap_bool DEFAULT abap_true
       RETURNING
         VALUE(ri_viewer)        TYPE REF TO zif_abapgit_html_viewer .
+    CLASS-METHODS get_gui_jumper
+      RETURNING
+        VALUE(ri_gui_jumper) TYPE REF TO zif_abapgit_gui_jumper .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -48,6 +51,7 @@ CLASS zcl_abapgit_ui_factory DEFINITION
     CLASS-DATA go_gui TYPE REF TO zcl_abapgit_gui .
     CLASS-DATA gi_fe_services TYPE REF TO zif_abapgit_frontend_services .
     CLASS-DATA gi_gui_services TYPE REF TO zif_abapgit_gui_services .
+    CLASS-DATA gi_gui_jumper TYPE REF TO zif_abapgit_gui_jumper .
 ENDCLASS.
 
 
@@ -169,6 +173,17 @@ CLASS zcl_abapgit_ui_factory IMPLEMENTATION.
     ENDIF.
 
     ri_gui_functions = gi_gui_functions.
+
+  ENDMETHOD.
+
+
+  METHOD get_gui_jumper.
+
+   IF gi_gui_jumper IS INITIAL.
+      CREATE OBJECT gi_gui_jumper TYPE zcl_abapgit_gui_jumper.
+    ENDIF.
+
+    ri_gui_jumper = gi_gui_jumper.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -179,7 +179,7 @@ CLASS zcl_abapgit_ui_factory IMPLEMENTATION.
 
   METHOD get_gui_jumper.
 
-   IF gi_gui_jumper IS INITIAL.
+    IF gi_gui_jumper IS INITIAL.
       CREATE OBJECT gi_gui_jumper TYPE zcl_abapgit_gui_jumper.
     ENDIF.
 

--- a/src/ui/zif_abapgit_gui_jumper.intf.abap
+++ b/src/ui/zif_abapgit_gui_jumper.intf.abap
@@ -1,0 +1,26 @@
+INTERFACE zif_abapgit_gui_jumper
+  PUBLIC.
+
+  METHODS jump
+    IMPORTING
+      !is_item         TYPE zif_abapgit_definitions=>ty_item
+      !iv_sub_obj_name TYPE zif_abapgit_definitions=>ty_item-obj_name OPTIONAL
+      !iv_sub_obj_type TYPE zif_abapgit_definitions=>ty_item-obj_type OPTIONAL
+      !iv_line_number  TYPE i OPTIONAL
+      !iv_new_window   TYPE abap_bool DEFAULT abap_true
+    RETURNING
+      VALUE(rv_exit)   TYPE abap_bool
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS jump_adt
+    IMPORTING
+      !is_item         TYPE zif_abapgit_definitions=>ty_item
+      !iv_sub_obj_name TYPE zif_abapgit_definitions=>ty_item-obj_name
+      !iv_line_number  TYPE i
+    RETURNING
+      VALUE(rv_exit)   TYPE abap_bool
+    RAISING
+      zcx_abapgit_exception.
+
+ENDINTERFACE.

--- a/src/ui/zif_abapgit_gui_jumper.intf.xml
+++ b/src/ui/zif_abapgit_gui_jumper.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_GUI_JUMPER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI Jump</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
The goal is to greatly simplify the code to jump to an object, and to separate UI and object layers some more.

This PR introduces **GUI Jumper** (`zcl/if_abapgit_gui_jumper`), which covers all generic options to show an object. It tries the following options in order:
- ADT (if enabled)
- Workbench with line number
- Workbench without line number
- Transport System (new; handles many objects)

Only if all fail, abapGit will call the object-specific handler, which will be necessary only in exceptional cases. 

Also moves ADT logic from `zcl_abapgit_objects(_super)` to `zcl_abapgit_adt_link`. 

Next steps:

- Remove `jump_adt` and `jump_se11` from `zcl_abapgit_objects_super` and replace by GUI Jumper
- Remove almost all object-specific jump handlers (`zif_abapgit_object~jump`) since they are covered by GUI Jumper now
- Consolidate "jump to transport" and "jump to user" into GUI Jumper