### PR TITLE
Skip ZCL_ABAPGIT_INTEGRATION_GIT test

### DIFF
--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -90,6 +90,7 @@
     "addCommonJS": true,
     "unknownTypes": "runtimeError",
     "skip": [
+      {"object": "ZCL_ABAPGIT_INTEGRATION_GIT", "class": "ltcl_test", "method": "test01",    "note": "started failing at #1775"},
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_test", "method": "test_direct_text"},
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_test", "method": "test_no_text"},
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_get_t100_longtext", "method": "test01"},


### PR DESCRIPTION
Temporarily skip this test class. Worked ok before #1775, but not anymore.