### PR TITLE
Expand TABL includes before PUT

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -801,6 +801,22 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
       corr_insert( iv_package = iv_package
                    ig_object_class = 'DICT' ).
 
+      CALL FUNCTION 'DD_TABL_EXPAND'
+        EXPORTING
+          dd02v_wa          = ls_dd02v
+        TABLES
+          dd03p_tab         = lt_dd03p
+          dd05m_tab         = lt_dd05m
+          dd08v_tab         = lt_dd08v
+          dd35v_tab         = lt_dd35v
+          dd36m_tab         = lt_dd36m
+        EXCEPTIONS
+          illegal_parameter = 1
+          OTHERS            = 2.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
+
       CALL FUNCTION 'DDIF_TABL_PUT'
         EXPORTING
           name              = lv_name


### PR DESCRIPTION
Closes #5152

maybe some DD gurus should validate... but looks like a simple fix and follows what actually SE11 does.

And worked on my target systems. (no more irrelevant diffs !)