### PR TITLE
Hotkey overview: Show link hint activation key

### DIFF
--- a/src/ui/zcl_abapgit_gui_hotkey_ctl.clas.abap
+++ b/src/ui/zcl_abapgit_gui_hotkey_ctl.clas.abap
@@ -132,7 +132,8 @@ CLASS zcl_abapgit_gui_hotkey_ctl IMPLEMENTATION.
     DATA:
       lv_hint               TYPE string,
       lt_registered_hotkeys TYPE zif_abapgit_gui_hotkeys=>ty_hotkeys_with_descr,
-      lv_hotkey             TYPE string.
+      lv_hotkey             TYPE string,
+      ls_user_settings      TYPE zif_abapgit_definitions=>ty_s_user_settings.
 
     FIELD-SYMBOLS <ls_hotkey> LIKE LINE OF lt_registered_hotkeys.
 
@@ -153,6 +154,16 @@ CLASS zcl_abapgit_gui_hotkey_ctl IMPLEMENTATION.
         && |<span class="key-descr">{ <ls_hotkey>-description }</span>|
         && |</li>| ).
     ENDLOOP.
+
+    " render link hints activation key
+    ls_user_settings = zcl_abapgit_persistence_user=>get_instance( )->get_settings( ).
+    IF ls_user_settings-link_hints_enabled = abap_true.
+      ri_html->add( |<li>|
+         && |<span class="key-id">{ ls_user_settings-link_hint_key }</span>|
+         && |<span class="key-descr">Link Hints</span>|
+         && |</li>| ).
+    ENDIF.
+
     ri_html->add( '</ul>' ).
 
     CLEAR lv_hotkey.


### PR DESCRIPTION
If link hints are activated in user settings
![grafik](https://user-images.githubusercontent.com/17437789/140874933-65a49937-ff68-42f9-9024-c636cc112c25.png)
then they are shown in hotkey overview
![grafik](https://user-images.githubusercontent.com/17437789/140874938-5ae24611-7306-4179-90c5-d686567620bd.png)
