### PR TITLE
update to node16 + ignore scripts

### DIFF
--- a/.github/workflows/ajson_mirror.yaml
+++ b/.github/workflows/ajson_mirror.yaml
@@ -9,7 +9,7 @@ jobs:
   pr_ajson_changes:
     # Origin repo only
     if: github.repository == 'abapGit/abapGit'
-    
+
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
     - name: run
       run: |
         git clone https://github.com/abapGit/ajson_mirror.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Run npm steps
       run: |
         npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
     - name: npm run unit
       run: |
         npm install
@@ -37,6 +39,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
     - name: npm run integration
       run: |
         npm install

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "devDependencies": {
-    "@abaplint/cli": "^2.80.7",
+    "@abaplint/cli": "^2.80.8",
     "@abaplint/runtime": "^1.6.63",
     "@abaplint/transpiler-cli": "^1.6.63",
     "abapmerge": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     ]
   },
   "devDependencies": {
-    "@abaplint/cli": "^2.79.35",
-    "@abaplint/runtime": "^1.6.62",
-    "@abaplint/transpiler-cli": "^1.6.62",
+    "@abaplint/cli": "^2.80.7",
+    "@abaplint/runtime": "^1.6.63",
+    "@abaplint/transpiler-cli": "^1.6.63",
     "abapmerge": "^0.14.3",
     "c8": "^7.10.0",
-    "eslint": "^8.1.0"
+    "eslint": "^8.2.0"
   }
 }


### PR DESCRIPTION
update to require node 16, as it handles ignore-scripts properly

`ignore-scripts=true` set due to https://news.ycombinator.com/item?id=29122098 to protect our developers, there should not be any dependencies requiring post install steps in abapGit

note that ignore-scripts on node 14 ignores everything, so update to 16 is required

https://docs.npmjs.com/cli/v7/using-npm/config#ignore-scripts