### PR TITLE
Make exceptions compatible with 702

### DIFF
--- a/src/ui/core/zcx_abapgit_cancel.clas.abap
+++ b/src/ui/core/zcx_abapgit_cancel.clas.abap
@@ -24,21 +24,20 @@ ENDCLASS.
 CLASS zcx_abapgit_cancel IMPLEMENTATION.
 
 
-  method CONSTRUCTOR.
-CALL METHOD SUPER->CONSTRUCTOR
-EXPORTING
-PREVIOUS = PREVIOUS
-II_LOG = II_LOG
-MSGV1 = MSGV1
-MSGV2 = MSGV2
-MSGV3 = MSGV3
-MSGV4 = MSGV4
-.
-clear me->textid.
-if textid is initial.
-  IF_T100_MESSAGE~T100KEY = IF_T100_MESSAGE=>DEFAULT_TEXTID.
-else.
-  IF_T100_MESSAGE~T100KEY = TEXTID.
-endif.
-  endmethod.
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+    super->constructor(
+      previous = previous
+      ii_log   = ii_log
+      msgv1    = msgv1
+      msgv2    = msgv2
+      msgv3    = msgv3
+      msgv4    = msgv4 ).
+
+    CLEAR me->textid.
+    IF textid IS INITIAL.
+      if_t100_message~t100key = if_t100_message=>default_textid.
+    ELSE.
+      if_t100_message~t100key = textid.
+    ENDIF.
+  ENDMETHOD.
 ENDCLASS.

--- a/src/ui/core/zcx_abapgit_cancel.clas.abap
+++ b/src/ui/core/zcx_abapgit_cancel.clas.abap
@@ -2,13 +2,43 @@ CLASS zcx_abapgit_cancel DEFINITION
   PUBLIC
   INHERITING FROM zcx_abapgit_exception
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !textid   LIKE if_t100_message=>t100key OPTIONAL
+        !previous LIKE previous OPTIONAL
+        !ii_log   TYPE REF TO zif_abapgit_log OPTIONAL
+        !msgv1    TYPE symsgv OPTIONAL
+        !msgv2    TYPE symsgv OPTIONAL
+        !msgv3    TYPE symsgv OPTIONAL
+        !msgv4    TYPE symsgv OPTIONAL.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
-CLASS ZCX_ABAPGIT_CANCEL IMPLEMENTATION.
+
+CLASS zcx_abapgit_cancel IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+PREVIOUS = PREVIOUS
+II_LOG = II_LOG
+MSGV1 = MSGV1
+MSGV2 = MSGV2
+MSGV3 = MSGV3
+MSGV4 = MSGV4
+.
+clear me->textid.
+if textid is initial.
+  IF_T100_MESSAGE~T100KEY = IF_T100_MESSAGE=>DEFAULT_TEXTID.
+else.
+  IF_T100_MESSAGE~T100KEY = TEXTID.
+endif.
+  endmethod.
 ENDCLASS.

--- a/src/zcx_abapgit_not_found.clas.abap
+++ b/src/zcx_abapgit_not_found.clas.abap
@@ -19,11 +19,9 @@ ENDCLASS.
 CLASS zcx_abapgit_not_found IMPLEMENTATION.
 
 
-  method CONSTRUCTOR.
-CALL METHOD SUPER->CONSTRUCTOR
-EXPORTING
-TEXTID = TEXTID
-PREVIOUS = PREVIOUS
-.
-  endmethod.
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+    super->constructor(
+      textid   = textid
+      previous = previous ).
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zcx_abapgit_not_found.clas.abap
+++ b/src/zcx_abapgit_not_found.clas.abap
@@ -2,9 +2,14 @@ CLASS zcx_abapgit_not_found DEFINITION
   PUBLIC
   INHERITING FROM cx_static_check
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !textid   LIKE textid OPTIONAL
+        !previous LIKE previous OPTIONAL.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -12,4 +17,13 @@ ENDCLASS.
 
 
 CLASS zcx_abapgit_not_found IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+  endmethod.
 ENDCLASS.


### PR DESCRIPTION
I finally solved the puzzle on how to make the developer version work on 702.

702 does not deserialize exception classes correctly that have a constructor in a super-class (see #1273). Adding an explicit constructor that calls the super-constructor, the issue is avoided.

Closes #1273