### PR TITLE
Adjust syntax highlighter output

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_abap.clas.testclasses.abap
+++ b/src/syntax/zcl_abapgit_syntax_abap.clas.testclasses.abap
@@ -79,8 +79,8 @@ CLASS ltcl_syntax_basic_logic IMPLEMENTATION.
     lv_line_exp =
       '<span class="keyword">call</span>' &&
       ' <span class="keyword">function</span>' &&
-      ' <span class="text">&#39;FM_NAME&#39;</span>.' &&
-      ' <span class="comment">&quot; Commented</span>'.
+      | <span class="text">'FM_NAME'</span>.| &&
+      ' <span class="comment">" Commented</span>'.
 
     lv_line_act = mo_syntax_highlighter->process_line( lv_line ).
 

--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -112,7 +112,7 @@ CLASS zcl_abapgit_syntax_highlighter IMPLEMENTATION.
     DATA lv_escaped TYPE string.
 
     lv_escaped = escape( val    = iv_line
-                         format = cl_abap_format=>e_html_attr ).
+                         format = cl_abap_format=>e_html_text ).
 
     lv_escaped = show_hidden_chars( lv_escaped ).
 

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
@@ -55,11 +55,11 @@ CLASS ltcl_abapgit_syntax_xml IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = |<span class="xml_tag">&lt;ECTD</span>|
          && |<span class="attr"> SAPRL</span>=|
-         && |<span class="attr_val">&quot;751&quot;</span>|
+         && |<span class="attr_val">"751"</span>|
          && |<span class="attr"> VERSION</span>=|
-         && |<span class="attr_val">&quot;1.5&quot;</span>|
-         && |<span class="attr"> DOWNLOADDATE</span>=<span class="attr_val">&quot;&quot;</span>|
-         && |<span class="attr"> DOWNLOADTIME</span>=<span class="attr_val">&quot;&quot;</span>|
+         && |<span class="attr_val">"1.5"</span>|
+         && |<span class="attr"> DOWNLOADDATE</span>=<span class="attr_val">""</span>|
+         && |<span class="attr"> DOWNLOADTIME</span>=<span class="attr_val">""</span>|
          && |<span class="xml_tag">&gt;</span>|
       act = mo_cut->process_line( |<ECTD SAPRL="751" VERSION="1.5" DOWNLOADDATE="" DOWNLOADTIME="">| ) ).
 
@@ -69,16 +69,16 @@ CLASS ltcl_abapgit_syntax_xml IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       exp = |<span class="attr"> SAPRL</span>=|
-         && |<span class="attr_val">&quot;751&quot;</span>|
+         && |<span class="attr_val">"751"</span>|
          && |<span class="attr"> VERSION</span>=|
-         && |<span class="attr_val">&quot;&gt;1.5&quot;</span>|
+         && |<span class="attr_val">"&gt;1.5"</span>|
       act = mo_cut->process_line( | SAPRL="751" VERSION=">1.5"| ) ).
 
     cl_abap_unit_assert=>assert_equals(
       exp = |<span class="attr">SAPRL</span>=|
-         && |<span class="attr_val">&quot;751&quot;</span>|
+         && |<span class="attr_val">"751"</span>|
          && |<span class="attr"> VERSION</span>=|
-         && |<span class="attr_val">&#39;&gt;1.5&#39;</span>|
+         && |<span class="attr_val">'&gt;1.5'</span>|
       act = mo_cut->process_line( |SAPRL="751" VERSION='>1.5'| ) ).
 
   ENDMETHOD.
@@ -92,9 +92,9 @@ CLASS ltcl_abapgit_syntax_xml IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = |<span class="xml_tag">&lt;ECTD</span>|
          && |<span class="attr"> SAPRL</span>=|
-         && |<span class="attr_val">&quot;751&quot;</span>|
+         && |<span class="attr_val">"751"</span>|
          && |<span class="attr"> VERSION</span>=|
-         && |<span class="attr_val">&quot;1.5&quot;</span>|
+         && |<span class="attr_val">"1.5"</span>|
       act = mo_cut->process_line( |<ECTD SAPRL="751" VERSION="1.5"| ) ).
 
 

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -215,13 +215,6 @@
       {"object": "ZCL_ABAPGIT_INJECTOR", "class": "ltcl_no_dependency_injection", "method": "no_injection"},
       {"object": "ZCL_ABAPGIT_INJECTOR", "class": "ltcl_simple_dependency_inject", "method": "simple_injection"},
 
-      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "sole_closing_xml_tag", "note": "#5128"},
-      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "complete_xml_tag", "note": "#5128"},
-      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "complete_xml_tag_with_closing", "note": "#5128"},
-      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "empty_attributes", "note": "#5128"},
-      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "open_tags", "note": "#5128"},
-      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "attributes_only", "note": "#5128"},
-
       {"object": "ZCL_ABAPGIT_HTML_FORM_UTILS", "class": "ltcl_test_form", "method": "validate", "note": "Void type: TIMESTAMPL"},
       {"object": "ZCL_ABAPGIT_HTML_FORM_UTILS", "class": "ltcl_test_form", "method": "normalize", "note": "Void type: TIMESTAMPL"},
       {"object": "ZCL_ABAPGIT_HTML_FORM_UTILS", "class": "ltcl_test_form", "method": "is_empty", "note": "Void type: TIMESTAMPL"},

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -215,6 +215,13 @@
       {"object": "ZCL_ABAPGIT_INJECTOR", "class": "ltcl_no_dependency_injection", "method": "no_injection"},
       {"object": "ZCL_ABAPGIT_INJECTOR", "class": "ltcl_simple_dependency_inject", "method": "simple_injection"},
 
+      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "sole_closing_xml_tag", "note": "#5128"},
+      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "complete_xml_tag", "note": "#5128"},
+      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "complete_xml_tag_with_closing", "note": "#5128"},
+      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "empty_attributes", "note": "#5128"},
+      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "open_tags", "note": "#5128"},
+      {"object": "ZCL_ABAPGIT_SYNTAX_XML", "class": "ltcl_abapgit_syntax_xml", "method": "attributes_only", "note": "#5128"},
+
       {"object": "ZCL_ABAPGIT_HTML_FORM_UTILS", "class": "ltcl_test_form", "method": "validate", "note": "Void type: TIMESTAMPL"},
       {"object": "ZCL_ABAPGIT_HTML_FORM_UTILS", "class": "ltcl_test_form", "method": "normalize", "note": "Void type: TIMESTAMPL"},
       {"object": "ZCL_ABAPGIT_HTML_FORM_UTILS", "class": "ltcl_test_form", "method": "is_empty", "note": "Void type: TIMESTAMPL"},


### PR DESCRIPTION
Minor adjustment to output of syntax highlighter. There's no need to escape quotes, so `e_html_text` is sufficient.

PS: Change will make implementing "Highlight parts where a changed line is changed" a bit easier (#2804)