### PR TITLE
add more toolbars to Command Palette

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2326,11 +2326,13 @@ function enumerateToolbarActions() {
     }
   }
 
-  var toolbarRoot = document.getElementById("toolbar-main");
-  if (toolbarRoot && toolbarRoot.nodeName === "UL") processUL(toolbarRoot);
-  toolbarRoot = document.getElementById("toolbar-repo");
-  if (toolbarRoot && toolbarRoot.nodeName === "UL") processUL(toolbarRoot);
-  // Add more toolbars ?
+  [].slice.call(document.querySelectorAll("[id*=toolbar]"))
+    .filter(function(toolbar){
+      return (toolbar && toolbar.nodeName === "UL");
+    }).forEach(function(toolbar){
+      processUL(toolbar);
+    });
+
   if (items.length === 0) return;
 
   items = items.map(function(item) {


### PR DESCRIPTION
e.g. on various settings pages
![grafik](https://user-images.githubusercontent.com/17437789/141816184-ad1b8d55-f59c-4f77-964a-dd4eec818499.png)

and others which haven't been supported because they're part of high order component (hoc)
![grafik](https://user-images.githubusercontent.com/17437789/141815985-5d81066f-dc64-414c-8433-7bf807b81209.png)

now all toolbars which ids start with `toolbar` are considered. 