### PR TITLE
Update guide-changelog.md

### DIFF
--- a/docs/collections/_development/guide-changelog.md
+++ b/docs/collections/_development/guide-changelog.md
@@ -3,7 +3,7 @@ title: Changelog
 order: 150
 ---
 
-abapGit allows to show a changelog notes, based on changelog file in the repository base
+abapGit allows to show a changelog notes, based on changelog file in the repository base, and on [APACK](ref-apack.html) class containing the current version.
 
 ## File format ##
 A file named as pattern `CHANGELOG*` or `changelog*`


### PR DESCRIPTION
The changelog is displayed only if the repository contains a class which implements `ZIF_APACK_MANIFEST`, whose constructor initializes the current version in attribute `zif_apack_manifest~descriptor-version`.