### PR TITLE
add form actions to command palette

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -24,7 +24,7 @@
 /* exported addMarginBottom */
 /* exported enumerateJumpAllFiles */
 /* exported createRepoCatalogEnumerator */
-/* exported enumerateToolbarActions */
+/* exported enumerateUiActions */
 /* exported onDiffCollapse */
 /* exported restoreScrollPosition */
 
@@ -2304,7 +2304,7 @@ function createRepoCatalogEnumerator(catalog, action) {
   };
 }
 
-function enumerateToolbarActions() {
+function enumerateUiActions() {
 
   var items = [];
   function processUL(ulNode, prefix) {
@@ -2326,14 +2326,13 @@ function enumerateToolbarActions() {
     }
   }
 
+  // toolbars
   [].slice.call(document.querySelectorAll("[id*=toolbar]"))
     .filter(function(toolbar){
       return (toolbar && toolbar.nodeName === "UL");
     }).forEach(function(toolbar){
       processUL(toolbar);
     });
-
-  if (items.length === 0) return;
 
   items = items.map(function(item) {
     var action = "";
@@ -2351,6 +2350,24 @@ function enumerateToolbarActions() {
       title:     (prefix ? prefix + ": " : "") + anchor.innerText.trim()
     };
   });
+
+  // forms
+  [].slice.call(document.querySelectorAll("input[type='submit']"))
+    .forEach(function(input){
+      items.push({
+        action: function(){
+          if ([].slice.call(input.classList).indexOf("main") !== -1){
+            var parentForm = input.parentNode.parentNode.parentNode;
+            if (parentForm.nodeName === "FORM"){
+              parentForm.submit();
+            }
+          } else {
+            submitSapeventForm({}, input.formAction, "post");
+          }
+        },
+        title: input.value + " " + input.title.replace(/\[.*\]/,"")
+      });
+    });
 
   return items;
 }

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -164,7 +164,7 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
   METHOD render_command_palettes.
 
-    ii_html->add( 'var gCommandPalette = new CommandPalette(enumerateToolbarActions, {' ).
+    ii_html->add( 'var gCommandPalette = new CommandPalette(enumerateUiActions, {' ).
     ii_html->add( '  toggleKey: "F1",' ).
     ii_html->add( '  hotkeyDescription: "Command ..."' ).
     ii_html->add( '});' ).

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -759,7 +759,7 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
       ii_html->add( '</div>' ).
       ii_html->add( '<div class="command-container">' ).
       ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }"|
-                 && |title="{ is_field-label }">| ).
+                 && | title="{ is_field-label }">| ).
       ii_html->add( '</div>' ).
     ENDIF.
 

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -758,7 +758,8 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
     IF is_field-side_action IS NOT INITIAL.
       ii_html->add( '</div>' ).
       ii_html->add( '<div class="command-container">' ).
-      ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }">| ).
+      ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }"|
+                 && |title="{ is_field-label }">| ).
       ii_html->add( '</div>' ).
     ENDIF.
 


### PR DESCRIPTION
Now form actions are available on command palette too.

E.g. commit page
![grafik](https://user-images.githubusercontent.com/17437789/142264436-1ad6c346-ae0b-4431-ae37-5511bba7f5db.png)

E.g. settings page
![grafik](https://user-images.githubusercontent.com/17437789/142264487-0835be79-44fc-43c2-b4bb-22f6ddbd3543.png)
