### PR TITLE
Decouple last direct usage of `CL_GUI_FRONTEND_SERVICES`

### DIFF
--- a/src/cts/zcl_abapgit_transport_mass.clas.locals_imp.abap
+++ b/src/cts/zcl_abapgit_transport_mass.clas.locals_imp.abap
@@ -23,11 +23,13 @@ CLASS lcl_gui IMPLEMENTATION.
 
   METHOD f4_folder.
 
-    DATA lv_title TYPE string.
+    DATA: lv_title   TYPE string,
+          lo_fe_serv TYPE REF TO zif_abapgit_frontend_services.
 
+    lo_fe_serv = zcl_abapgit_ui_factory=>get_frontend_services( ).
     lv_title = 'Choose the destination folder for the ZIP files'.
 
-    zcl_abapgit_ui_factory=>get_frontend_services( )->directory_browse(
+    lo_fe_serv->directory_browse(
       EXPORTING
          iv_window_title   = lv_title
          iv_initial_folder = gv_last_folder
@@ -143,11 +145,15 @@ ENDCLASS.
 CLASS lcl_transport_zipper IMPLEMENTATION.
 
   METHOD constructor.
+    DATA lo_fe_serv TYPE REF TO zif_abapgit_frontend_services.
+
+    lo_fe_serv = zcl_abapgit_ui_factory=>get_frontend_services( ).
+
     mv_timestamp = |{ sy-datlo }_{ sy-timlo }|.
     mv_full_folder = get_full_folder( iv_folder ).
 
     TRY.
-        zcl_abapgit_ui_factory=>get_frontend_services( )->get_file_separator(
+        lo_fe_serv->get_file_separator(
           CHANGING
             cv_file_separator = mv_separator ).
       CATCH zcx_abapgit_exception.
@@ -187,13 +193,12 @@ CLASS lcl_transport_zipper IMPLEMENTATION.
   METHOD get_filename.
 
     " Generate filename
-    CONCATENATE is_trkorr-trkorr '_' is_trkorr-as4text '_' mv_timestamp c_zip_ext
-      INTO rv_filename.
+    rv_filename = |{ is_trkorr-trkorr }_{ is_trkorr-as4text }_{ mv_timestamp }{ c_zip_ext }|.
 
     " Remove reserved characters (for Windows based systems)
     TRANSLATE rv_filename USING '/ \ : " * > < ? | '.
 
-    CONCATENATE mv_full_folder rv_filename INTO rv_filename SEPARATED BY mv_separator.
+    rv_filename = |{ mv_full_folder }{ mv_separator }{ rv_filename }|.
 
   ENDMETHOD.
 

--- a/src/cts/zcl_abapgit_transport_mass.clas.locals_imp.abap
+++ b/src/cts/zcl_abapgit_transport_mass.clas.locals_imp.abap
@@ -153,9 +153,7 @@ CLASS lcl_transport_zipper IMPLEMENTATION.
     mv_full_folder = get_full_folder( iv_folder ).
 
     TRY.
-        lo_fe_serv->get_file_separator(
-          CHANGING
-            cv_file_separator = mv_separator ).
+        lo_fe_serv->get_file_separator( CHANGING cv_file_separator = mv_separator ).
       CATCH zcx_abapgit_exception.
         "Default MS Windows separator
         mv_separator = '\'.

--- a/src/cts/zcl_abapgit_transport_mass.clas.locals_imp.abap
+++ b/src/cts/zcl_abapgit_transport_mass.clas.locals_imp.abap
@@ -1,13 +1,21 @@
 CLASS lcl_gui DEFINITION FINAL.
-
   PUBLIC SECTION.
-
-    CLASS-METHODS f4_folder RETURNING VALUE(rv_folder) TYPE string RAISING zcx_abapgit_exception.
-    CLASS-METHODS open_folder_frontend IMPORTING iv_folder TYPE string.
-    CLASS-METHODS select_tr_requests RETURNING VALUE(rt_trkorr) TYPE trwbo_request_headers.
+    CLASS-METHODS f4_folder
+      RETURNING
+        VALUE(rv_folder) TYPE string
+      RAISING
+        zcx_abapgit_exception.
+    CLASS-METHODS open_folder_frontend
+      IMPORTING
+        iv_folder TYPE string
+      RAISING
+        zcx_abapgit_exception.
+    CLASS-METHODS select_tr_requests
+      RETURNING
+        VALUE(rt_trkorr) TYPE trwbo_request_headers.
 
   PRIVATE SECTION.
-    CLASS-DATA: gv_last_folder TYPE string.
+    CLASS-DATA gv_last_folder TYPE string.
 
 ENDCLASS.
 
@@ -15,7 +23,7 @@ CLASS lcl_gui IMPLEMENTATION.
 
   METHOD f4_folder.
 
-    DATA: lv_title  TYPE string.
+    DATA lv_title TYPE string.
 
     lv_title = 'Choose the destination folder for the ZIP files'.
 
@@ -71,14 +79,14 @@ CLASS lcl_gui IMPLEMENTATION.
     ls_popup-start_column = 5.
     ls_popup-start_row    = 5.
 
-*- Prepare the selection ----------------------------------------------*
+    " Prepare the selection
     ls_selection-trkorrpattern = space.
     ls_selection-client        = space.
     ls_selection-stdrequest    = space.
     ls_selection-reqfunctions  = 'K'.
     ls_selection-reqstatus     = 'RNODL'.
 
-*- Call transport selection popup -------------------------------------*
+    " Call transport selection popup
     CALL FUNCTION 'TRINT_SELECT_REQUESTS'
       EXPORTING
         iv_username_pattern    = '*'
@@ -104,38 +112,55 @@ CLASS lcl_gui IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_transport_zipper DEFINITION FINAL.
-
   PUBLIC SECTION.
     TYPES ty_folder TYPE string.
     TYPES ty_filename TYPE string.
 
-* File extension
     CONSTANTS c_zip_ext TYPE string VALUE '.zip'.
 
-    METHODS constructor  IMPORTING iv_folder TYPE ty_folder
-                         RAISING   zcx_abapgit_exception.
+    METHODS constructor
+      IMPORTING
+        iv_folder TYPE ty_folder
+      RAISING
+        zcx_abapgit_exception.
 
-    METHODS generate_files IMPORTING it_trkorr TYPE trwbo_request_headers
-                                     ig_logic  TYPE any
-                           RAISING   zcx_abapgit_exception.
+    METHODS generate_files
+      IMPORTING
+        it_trkorr TYPE trwbo_request_headers
+        ig_logic  TYPE any
+      RAISING
+        zcx_abapgit_exception.
 
-    METHODS get_folder RETURNING VALUE(rv_full_folder) TYPE ty_folder.
+    METHODS get_folder
+      RETURNING
+        VALUE(rv_full_folder) TYPE ty_folder.
 
-    CLASS-METHODS does_folder_exist IMPORTING iv_folder              TYPE string
-                                    RETURNING VALUE(rv_folder_exist) TYPE abap_bool
-                                    RAISING   zcx_abapgit_exception.
+    CLASS-METHODS does_folder_exist
+      IMPORTING
+        iv_folder              TYPE string
+      RETURNING
+        VALUE(rv_folder_exist) TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception.
 
   PRIVATE SECTION.
     DATA: mv_timestamp   TYPE string,
           mv_separator   TYPE c,
           mv_full_folder TYPE ty_folder.
 
-    METHODS get_full_folder IMPORTING iv_folder             TYPE ty_folder
-                            RETURNING VALUE(rv_full_folder) TYPE ty_folder
-                            RAISING   zcx_abapgit_exception.
+    METHODS get_full_folder
+      IMPORTING
+        iv_folder             TYPE ty_folder
+      RETURNING
+        VALUE(rv_full_folder) TYPE ty_folder
+      RAISING
+        zcx_abapgit_exception.
 
-    METHODS get_filename IMPORTING is_trkorr          TYPE trwbo_request_header
-                         RETURNING VALUE(rv_filename) TYPE ty_filename.
+    METHODS get_filename
+      IMPORTING
+        is_trkorr          TYPE trwbo_request_header
+      RETURNING
+        VALUE(rv_filename) TYPE ty_filename.
 
 ENDCLASS.
 
@@ -234,11 +259,11 @@ CLASS lcl_transport_zipper IMPLEMENTATION.
 
   METHOD get_filename.
 
-* Generate filename
+    " Generate filename
     CONCATENATE is_trkorr-trkorr '_' is_trkorr-as4text '_' mv_timestamp c_zip_ext
       INTO rv_filename.
 
-* Remove reserved characters (for Windows based systems)
+    " Remove reserved characters (for Windows based systems)
     TRANSLATE rv_filename USING '/ \ : " * > < ? | '.
 
     CONCATENATE mv_full_folder rv_filename INTO rv_filename SEPARATED BY mv_separator.

--- a/src/ui/zcl_abapgit_frontend_services.clas.abap
+++ b/src/ui/zcl_abapgit_frontend_services.clas.abap
@@ -299,4 +299,43 @@ CLASS ZCL_ABAPGIT_FRONTEND_SERVICES IMPLEMENTATION.
     ENDIF.
   ENDMETHOD.
 
+  METHOD zif_abapgit_frontend_services~directory_exist.
+    cl_gui_frontend_services=>directory_exist(
+      EXPORTING
+        directory            = iv_directory
+      RECEIVING
+        result               = rv_exists
+      EXCEPTIONS
+        cntl_error           = 1
+        error_no_gui         = 2
+        wrong_parameter      = 3
+        not_supported_by_gui = 4
+        OTHERS               = 5 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~directory_create.
+    cl_gui_frontend_services=>directory_create(
+      EXPORTING
+        directory                = iv_directory
+      CHANGING
+        rc                       = cv_rc
+      EXCEPTIONS
+        directory_create_failed  = 1
+        cntl_error               = 2
+        error_no_gui             = 3
+        directory_access_denied  = 4
+        directory_already_exists = 5
+        path_not_found           = 6
+        unknown_error            = 7
+        not_supported_by_gui     = 8
+        wrong_parameter          = 9
+        OTHERS                   = 10 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zif_abapgit_frontend_services.intf.abap
+++ b/src/ui/zif_abapgit_frontend_services.intf.abap
@@ -82,4 +82,20 @@ INTERFACE zif_abapgit_frontend_services PUBLIC.
     RAISING
       zcx_abapgit_exception.
 
+  METHODS directory_exist
+    IMPORTING
+      iv_directory     TYPE string
+    RETURNING
+      VALUE(rv_exists) TYPE abap_bool
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS directory_create
+    IMPORTING
+      iv_directory TYPE string
+    CHANGING
+      cv_rc        TYPE i
+    RAISING
+      zcx_abapgit_exception.
+
 ENDINTERFACE.

--- a/src/ui/zif_abapgit_frontend_services.intf.abap
+++ b/src/ui/zif_abapgit_frontend_services.intf.abap
@@ -8,7 +8,7 @@ INTERFACE zif_abapgit_frontend_services PUBLIC.
     RETURNING
       VALUE(rv_xstr) TYPE xstring
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS file_download
     IMPORTING
       !iv_path TYPE string
@@ -23,7 +23,7 @@ INTERFACE zif_abapgit_frontend_services PUBLIC.
     RETURNING
       VALUE(rv_path)       TYPE string
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS show_file_open_dialog
     IMPORTING
       !iv_title            TYPE string
@@ -32,7 +32,7 @@ INTERFACE zif_abapgit_frontend_services PUBLIC.
     RETURNING
       VALUE(rv_path)       TYPE string
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
 
   METHODS clipboard_export
     IMPORTING


### PR DESCRIPTION
- methods `directory_exist` and `directory_create` added to interface
- changes/cleanup in `zcl_abapgit_transport_mass` local types:
  - replace direct `cl_gui_frontend_services` usage with interface
  - normalize comments
  - normalize method signature formatting
  - replace concat with string templates
 
closes #2510