### PR TITLE
Refactor: Jump to Object Logic

### DIFF
--- a/src/objects/zcl_abapgit_object_acid.clas.abap
+++ b/src/objects/zcl_abapgit_object_acid.clas.abap
@@ -173,14 +173,7 @@ CLASS zcl_abapgit_object_acid IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'ACID'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_amsd.clas.abap
+++ b/src/objects/zcl_abapgit_object_amsd.clas.abap
@@ -369,22 +369,7 @@ CLASS zcl_abapgit_object_amsd IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_bdef.clas.abap
+++ b/src/objects/zcl_abapgit_object_bdef.clas.abap
@@ -567,22 +567,7 @@ CLASS zcl_abapgit_object_bdef IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_char.clas.abap
+++ b/src/objects/zcl_abapgit_object_char.clas.abap
@@ -31,7 +31,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CHAR IMPLEMENTATION.
+CLASS zcl_abapgit_object_char IMPLEMENTATION.
 
 
   METHOD instantiate_char_and_lock.
@@ -254,21 +254,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CHAR IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -93,7 +93,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
+CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -662,12 +662,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'CLAS'
-        in_new_window = abap_true.
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cmpt.clas.abap
+++ b/src/objects/zcl_abapgit_object_cmpt.clas.abap
@@ -189,21 +189,7 @@ CLASS zcl_abapgit_object_cmpt IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_dcls.clas.abap
@@ -168,16 +168,7 @@ CLASS zcl_abapgit_object_dcls IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    TRY.
-
-        jump_adt( iv_obj_name = ms_item-obj_name
-                  iv_obj_type = ms_item-obj_type ).
-
-      CATCH zcx_abapgit_exception.
-        zcx_abapgit_exception=>raise( 'DCLS Jump Error' ).
-    ENDTRY.
-
+    " Covered by ZCL_ABAPGIT_ADT_LINK=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -148,8 +148,8 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
         IF sy-subrc = 0.
           ASSIGN COMPONENT 'DDLNAME' OF STRUCTURE <lg_entity_view> TO <lg_ddlname>.
 
-          jump_adt( iv_obj_name = <lg_ddlname>
-                    iv_obj_type = 'DDLS' ).
+          zcl_abapgit_adt_link=>jump( iv_obj_name = <lg_ddlname>
+                                      iv_obj_type = 'DDLS' ).
 
         ENDIF.
 

--- a/src/objects/zcl_abapgit_object_ddlx.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddlx.clas.abap
@@ -243,15 +243,7 @@ CLASS zcl_abapgit_object_ddlx IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    TRY.
-        jump_adt( iv_obj_name = ms_item-obj_name
-                  iv_obj_type = ms_item-obj_type ).
-
-      CATCH zcx_abapgit_exception.
-        zcx_abapgit_exception=>raise( 'DDLX Jump Error' ).
-    ENDTRY.
-
+    " Covered by ZCL_ABAPGIT_ADT_LINK=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -700,19 +700,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = 'DEVC'
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -335,9 +335,7 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    jump_se11( ).
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_drul.clas.abap
+++ b/src/objects/zcl_abapgit_object_drul.clas.abap
@@ -400,22 +400,7 @@ CLASS zcl_abapgit_object_drul IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dtdc.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtdc.clas.abap
@@ -401,22 +401,7 @@ CLASS zcl_abapgit_object_dtdc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -36,7 +36,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
+CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -271,9 +271,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    jump_se11( ).
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ecatt_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_ecatt_super.clas.abap
@@ -560,22 +560,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_enhc.clas.abap
+++ b/src/objects/zcl_abapgit_object_enhc.clas.abap
@@ -196,20 +196,7 @@ CLASS zcl_abapgit_object_enhc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true
-      EXCEPTIONS
-        OTHERS        = 1.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_enho.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho.clas.abap
@@ -208,14 +208,7 @@ CLASS zcl_abapgit_object_enho IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'ENHO'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_enhs.clas.abap
+++ b/src/objects/zcl_abapgit_object_enhs.clas.abap
@@ -19,7 +19,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_ENHS IMPLEMENTATION.
+CLASS zcl_abapgit_object_enhs IMPLEMENTATION.
 
 
   METHOD factory.
@@ -174,14 +174,7 @@ CLASS ZCL_ABAPGIT_OBJECT_ENHS IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'ENHS'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_enqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_enqu.clas.abap
@@ -130,9 +130,7 @@ CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    jump_se11( ).
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ensc.clas.abap
+++ b/src/objects/zcl_abapgit_object_ensc.clas.abap
@@ -160,14 +160,7 @@ CLASS zcl_abapgit_object_ensc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'ENSC'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ftgl.clas.abap
+++ b/src/objects/zcl_abapgit_object_ftgl.clas.abap
@@ -29,7 +29,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_FTGL IMPLEMENTATION.
+CLASS zcl_abapgit_object_ftgl IMPLEMENTATION.
 
 
   METHOD clear_field.
@@ -165,22 +165,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FTGL IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS_REMOTE'
-      STARTING NEW TASK 'GIT'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -145,40 +145,6 @@ ENDCLASS.
 CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
 
-  METHOD belongs_incl_to_other_fugr.
-    " make sure that the include belongs to the function group
-    " like in LSEAPFAP Form TADIR_MAINTENANCE
-    DATA ls_tadir TYPE tadir.
-    DATA lv_namespace TYPE rs38l-namespace.
-    DATA lv_area TYPE rs38l-area.
-    DATA lv_include TYPE rs38l-include.
-
-    rv_belongs_to_other_fugr = abap_false.
-    IF iv_include(1) = 'L' OR iv_include+1 CS '/L'.
-      lv_include = iv_include.
-      ls_tadir-object = 'FUGR'.
-
-      CALL FUNCTION 'FUNCTION_INCLUDE_SPLIT'
-        IMPORTING
-          namespace = lv_namespace
-          group     = lv_area
-        CHANGING
-          include   = lv_include
-        EXCEPTIONS
-          OTHERS    = 1.
-      IF lv_area(1) = 'X'.    " "EXIT"-function-module
-        ls_tadir-object = 'FUGS'.
-      ENDIF.
-      IF sy-subrc = 0.
-        CONCATENATE lv_namespace lv_area INTO ls_tadir-obj_name.
-        IF ls_tadir-obj_name <> ms_item-obj_name.
-          rv_belongs_to_other_fugr = abap_true.
-        ENDIF.
-      ENDIF.
-    ENDIF.
-  ENDMETHOD.
-
-
   METHOD check_rfc_parameters.
 
 * function module RS_FUNCTIONMODULE_INSERT does the same deep down, but the right error
@@ -1238,5 +1204,39 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
                    ig_data = ls_cua ).
     ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD belongs_incl_to_other_fugr.
+    " make sure that the include belongs to the function group
+    " like in LSEAPFAP Form TADIR_MAINTENANCE
+    DATA ls_tadir TYPE tadir.
+    DATA lv_namespace TYPE rs38l-namespace.
+    DATA lv_area TYPE rs38l-area.
+    DATA lv_include TYPE rs38l-include.
+
+    rv_belongs_to_other_fugr = abap_false.
+    IF iv_include(1) = 'L' OR iv_include+1 CS '/L'.
+      lv_include = iv_include.
+      ls_tadir-object = 'FUGR'.
+
+      CALL FUNCTION 'FUNCTION_INCLUDE_SPLIT'
+        IMPORTING
+          namespace = lv_namespace
+          group     = lv_area
+        CHANGING
+          include   = lv_include
+        EXCEPTIONS
+          OTHERS    = 1.
+      IF lv_area(1) = 'X'.    " "EXIT"-function-module
+        ls_tadir-object = 'FUGS'.
+      ENDIF.
+      IF sy-subrc = 0.
+        CONCATENATE lv_namespace lv_area INTO ls_tadir-obj_name.
+        IF ls_tadir-obj_name <> ms_item-obj_name.
+          rv_belongs_to_other_fugr = abap_true.
+        ENDIF.
+      ENDIF.
+    ENDIF.
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -145,6 +145,40 @@ ENDCLASS.
 CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
 
+  METHOD belongs_incl_to_other_fugr.
+    " make sure that the include belongs to the function group
+    " like in LSEAPFAP Form TADIR_MAINTENANCE
+    DATA ls_tadir TYPE tadir.
+    DATA lv_namespace TYPE rs38l-namespace.
+    DATA lv_area TYPE rs38l-area.
+    DATA lv_include TYPE rs38l-include.
+
+    rv_belongs_to_other_fugr = abap_false.
+    IF iv_include(1) = 'L' OR iv_include+1 CS '/L'.
+      lv_include = iv_include.
+      ls_tadir-object = 'FUGR'.
+
+      CALL FUNCTION 'FUNCTION_INCLUDE_SPLIT'
+        IMPORTING
+          namespace = lv_namespace
+          group     = lv_area
+        CHANGING
+          include   = lv_include
+        EXCEPTIONS
+          OTHERS    = 1.
+      IF lv_area(1) = 'X'.    " "EXIT"-function-module
+        ls_tadir-object = 'FUGS'.
+      ENDIF.
+      IF sy-subrc = 0.
+        CONCATENATE lv_namespace lv_area INTO ls_tadir-obj_name.
+        IF ls_tadir-obj_name <> ms_item-obj_name.
+          rv_belongs_to_other_fugr = abap_true.
+        ENDIF.
+      ENDIF.
+    ENDIF.
+  ENDMETHOD.
+
+
   METHOD check_rfc_parameters.
 
 * function module RS_FUNCTIONMODULE_INSERT does the same deep down, but the right error
@@ -1154,14 +1188,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'FUGR'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 
@@ -1211,39 +1238,5 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
                    ig_data = ls_cua ).
     ENDIF.
 
-  ENDMETHOD.
-
-
-  METHOD belongs_incl_to_other_fugr.
-    " make sure that the include belongs to the function group
-    " like in LSEAPFAP Form TADIR_MAINTENANCE
-    DATA ls_tadir TYPE tadir.
-    DATA lv_namespace TYPE rs38l-namespace.
-    DATA lv_area TYPE rs38l-area.
-    DATA lv_include TYPE rs38l-include.
-
-    rv_belongs_to_other_fugr = abap_false.
-    IF iv_include(1) = 'L' OR iv_include+1 CS '/L'.
-      lv_include = iv_include.
-      ls_tadir-object = 'FUGR'.
-
-      CALL FUNCTION 'FUNCTION_INCLUDE_SPLIT'
-        IMPORTING
-          namespace = lv_namespace
-          group     = lv_area
-        CHANGING
-          include   = lv_include
-        EXCEPTIONS
-          OTHERS    = 1.
-      IF lv_area(1) = 'X'.    " "EXIT"-function-module
-        ls_tadir-object = 'FUGS'.
-      ENDIF.
-      IF sy-subrc = 0.
-        CONCATENATE lv_namespace lv_area INTO ls_tadir-obj_name.
-        IF ls_tadir-obj_name <> ms_item-obj_name.
-          rv_belongs_to_other_fugr = abap_true.
-        ENDIF.
-      ENDIF.
-    ENDIF.
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_iamu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iamu.clas.abap
@@ -39,7 +39,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_IAMU IMPLEMENTATION.
+CLASS zcl_abapgit_object_iamu IMPLEMENTATION.
 
 
   METHOD load_mime_api.
@@ -299,13 +299,7 @@ CLASS ZCL_ABAPGIT_OBJECT_IAMU IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iarp.clas.abap
+++ b/src/objects/zcl_abapgit_object_iarp.clas.abap
@@ -70,7 +70,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_IARP IMPLEMENTATION.
+CLASS zcl_abapgit_object_iarp IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -372,20 +372,7 @@ CLASS ZCL_ABAPGIT_OBJECT_IARP IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |error from RS_TOOL_ACCESS. Subrc={ sy-subrc }| ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iasp.clas.abap
+++ b/src/objects/zcl_abapgit_object_iasp.clas.abap
@@ -353,20 +353,7 @@ CLASS zcl_abapgit_object_iasp IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iatu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iatu.clas.abap
@@ -111,6 +111,193 @@ CLASS zcl_abapgit_object_iatu IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD w3_api_create_new.
+
+    cl_w3_api_template=>if_w3_api_template~create_new(
+      EXPORTING
+        p_template_data          = is_template_data
+        p_program_name           = is_template_data-programm
+      IMPORTING
+        p_template               = ri_template
+      EXCEPTIONS
+        object_already_existing  = 1
+        object_just_created      = 2
+        not_authorized           = 3
+        undefined_name           = 4
+        author_not_existing      = 5
+        action_cancelled         = 6
+        error_occured            = 7
+        user_error               = 8
+        OTHERS                   = 9 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~create_new subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_delete.
+
+    ii_template->if_w3_api_object~delete(
+      EXCEPTIONS
+        object_not_empty      = 1
+        object_not_changeable = 2
+        object_invalid        = 3
+        error_occured         = 4
+        OTHERS                = 5 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~delete subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_get_attributes.
+
+    ii_template->get_attributes(
+      IMPORTING
+        p_attributes     = rs_attributes
+      EXCEPTIONS
+        object_invalid   = 1
+        template_deleted = 2
+        error_occured    = 3
+        OTHERS           = 4 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_attributes subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_get_source.
+
+    ii_template->get_source(
+      IMPORTING
+        p_source         = rt_source
+      EXCEPTIONS
+        object_invalid   = 1
+        template_deleted = 2
+        error_occured    = 3
+        OTHERS           = 4 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_source subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_load.
+
+    cl_w3_api_template=>if_w3_api_template~load(
+      EXPORTING
+        p_template_name     = is_name
+      IMPORTING
+        p_template          = ri_template
+      EXCEPTIONS
+        object_not_existing = 1
+        permission_failure  = 2
+        error_occured       = 3
+        OTHERS              = 4 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from if_w3_api_template~load subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_save.
+
+    ii_template->if_w3_api_object~save(
+      EXCEPTIONS
+        object_invalid        = 1
+        object_not_changeable = 2
+        action_cancelled      = 3
+        permission_failure    = 4
+        not_changed           = 5
+        data_invalid          = 6
+        error_occured         = 7
+        OTHERS                = 8 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~save subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_set_attributes.
+
+    ii_template->set_attributes(
+      EXPORTING
+        p_attributes          = is_attr
+      EXCEPTIONS
+        object_not_changeable = 1
+        object_deleted        = 2
+        object_invalid        = 3
+        author_not_existing   = 4
+        authorize_failure     = 5
+        error_occured         = 6
+        OTHERS                = 7 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_attributes subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_set_changeable.
+
+    ii_template->if_w3_api_object~set_changeable(
+      EXPORTING
+        p_changeable                 = iv_changeable
+      EXCEPTIONS
+        action_cancelled             = 1
+        object_locked_by_other_user  = 2
+        permission_failure           = 3
+        object_already_changeable    = 4
+        object_already_unlocked      = 5
+        object_just_created          = 6
+        object_deleted               = 7
+        object_modified              = 8
+        object_not_existing          = 9
+        object_invalid               = 10
+        error_occured                = 11
+        OTHERS                       = 12 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_changeable subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_set_source.
+
+    ii_template->set_source(
+      EXPORTING
+        p_source              = it_source
+      EXCEPTIONS
+        object_not_changeable = 1
+        object_deleted        = 2
+        object_invalid        = 3
+        authorize_failure     = 4
+        invalid_parameter     = 5
+        error_occured         = 6
+        OTHERS                = 7 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_source subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_object~changed_by.
     rv_user = c_user_unknown. " todo
   ENDMETHOD.
@@ -193,13 +380,7 @@ CLASS zcl_abapgit_object_iatu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 
@@ -221,191 +402,6 @@ CLASS zcl_abapgit_object_iatu IMPLEMENTATION.
 
     mo_files->add_string( iv_ext    = 'html'
                           iv_string = lv_source ).
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_load.
-
-    cl_w3_api_template=>if_w3_api_template~load(
-      EXPORTING
-        p_template_name     = is_name
-      IMPORTING
-        p_template          = ri_template
-      EXCEPTIONS
-        object_not_existing = 1
-        permission_failure  = 2
-        error_occured       = 3
-        OTHERS              = 4 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from if_w3_api_template~load subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_set_changeable.
-
-    ii_template->if_w3_api_object~set_changeable(
-      EXPORTING
-        p_changeable                 = iv_changeable
-      EXCEPTIONS
-        action_cancelled             = 1
-        object_locked_by_other_user  = 2
-        permission_failure           = 3
-        object_already_changeable    = 4
-        object_already_unlocked      = 5
-        object_just_created          = 6
-        object_deleted               = 7
-        object_modified              = 8
-        object_not_existing          = 9
-        object_invalid               = 10
-        error_occured                = 11
-        OTHERS                       = 12 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_changeable subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_delete.
-
-    ii_template->if_w3_api_object~delete(
-      EXCEPTIONS
-        object_not_empty      = 1
-        object_not_changeable = 2
-        object_invalid        = 3
-        error_occured         = 4
-        OTHERS                = 5 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~delete subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_save.
-
-    ii_template->if_w3_api_object~save(
-      EXCEPTIONS
-        object_invalid        = 1
-        object_not_changeable = 2
-        action_cancelled      = 3
-        permission_failure    = 4
-        not_changed           = 5
-        data_invalid          = 6
-        error_occured         = 7
-        OTHERS                = 8 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~save subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-  METHOD w3_api_get_attributes.
-
-    ii_template->get_attributes(
-      IMPORTING
-        p_attributes     = rs_attributes
-      EXCEPTIONS
-        object_invalid   = 1
-        template_deleted = 2
-        error_occured    = 3
-        OTHERS           = 4 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_attributes subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_get_source.
-
-    ii_template->get_source(
-      IMPORTING
-        p_source         = rt_source
-      EXCEPTIONS
-        object_invalid   = 1
-        template_deleted = 2
-        error_occured    = 3
-        OTHERS           = 4 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_source subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_create_new.
-
-    cl_w3_api_template=>if_w3_api_template~create_new(
-      EXPORTING
-        p_template_data          = is_template_data
-        p_program_name           = is_template_data-programm
-      IMPORTING
-        p_template               = ri_template
-      EXCEPTIONS
-        object_already_existing  = 1
-        object_just_created      = 2
-        not_authorized           = 3
-        undefined_name           = 4
-        author_not_existing      = 5
-        action_cancelled         = 6
-        error_occured            = 7
-        user_error               = 8
-        OTHERS                   = 9 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~create_new subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-  METHOD w3_api_set_attributes.
-
-    ii_template->set_attributes(
-      EXPORTING
-        p_attributes          = is_attr
-      EXCEPTIONS
-        object_not_changeable = 1
-        object_deleted        = 2
-        object_invalid        = 3
-        author_not_existing   = 4
-        authorize_failure     = 5
-        error_occured         = 6
-        OTHERS                = 7 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_attributes subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_set_source.
-
-    ii_template->set_source(
-      EXPORTING
-        p_source              = it_source
-      EXCEPTIONS
-        object_not_changeable = 1
-        object_deleted        = 2
-        object_invalid        = 3
-        authorize_failure     = 4
-        invalid_parameter     = 5
-        error_occured         = 6
-        OTHERS                = 7 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_source subrc={ sy-subrc }| ).
-    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_iatu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iatu.clas.abap
@@ -111,193 +111,6 @@ CLASS zcl_abapgit_object_iatu IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD w3_api_create_new.
-
-    cl_w3_api_template=>if_w3_api_template~create_new(
-      EXPORTING
-        p_template_data          = is_template_data
-        p_program_name           = is_template_data-programm
-      IMPORTING
-        p_template               = ri_template
-      EXCEPTIONS
-        object_already_existing  = 1
-        object_just_created      = 2
-        not_authorized           = 3
-        undefined_name           = 4
-        author_not_existing      = 5
-        action_cancelled         = 6
-        error_occured            = 7
-        user_error               = 8
-        OTHERS                   = 9 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~create_new subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_delete.
-
-    ii_template->if_w3_api_object~delete(
-      EXCEPTIONS
-        object_not_empty      = 1
-        object_not_changeable = 2
-        object_invalid        = 3
-        error_occured         = 4
-        OTHERS                = 5 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~delete subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_get_attributes.
-
-    ii_template->get_attributes(
-      IMPORTING
-        p_attributes     = rs_attributes
-      EXCEPTIONS
-        object_invalid   = 1
-        template_deleted = 2
-        error_occured    = 3
-        OTHERS           = 4 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_attributes subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_get_source.
-
-    ii_template->get_source(
-      IMPORTING
-        p_source         = rt_source
-      EXCEPTIONS
-        object_invalid   = 1
-        template_deleted = 2
-        error_occured    = 3
-        OTHERS           = 4 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_source subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_load.
-
-    cl_w3_api_template=>if_w3_api_template~load(
-      EXPORTING
-        p_template_name     = is_name
-      IMPORTING
-        p_template          = ri_template
-      EXCEPTIONS
-        object_not_existing = 1
-        permission_failure  = 2
-        error_occured       = 3
-        OTHERS              = 4 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from if_w3_api_template~load subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_save.
-
-    ii_template->if_w3_api_object~save(
-      EXCEPTIONS
-        object_invalid        = 1
-        object_not_changeable = 2
-        action_cancelled      = 3
-        permission_failure    = 4
-        not_changed           = 5
-        data_invalid          = 6
-        error_occured         = 7
-        OTHERS                = 8 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~save subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_set_attributes.
-
-    ii_template->set_attributes(
-      EXPORTING
-        p_attributes          = is_attr
-      EXCEPTIONS
-        object_not_changeable = 1
-        object_deleted        = 2
-        object_invalid        = 3
-        author_not_existing   = 4
-        authorize_failure     = 5
-        error_occured         = 6
-        OTHERS                = 7 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_attributes subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_set_changeable.
-
-    ii_template->if_w3_api_object~set_changeable(
-      EXPORTING
-        p_changeable                 = iv_changeable
-      EXCEPTIONS
-        action_cancelled             = 1
-        object_locked_by_other_user  = 2
-        permission_failure           = 3
-        object_already_changeable    = 4
-        object_already_unlocked      = 5
-        object_just_created          = 6
-        object_deleted               = 7
-        object_modified              = 8
-        object_not_existing          = 9
-        object_invalid               = 10
-        error_occured                = 11
-        OTHERS                       = 12 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_changeable subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD w3_api_set_source.
-
-    ii_template->set_source(
-      EXPORTING
-        p_source              = it_source
-      EXCEPTIONS
-        object_not_changeable = 1
-        object_deleted        = 2
-        object_invalid        = 3
-        authorize_failure     = 4
-        invalid_parameter     = 5
-        error_occured         = 6
-        OTHERS                = 7 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_source subrc={ sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_object~changed_by.
     rv_user = c_user_unknown. " todo
   ENDMETHOD.
@@ -402,6 +215,191 @@ CLASS zcl_abapgit_object_iatu IMPLEMENTATION.
 
     mo_files->add_string( iv_ext    = 'html'
                           iv_string = lv_source ).
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_load.
+
+    cl_w3_api_template=>if_w3_api_template~load(
+      EXPORTING
+        p_template_name     = is_name
+      IMPORTING
+        p_template          = ri_template
+      EXCEPTIONS
+        object_not_existing = 1
+        permission_failure  = 2
+        error_occured       = 3
+        OTHERS              = 4 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from if_w3_api_template~load subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_set_changeable.
+
+    ii_template->if_w3_api_object~set_changeable(
+      EXPORTING
+        p_changeable                 = iv_changeable
+      EXCEPTIONS
+        action_cancelled             = 1
+        object_locked_by_other_user  = 2
+        permission_failure           = 3
+        object_already_changeable    = 4
+        object_already_unlocked      = 5
+        object_just_created          = 6
+        object_deleted               = 7
+        object_modified              = 8
+        object_not_existing          = 9
+        object_invalid               = 10
+        error_occured                = 11
+        OTHERS                       = 12 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_changeable subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_delete.
+
+    ii_template->if_w3_api_object~delete(
+      EXCEPTIONS
+        object_not_empty      = 1
+        object_not_changeable = 2
+        object_invalid        = 3
+        error_occured         = 4
+        OTHERS                = 5 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~delete subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_save.
+
+    ii_template->if_w3_api_object~save(
+      EXCEPTIONS
+        object_invalid        = 1
+        object_not_changeable = 2
+        action_cancelled      = 3
+        permission_failure    = 4
+        not_changed           = 5
+        data_invalid          = 6
+        error_occured         = 7
+        OTHERS                = 8 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~save subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD w3_api_get_attributes.
+
+    ii_template->get_attributes(
+      IMPORTING
+        p_attributes     = rs_attributes
+      EXCEPTIONS
+        object_invalid   = 1
+        template_deleted = 2
+        error_occured    = 3
+        OTHERS           = 4 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_attributes subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_get_source.
+
+    ii_template->get_source(
+      IMPORTING
+        p_source         = rt_source
+      EXCEPTIONS
+        object_invalid   = 1
+        template_deleted = 2
+        error_occured    = 3
+        OTHERS           = 4 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~get_source subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_create_new.
+
+    cl_w3_api_template=>if_w3_api_template~create_new(
+      EXPORTING
+        p_template_data          = is_template_data
+        p_program_name           = is_template_data-programm
+      IMPORTING
+        p_template               = ri_template
+      EXCEPTIONS
+        object_already_existing  = 1
+        object_just_created      = 2
+        not_authorized           = 3
+        undefined_name           = 4
+        author_not_existing      = 5
+        action_cancelled         = 6
+        error_occured            = 7
+        user_error               = 8
+        OTHERS                   = 9 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~create_new subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD w3_api_set_attributes.
+
+    ii_template->set_attributes(
+      EXPORTING
+        p_attributes          = is_attr
+      EXCEPTIONS
+        object_not_changeable = 1
+        object_deleted        = 2
+        object_invalid        = 3
+        author_not_existing   = 4
+        authorize_failure     = 5
+        error_occured         = 6
+        OTHERS                = 7 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_attributes subrc={ sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD w3_api_set_source.
+
+    ii_template->set_source(
+      EXPORTING
+        p_source              = it_source
+      EXCEPTIONS
+        object_not_changeable = 1
+        object_deleted        = 2
+        object_invalid        = 3
+        authorize_failure     = 4
+        invalid_parameter     = 5
+        error_occured         = 6
+        OTHERS                = 7 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from w3_api_template~set_source subrc={ sy-subrc }| ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_iaxu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iaxu.clas.abap
@@ -39,7 +39,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_IAXU IMPLEMENTATION.
+CLASS zcl_abapgit_object_iaxu IMPLEMENTATION.
 
 
   METHOD read.
@@ -290,13 +290,7 @@ CLASS ZCL_ABAPGIT_OBJECT_IAXU IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -316,12 +316,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'INTF'
-        in_new_window = abap_true.
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -48,7 +48,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
+CLASS zcl_abapgit_object_msag IMPLEMENTATION.
 
 
   METHOD delete_documentation.
@@ -452,14 +452,7 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'MSAG'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_oa2p.clas.abap
+++ b/src/objects/zcl_abapgit_object_oa2p.clas.abap
@@ -22,6 +22,7 @@ ENDCLASS.
 
 CLASS zcl_abapgit_object_oa2p IMPLEMENTATION.
 
+
   METHOD constructor.
 
     super->constructor( is_item     = is_item
@@ -242,14 +243,7 @@ CLASS zcl_abapgit_object_oa2p IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = mv_profile
-        object_type   = 'OA2P'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_otgr.clas.abap
+++ b/src/objects/zcl_abapgit_object_otgr.clas.abap
@@ -227,19 +227,7 @@ CLASS zcl_abapgit_object_otgr IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_para.clas.abap
+++ b/src/objects/zcl_abapgit_object_para.clas.abap
@@ -212,14 +212,7 @@ CLASS zcl_abapgit_object_para IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'PARA'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_pdxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_pdxx_super.clas.abap
@@ -22,7 +22,9 @@ CLASS zcl_abapgit_object_pdxx_super DEFINITION
 ENDCLASS.
 
 
+
 CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
+
 
   METHOD check_subrc_for.
     IF sy-subrc <> 0.
@@ -31,25 +33,16 @@ CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_object~exists.
+  METHOD constructor.
 
-    CALL FUNCTION 'RH_READ_OBJECT'
-      EXPORTING
-        plvar     = '01'
-        otype     = ms_objkey-otype
-        objid     = ms_objkey-objid
-        istat     = '1'
-        begda     = sy-datum
-        endda     = '99991231'
-        ointerval = 'X'
-        read_db   = 'X'
-      EXCEPTIONS
-        not_found = 1
-        OTHERS    = 2.
+    super->constructor( is_item     = is_item
+                        iv_language = iv_language ).
 
-    rv_bool = boolc( sy-subrc = 0 ).
+    ms_objkey-otype = is_item-obj_type+2(2).
+    ms_objkey-objid = ms_item-obj_name.
 
   ENDMETHOD.
+
 
   METHOD zif_abapgit_object~changed_by.
 
@@ -89,6 +82,27 @@ CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_object~exists.
+
+    CALL FUNCTION 'RH_READ_OBJECT'
+      EXPORTING
+        plvar     = '01'
+        otype     = ms_objkey-otype
+        objid     = ms_objkey-objid
+        istat     = '1'
+        begda     = sy-datum
+        endda     = '99991231'
+        ointerval = 'X'
+        read_db   = 'X'
+      EXCEPTIONS
+        not_found = 1
+        OTHERS    = 2.
+
+    rv_bool = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_object~get_comparator.
     RETURN.
   ENDMETHOD.
@@ -116,30 +130,11 @@ CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    CALL FUNCTION 'RS_TOOL_ACCESS_REMOTE'
-      STARTING NEW TASK 'GIT'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type
-      EXCEPTIONS
-        OTHERS      = 0.
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~serialize.
     ASSERT 1 = 2. "Must be redefined
   ENDMETHOD.
-
-
-  METHOD constructor.
-
-    super->constructor( is_item     = is_item
-                        iv_language = iv_language ).
-
-    ms_objkey-otype = is_item-obj_type+2(2).
-    ms_objkey-objid = ms_item-obj_name.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_pdxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_pdxx_super.clas.abap
@@ -22,9 +22,7 @@ CLASS zcl_abapgit_object_pdxx_super DEFINITION
 ENDCLASS.
 
 
-
 CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
-
 
   METHOD check_subrc_for.
     IF sy-subrc <> 0.
@@ -33,16 +31,25 @@ CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD constructor.
+  METHOD zif_abapgit_object~exists.
 
-    super->constructor( is_item     = is_item
-                        iv_language = iv_language ).
+    CALL FUNCTION 'RH_READ_OBJECT'
+      EXPORTING
+        plvar     = '01'
+        otype     = ms_objkey-otype
+        objid     = ms_objkey-objid
+        istat     = '1'
+        begda     = sy-datum
+        endda     = '99991231'
+        ointerval = 'X'
+        read_db   = 'X'
+      EXCEPTIONS
+        not_found = 1
+        OTHERS    = 2.
 
-    ms_objkey-otype = is_item-obj_type+2(2).
-    ms_objkey-objid = ms_item-obj_name.
+    rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
-
 
   METHOD zif_abapgit_object~changed_by.
 
@@ -82,27 +89,6 @@ CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_object~exists.
-
-    CALL FUNCTION 'RH_READ_OBJECT'
-      EXPORTING
-        plvar     = '01'
-        otype     = ms_objkey-otype
-        objid     = ms_objkey-objid
-        istat     = '1'
-        begda     = sy-datum
-        endda     = '99991231'
-        ointerval = 'X'
-        read_db   = 'X'
-      EXCEPTIONS
-        not_found = 1
-        OTHERS    = 2.
-
-    rv_bool = boolc( sy-subrc = 0 ).
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_object~get_comparator.
     RETURN.
   ENDMETHOD.
@@ -137,4 +123,16 @@ CLASS zcl_abapgit_object_pdxx_super IMPLEMENTATION.
   METHOD zif_abapgit_object~serialize.
     ASSERT 1 = 2. "Must be redefined
   ENDMETHOD.
+
+
+  METHOD constructor.
+
+    super->constructor( is_item     = is_item
+                        iv_language = iv_language ).
+
+    ms_objkey-otype = is_item-obj_type+2(2).
+    ms_objkey-objid = ms_item-obj_name.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_pinf.clas.abap
+++ b/src/objects/zcl_abapgit_object_pinf.clas.abap
@@ -339,14 +339,7 @@ CLASS zcl_abapgit_object_pinf IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'PINF'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_prag.clas.abap
+++ b/src/objects/zcl_abapgit_object_prag.clas.abap
@@ -29,7 +29,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_PRAG IMPLEMENTATION.
+CLASS zcl_abapgit_object_prag IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -133,17 +133,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PRAG IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -42,7 +42,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
+CLASS zcl_abapgit_object_prog IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -317,14 +317,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'PROG'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_saxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_saxx_super.clas.abap
@@ -328,13 +328,7 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfbf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfbf.clas.abap
@@ -14,7 +14,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SFBF IMPLEMENTATION.
+CLASS zcl_abapgit_object_sfbf IMPLEMENTATION.
 
 
   METHOD get.
@@ -191,14 +191,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SFBF IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'SFBF'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfbs.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfbs.clas.abap
@@ -14,7 +14,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SFBS IMPLEMENTATION.
+CLASS zcl_abapgit_object_sfbs IMPLEMENTATION.
 
 
   METHOD get.
@@ -177,14 +177,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SFBS IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'SFBS'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfpf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpf.clas.abap
@@ -33,7 +33,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SFPF IMPLEMENTATION.
+CLASS zcl_abapgit_object_sfpf IMPLEMENTATION.
 
 
   METHOD fix_oref.
@@ -297,13 +297,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SFPF IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfpi.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpi.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SFPI IMPLEMENTATION.
+CLASS zcl_abapgit_object_sfpi IMPLEMENTATION.
 
 
   METHOD interface_to_xstring.
@@ -171,13 +171,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SFPI IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfsw.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfsw.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SFSW IMPLEMENTATION.
+CLASS zcl_abapgit_object_sfsw IMPLEMENTATION.
 
 
   METHOD get.
@@ -226,14 +226,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SFSW IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'SFSW'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -129,9 +129,7 @@ CLASS zcl_abapgit_object_shlp IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    jump_se11( ).
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -2,17 +2,16 @@ CLASS zcl_abapgit_object_sicf DEFINITION
   PUBLIC
   INHERITING FROM zcl_abapgit_objects_super
   FINAL
-  CREATE PUBLIC.
+  CREATE PUBLIC .
 
   PUBLIC SECTION.
 
-    INTERFACES zif_abapgit_object.
+    INTERFACES zif_abapgit_object .
 
     ALIASES mo_files
-      FOR zif_abapgit_object~mo_files.
+      FOR zif_abapgit_object~mo_files .
 
-    TYPES:
-      ty_hash TYPE c LENGTH 25.
+    TYPES: ty_hash TYPE c LENGTH 25.
 
     CLASS-METHODS read_tadir_sicf
       IMPORTING
@@ -21,14 +20,14 @@ CLASS zcl_abapgit_object_sicf DEFINITION
       RETURNING
         VALUE(rs_tadir) TYPE zif_abapgit_definitions=>ty_tadir
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     CLASS-METHODS read_sicf_url
       IMPORTING
         !iv_obj_name   TYPE tadir-obj_name
       RETURNING
         VALUE(rv_hash) TYPE ty_hash
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -2,16 +2,17 @@ CLASS zcl_abapgit_object_sicf DEFINITION
   PUBLIC
   INHERITING FROM zcl_abapgit_objects_super
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
 
-    INTERFACES zif_abapgit_object .
+    INTERFACES zif_abapgit_object.
 
     ALIASES mo_files
-      FOR zif_abapgit_object~mo_files .
+      FOR zif_abapgit_object~mo_files.
 
-    TYPES: ty_hash TYPE c LENGTH 25.
+    TYPES:
+      ty_hash TYPE c LENGTH 25.
 
     CLASS-METHODS read_tadir_sicf
       IMPORTING
@@ -20,14 +21,14 @@ CLASS zcl_abapgit_object_sicf DEFINITION
       RETURNING
         VALUE(rs_tadir) TYPE zif_abapgit_definitions=>ty_tadir
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
     CLASS-METHODS read_sicf_url
       IMPORTING
         !iv_obj_name   TYPE tadir-obj_name
       RETURNING
         VALUE(rv_hash) TYPE ty_hash
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 

--- a/src/objects/zcl_abapgit_object_smim.clas.abap
+++ b/src/objects/zcl_abapgit_object_smim.clas.abap
@@ -290,13 +290,7 @@ CLASS zcl_abapgit_object_smim IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_smtg.clas.abap
+++ b/src/objects/zcl_abapgit_object_smtg.clas.abap
@@ -387,22 +387,7 @@ CLASS zcl_abapgit_object_smtg IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS_REMOTE'
-      STARTING NEW TASK 'GIT'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 
@@ -443,5 +428,4 @@ CLASS zcl_abapgit_object_smtg IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_sots.clas.abap
+++ b/src/objects/zcl_abapgit_object_sots.clas.abap
@@ -322,28 +322,7 @@ CLASS zcl_abapgit_object_sots IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    DATA: lv_object_name TYPE eu_lname,
-          lv_object_type TYPE seu_obj.
-
-    lv_object_name = ms_item-obj_name.
-    lv_object_type = ms_item-obj_type.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS_REMOTE'
-      DESTINATION 'NONE'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = lv_object_name
-        object_type         = lv_object_type
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sprx.clas.abap
+++ b/src/objects/zcl_abapgit_object_sprx.clas.abap
@@ -49,7 +49,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SPRX IMPLEMENTATION.
+CLASS zcl_abapgit_object_sprx IMPLEMENTATION.
 
 
   METHOD check_sprx_tadir.
@@ -326,14 +326,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SPRX IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sqsc.clas.abap
+++ b/src/objects/zcl_abapgit_object_sqsc.clas.abap
@@ -112,7 +112,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SQSC IMPLEMENTATION.
+CLASS zcl_abapgit_object_sqsc IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -277,11 +277,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SQSC IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcl_abapgit_objects_super=>jump_adt(
-        iv_obj_name = ms_item-obj_name
-        iv_obj_type = ms_item-obj_type ).
-
+    " Covered by ZCL_ABAPGIT_ADT_LINK=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_srfc.clas.abap
+++ b/src/objects/zcl_abapgit_object_srfc.clas.abap
@@ -202,22 +202,7 @@ CLASS zcl_abapgit_object_srfc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name    " Object Name
-        object_type         = ms_item-obj_type    " Object Type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_srvb.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvb.clas.abap
@@ -228,22 +228,7 @@ CLASS zcl_abapgit_object_srvb IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_srvd.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvd.clas.abap
@@ -65,7 +65,91 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SRVD IMPLEMENTATION.
+CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
+
+
+  METHOD clear_field.
+
+    FIELD-SYMBOLS: <lv_value> TYPE data.
+
+    ASSIGN COMPONENT iv_fieldname OF STRUCTURE cs_metadata
+           TO <lv_value>.
+    ASSERT sy-subrc = 0.
+
+    CLEAR: <lv_value>.
+
+  ENDMETHOD.
+
+
+  METHOD clear_fields.
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'VERSION'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'CREATED_AT'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'CREATED_BY'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'CHANGED_AT'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'CHANGED_BY'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'RESPONSIBLE'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'PACKAGE_REF'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'MASTER_SYSTEM'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'DT_UUID'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'ABAP_LANGUAGE_VERSION'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname = 'LINKS'
+      CHANGING
+        cs_metadata  = cs_metadata ).
+
+  ENDMETHOD.
 
 
   METHOD constructor.
@@ -80,6 +164,169 @@ CLASS ZCL_ABAPGIT_OBJECT_SRVD IMPLEMENTATION.
       CATCH cx_sy_create_error.
         zcx_abapgit_exception=>raise( |SRVD not supported by your NW release| ).
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD get_object_data.
+
+    DATA:
+      lr_metadata TYPE REF TO data,
+      lr_data     TYPE REF TO data.
+
+    FIELD-SYMBOLS:
+      <lv_metadata_node> TYPE any,
+      <ls_metadata>      TYPE any,
+      <lv_source>        TYPE any,
+      <lg_data>          TYPE any.
+
+    CREATE DATA lr_data TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
+    ASSIGN lr_data->* TO <lg_data>.
+    ASSERT sy-subrc = 0.
+
+    ASSIGN COMPONENT 'METADATA' OF STRUCTURE <lg_data> TO <lv_metadata_node>.
+    ASSERT sy-subrc = 0.
+
+    CREATE DATA lr_metadata  TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_METADATA_EXTENDED').
+    ASSIGN lr_metadata->* TO <ls_metadata>.
+    ASSERT sy-subrc = 0.
+
+    io_xml->read(
+      EXPORTING
+        iv_name = mc_xml_parent_name
+      CHANGING
+        cg_data = <ls_metadata> ).
+
+    <lv_metadata_node> = <ls_metadata>.
+
+    ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <lg_data> TO <lv_source>.
+    ASSERT sy-subrc = 0.
+
+    <lv_source> = mo_files->read_string( mc_source_file ).
+    IF <lv_source> IS INITIAL.
+      <lv_source> = mo_files->read_string( 'assrvd' ).
+    ENDIF.
+
+    CREATE OBJECT ro_object_data TYPE ('CL_SRVD_WB_OBJECT_DATA').
+    ro_object_data->set_data( p_data = <lg_data>  ).
+
+  ENDMETHOD.
+
+
+  METHOD get_transport_req_if_needed.
+
+    DATA: li_sap_package TYPE REF TO zif_abapgit_sap_package.
+
+    li_sap_package = zcl_abapgit_factory=>get_sap_package( iv_package ).
+
+    IF li_sap_package->are_changes_recorded_in_tr_req( ) = abap_true.
+      rv_transport_request = zcl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD get_wb_object_operator.
+
+    DATA:
+      ls_object_type TYPE wbobjtype,
+      lx_error       TYPE REF TO cx_root.
+
+    IF mo_object_operator IS BOUND.
+      ro_object_operator = mo_object_operator.
+    ENDIF.
+
+    ls_object_type-objtype_tr = 'SRVD'.
+    ls_object_type-subtype_wb = 'SRV'.
+
+    TRY.
+        CALL METHOD ('CL_WB_OBJECT_OPERATOR')=>('CREATE_INSTANCE')
+          EXPORTING
+            object_type = ls_object_type
+            object_key  = mv_service_definition_key
+          RECEIVING
+            result      = mo_object_operator.
+
+      CATCH cx_root INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
+    ENDTRY.
+
+    ro_object_operator = mo_object_operator.
+
+  ENDMETHOD.
+
+
+  METHOD is_ddic.
+    rv_ddic = abap_false.
+  ENDMETHOD.
+
+
+  METHOD is_delete_tadir.
+    rv_delete_tadir = abap_true.
+  ENDMETHOD.
+
+
+  METHOD merge_object_data.
+
+    DATA:
+      lo_object_data        TYPE REF TO object,
+      lo_object_data_old    TYPE REF TO if_wb_object_data_model,
+      lr_new                TYPE REF TO data,
+      lr_old                TYPE REF TO data,
+      lo_wb_object_operator TYPE REF TO object.
+
+    FIELD-SYMBOLS:
+      <ls_new>       TYPE any,
+      <ls_old>       TYPE any,
+      <lv_field_old> TYPE any,
+      <lv_field_new> TYPE any.
+
+    CREATE OBJECT lo_object_data TYPE ('CL_SRVD_WB_OBJECT_DATA').
+    lo_object_data = io_object_data.
+
+    CREATE DATA lr_new TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
+    ASSIGN lr_new->* TO <ls_new>.
+    ASSERT sy-subrc = 0.
+
+    CREATE DATA lr_old TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
+    ASSIGN lr_old->* TO <ls_old>.
+    ASSERT sy-subrc = 0.
+
+    CALL METHOD lo_object_data->('IF_WB_OBJECT_DATA_MODEL~GET_DATA')
+      EXPORTING
+        p_metadata_only  = abap_false
+        p_data_selection = 'AL'
+      IMPORTING
+        p_data           = <ls_new>.
+
+    lo_wb_object_operator = get_wb_object_operator( ).
+
+    CALL METHOD lo_wb_object_operator->('IF_WB_OBJECT_OPERATOR~READ')
+      EXPORTING
+        data_selection = 'AL' " if_wb_object_data_selection_co=>c_all_data
+      IMPORTING
+        eo_object_data = lo_object_data_old.
+
+    CALL METHOD lo_object_data_old->('GET_DATA')
+      EXPORTING
+        p_metadata_only  = abap_false
+        p_data_selection = 'AL' " if_wb_object_data_selection_co=>c_all_data
+      IMPORTING
+        p_data           = <ls_old>.
+
+    ASSIGN COMPONENT 'METADATA-DESCRIPTION' OF STRUCTURE <ls_old> TO <lv_field_old>.
+    ASSIGN COMPONENT 'METADATA-DESCRIPTION' OF STRUCTURE <ls_new> TO <lv_field_new>.
+    <lv_field_old> = <lv_field_new>.
+
+    ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <ls_old> TO <lv_field_old>.
+    ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <ls_new> TO <lv_field_new>.
+    <lv_field_old> = <lv_field_new>.
+
+    CREATE OBJECT ro_object_data_merged TYPE ('CL_SRVD_WB_OBJECT_DATA').
+
+    CALL METHOD ro_object_data_merged->('SET_DATA')
+      EXPORTING
+        p_data = <ls_old>.
 
   ENDMETHOD.
 
@@ -290,22 +537,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SRVD IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |RC={ sy-subrc } from RS_TOOL_ACCESS| ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 
@@ -360,253 +592,6 @@ CLASS ZCL_ABAPGIT_OBJECT_SRVD IMPLEMENTATION.
       CATCH cx_root INTO lx_error.
         zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD merge_object_data.
-
-    DATA:
-      lo_object_data        TYPE REF TO object,
-      lo_object_data_old    TYPE REF TO if_wb_object_data_model,
-      lr_new                TYPE REF TO data,
-      lr_old                TYPE REF TO data,
-      lo_wb_object_operator TYPE REF TO object.
-
-    FIELD-SYMBOLS:
-      <ls_new>       TYPE any,
-      <ls_old>       TYPE any,
-      <lv_field_old> TYPE any,
-      <lv_field_new> TYPE any.
-
-    CREATE OBJECT lo_object_data TYPE ('CL_SRVD_WB_OBJECT_DATA').
-    lo_object_data = io_object_data.
-
-    CREATE DATA lr_new TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
-    ASSIGN lr_new->* TO <ls_new>.
-    ASSERT sy-subrc = 0.
-
-    CREATE DATA lr_old TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
-    ASSIGN lr_old->* TO <ls_old>.
-    ASSERT sy-subrc = 0.
-
-    CALL METHOD lo_object_data->('IF_WB_OBJECT_DATA_MODEL~GET_DATA')
-      EXPORTING
-        p_metadata_only  = abap_false
-        p_data_selection = 'AL'
-      IMPORTING
-        p_data           = <ls_new>.
-
-    lo_wb_object_operator = get_wb_object_operator( ).
-
-    CALL METHOD lo_wb_object_operator->('IF_WB_OBJECT_OPERATOR~READ')
-      EXPORTING
-        data_selection = 'AL' " if_wb_object_data_selection_co=>c_all_data
-      IMPORTING
-        eo_object_data = lo_object_data_old.
-
-    CALL METHOD lo_object_data_old->('GET_DATA')
-      EXPORTING
-        p_metadata_only  = abap_false
-        p_data_selection = 'AL' " if_wb_object_data_selection_co=>c_all_data
-      IMPORTING
-        p_data           = <ls_old>.
-
-    ASSIGN COMPONENT 'METADATA-DESCRIPTION' OF STRUCTURE <ls_old> TO <lv_field_old>.
-    ASSIGN COMPONENT 'METADATA-DESCRIPTION' OF STRUCTURE <ls_new> TO <lv_field_new>.
-    <lv_field_old> = <lv_field_new>.
-
-    ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <ls_old> TO <lv_field_old>.
-    ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <ls_new> TO <lv_field_new>.
-    <lv_field_old> = <lv_field_new>.
-
-    CREATE OBJECT ro_object_data_merged TYPE ('CL_SRVD_WB_OBJECT_DATA').
-
-    CALL METHOD ro_object_data_merged->('SET_DATA')
-      EXPORTING
-        p_data = <ls_old>.
-
-  ENDMETHOD.
-
-
-  METHOD is_delete_tadir.
-    rv_delete_tadir = abap_true.
-  ENDMETHOD.
-
-
-  METHOD is_ddic.
-    rv_ddic = abap_false.
-  ENDMETHOD.
-
-
-  METHOD get_wb_object_operator.
-
-    DATA:
-      ls_object_type TYPE wbobjtype,
-      lx_error       TYPE REF TO cx_root.
-
-    IF mo_object_operator IS BOUND.
-      ro_object_operator = mo_object_operator.
-    ENDIF.
-
-    ls_object_type-objtype_tr = 'SRVD'.
-    ls_object_type-subtype_wb = 'SRV'.
-
-    TRY.
-        CALL METHOD ('CL_WB_OBJECT_OPERATOR')=>('CREATE_INSTANCE')
-          EXPORTING
-            object_type = ls_object_type
-            object_key  = mv_service_definition_key
-          RECEIVING
-            result      = mo_object_operator.
-
-      CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise_with_text( lx_error ).
-    ENDTRY.
-
-    ro_object_operator = mo_object_operator.
-
-  ENDMETHOD.
-
-
-  METHOD get_transport_req_if_needed.
-
-    DATA: li_sap_package TYPE REF TO zif_abapgit_sap_package.
-
-    li_sap_package = zcl_abapgit_factory=>get_sap_package( iv_package ).
-
-    IF li_sap_package->are_changes_recorded_in_tr_req( ) = abap_true.
-      rv_transport_request = zcl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD get_object_data.
-
-    DATA:
-      lr_metadata TYPE REF TO data,
-      lr_data     TYPE REF TO data.
-
-    FIELD-SYMBOLS:
-      <lv_metadata_node> TYPE any,
-      <ls_metadata>      TYPE any,
-      <lv_source>        TYPE any,
-      <lg_data>          TYPE any.
-
-    CREATE DATA lr_data TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
-    ASSIGN lr_data->* TO <lg_data>.
-    ASSERT sy-subrc = 0.
-
-    ASSIGN COMPONENT 'METADATA' OF STRUCTURE <lg_data> TO <lv_metadata_node>.
-    ASSERT sy-subrc = 0.
-
-    CREATE DATA lr_metadata  TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_METADATA_EXTENDED').
-    ASSIGN lr_metadata->* TO <ls_metadata>.
-    ASSERT sy-subrc = 0.
-
-    io_xml->read(
-      EXPORTING
-        iv_name = mc_xml_parent_name
-      CHANGING
-        cg_data = <ls_metadata> ).
-
-    <lv_metadata_node> = <ls_metadata>.
-
-    ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <lg_data> TO <lv_source>.
-    ASSERT sy-subrc = 0.
-
-    <lv_source> = mo_files->read_string( mc_source_file ).
-    IF <lv_source> IS INITIAL.
-      <lv_source> = mo_files->read_string( 'assrvd' ).
-    ENDIF.
-
-    CREATE OBJECT ro_object_data TYPE ('CL_SRVD_WB_OBJECT_DATA').
-    ro_object_data->set_data( p_data = <lg_data>  ).
-
-  ENDMETHOD.
-
-
-  METHOD clear_fields.
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'VERSION'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'CREATED_AT'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'CREATED_BY'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'CHANGED_AT'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'CHANGED_BY'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'RESPONSIBLE'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'PACKAGE_REF'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'MASTER_SYSTEM'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'DT_UUID'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'ABAP_LANGUAGE_VERSION'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname = 'LINKS'
-      CHANGING
-        cs_metadata  = cs_metadata ).
-
-  ENDMETHOD.
-
-
-  METHOD clear_field.
-
-    FIELD-SYMBOLS: <lv_value> TYPE data.
-
-    ASSIGN COMPONENT iv_fieldname OF STRUCTURE cs_metadata
-           TO <lv_value>.
-    ASSERT sy-subrc = 0.
-
-    CLEAR: <lv_value>.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_sxci.clas.abap
+++ b/src/objects/zcl_abapgit_object_sxci.clas.abap
@@ -187,22 +187,7 @@ CLASS zcl_abapgit_object_sxci IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -929,9 +929,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    jump_se11( ).
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -146,9 +146,7 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    jump_se11( ).
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_type.clas.abap
+++ b/src/objects/zcl_abapgit_object_type.clas.abap
@@ -23,7 +23,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TYPE IMPLEMENTATION.
+CLASS zcl_abapgit_object_type IMPLEMENTATION.
 
 
   METHOD create.
@@ -187,7 +187,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TYPE IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    jump_se11( ).
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ucsa.clas.abap
+++ b/src/objects/zcl_abapgit_object_ucsa.clas.abap
@@ -228,22 +228,7 @@ CLASS zcl_abapgit_object_ucsa IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -229,35 +229,7 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    DATA: ls_dd25v TYPE dd25v.
-
-    read_view( IMPORTING es_dd25v = ls_dd25v ).
-
-    CASE ls_dd25v-viewclass.
-      WHEN co_viewclass-view_variant.
-
-        CALL FUNCTION 'RS_TOOL_ACCESS'
-          EXPORTING
-            operation           = 'SHOW'
-            object_name         = ms_item-obj_name
-            object_type         = ms_item-obj_type
-            in_new_window       = abap_true
-          EXCEPTIONS
-            not_executed        = 1
-            invalid_object_type = 2
-            OTHERS              = 3.
-
-        IF sy-subrc <> 0.
-          zcx_abapgit_exception=>raise_t100( ).
-        ENDIF.
-
-      WHEN OTHERS.
-
-        jump_se11( ).
-
-    ENDCASE.
-
+    " Covered by ZCL_ABAPGIT_OBJECT=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_wapa.clas.abap
+++ b/src/objects/zcl_abapgit_object_wapa.clas.abap
@@ -53,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WAPA IMPLEMENTATION.
+CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
 
   METHOD create_new_application.
@@ -574,14 +574,7 @@ CLASS ZCL_ABAPGIT_OBJECT_WAPA IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_wdca.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdca.clas.abap
@@ -39,7 +39,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WDCA IMPLEMENTATION.
+CLASS zcl_abapgit_object_wdca IMPLEMENTATION.
 
 
   METHOD check.
@@ -366,14 +366,7 @@ CLASS ZCL_ABAPGIT_OBJECT_WDCA IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_wdcc.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdcc.clas.abap
@@ -16,7 +16,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WDCC IMPLEMENTATION.
+CLASS zcl_abapgit_object_wdcc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -314,14 +314,7 @@ CLASS ZCL_ABAPGIT_OBJECT_WDCC IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = 'WDCC'
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_wdya.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdya.clas.abap
@@ -21,7 +21,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WDYA IMPLEMENTATION.
+CLASS zcl_abapgit_object_wdya IMPLEMENTATION.
 
 
   METHOD read.
@@ -225,14 +225,7 @@ CLASS ZCL_ABAPGIT_OBJECT_WDYA IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_wdyn.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdyn.clas.abap
@@ -876,14 +876,7 @@ CLASS zcl_abapgit_object_wdyn IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_webi.clas.abap
+++ b/src/objects/zcl_abapgit_object_webi.clas.abap
@@ -61,7 +61,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
+CLASS zcl_abapgit_object_webi IMPLEMENTATION.
 
 
   METHOD handle_endpoint.
@@ -453,14 +453,7 @@ CLASS ZCL_ABAPGIT_OBJECT_WEBI IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_xinx.clas.abap
+++ b/src/objects/zcl_abapgit_object_xinx.clas.abap
@@ -60,6 +60,43 @@ CLASS zcl_abapgit_object_xinx IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD xinx_delete_docu.
+
+    DATA: lv_docuid  TYPE dokhl-id,
+          lv_doctype TYPE dokhl-typ,
+          lv_docname TYPE dokhl-object.
+
+    lv_docname    = iv_objname.
+    lv_docname+30 = iv_id.
+    CALL FUNCTION 'INTERN_DD_DOCU_ID_MATCH'
+      EXPORTING
+        p_trobjtype  = c_objtype_extension_index
+      IMPORTING
+        p_docu_id    = lv_docuid
+        p_doctype    = lv_doctype
+      EXCEPTIONS
+        illegal_type = 1
+        OTHERS       = 2.
+
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    CALL FUNCTION 'DOKU_DELETE_ALL'
+      EXPORTING
+        doku_id            = lv_docuid
+        doku_object        = lv_docname
+        doku_typ           = lv_doctype
+        suppress_authority = 'X'
+        suppress_enqueue   = 'X'
+        suppress_transport = 'X'
+      EXCEPTIONS
+        no_docu_found      = 1
+        OTHERS             = 2.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_object~changed_by.
     rv_user = c_user_unknown. " todo
   ENDMETHOD.
@@ -294,22 +331,7 @@ CLASS zcl_abapgit_object_xinx IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from RS_TOOL_ACCESS { sy-subrc }| ).
-    ENDIF.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 
@@ -342,41 +364,4 @@ CLASS zcl_abapgit_object_xinx IMPLEMENTATION.
                  ig_data = ls_extension_index ).
 
   ENDMETHOD.
-
-  METHOD xinx_delete_docu.
-
-    DATA: lv_docuid  TYPE dokhl-id,
-          lv_doctype TYPE dokhl-typ,
-          lv_docname TYPE dokhl-object.
-
-    lv_docname    = iv_objname.
-    lv_docname+30 = iv_id.
-    CALL FUNCTION 'INTERN_DD_DOCU_ID_MATCH'
-      EXPORTING
-        p_trobjtype  = c_objtype_extension_index
-      IMPORTING
-        p_docu_id    = lv_docuid
-        p_doctype    = lv_doctype
-      EXCEPTIONS
-        illegal_type = 1
-        OTHERS       = 2.
-
-    IF sy-subrc <> 0.
-      RETURN.
-    ENDIF.
-
-    CALL FUNCTION 'DOKU_DELETE_ALL'
-      EXPORTING
-        doku_id            = lv_docuid
-        doku_object        = lv_docname
-        doku_typ           = lv_doctype
-        suppress_authority = 'X'
-        suppress_enqueue   = 'X'
-        suppress_transport = 'X'
-      EXCEPTIONS
-        no_docu_found      = 1
-        OTHERS             = 2.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_xinx.clas.abap
+++ b/src/objects/zcl_abapgit_object_xinx.clas.abap
@@ -60,43 +60,6 @@ CLASS zcl_abapgit_object_xinx IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD xinx_delete_docu.
-
-    DATA: lv_docuid  TYPE dokhl-id,
-          lv_doctype TYPE dokhl-typ,
-          lv_docname TYPE dokhl-object.
-
-    lv_docname    = iv_objname.
-    lv_docname+30 = iv_id.
-    CALL FUNCTION 'INTERN_DD_DOCU_ID_MATCH'
-      EXPORTING
-        p_trobjtype  = c_objtype_extension_index
-      IMPORTING
-        p_docu_id    = lv_docuid
-        p_doctype    = lv_doctype
-      EXCEPTIONS
-        illegal_type = 1
-        OTHERS       = 2.
-
-    IF sy-subrc <> 0.
-      RETURN.
-    ENDIF.
-
-    CALL FUNCTION 'DOKU_DELETE_ALL'
-      EXPORTING
-        doku_id            = lv_docuid
-        doku_object        = lv_docname
-        doku_typ           = lv_doctype
-        suppress_authority = 'X'
-        suppress_enqueue   = 'X'
-        suppress_transport = 'X'
-      EXCEPTIONS
-        no_docu_found      = 1
-        OTHERS             = 2.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_object~changed_by.
     rv_user = c_user_unknown. " todo
   ENDMETHOD.
@@ -364,4 +327,41 @@ CLASS zcl_abapgit_object_xinx IMPLEMENTATION.
                  ig_data = ls_extension_index ).
 
   ENDMETHOD.
+
+  METHOD xinx_delete_docu.
+
+    DATA: lv_docuid  TYPE dokhl-id,
+          lv_doctype TYPE dokhl-typ,
+          lv_docname TYPE dokhl-object.
+
+    lv_docname    = iv_objname.
+    lv_docname+30 = iv_id.
+    CALL FUNCTION 'INTERN_DD_DOCU_ID_MATCH'
+      EXPORTING
+        p_trobjtype  = c_objtype_extension_index
+      IMPORTING
+        p_docu_id    = lv_docuid
+        p_doctype    = lv_doctype
+      EXCEPTIONS
+        illegal_type = 1
+        OTHERS       = 2.
+
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    CALL FUNCTION 'DOKU_DELETE_ALL'
+      EXPORTING
+        doku_id            = lv_docuid
+        doku_object        = lv_docname
+        doku_typ           = lv_doctype
+        suppress_authority = 'X'
+        suppress_enqueue   = 'X'
+        suppress_transport = 'X'
+      EXCEPTIONS
+        no_docu_found      = 1
+        OTHERS             = 2.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_xslt.clas.abap
+++ b/src/objects/zcl_abapgit_object_xslt.clas.abap
@@ -202,13 +202,7 @@ CLASS zcl_abapgit_object_xslt IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation   = 'SHOW'
-        object_name = ms_item-obj_name
-        object_type = ms_item-obj_type.
-
+    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -11,14 +11,6 @@ CLASS zcl_abapgit_objects_super DEFINITION
       IMPORTING
         !is_item     TYPE zif_abapgit_definitions=>ty_item
         !iv_language TYPE spras .
-    CLASS-METHODS jump_adt
-      IMPORTING
-        !iv_obj_name     TYPE zif_abapgit_definitions=>ty_item-obj_name
-        !iv_obj_type     TYPE zif_abapgit_definitions=>ty_item-obj_type
-        !iv_sub_obj_name TYPE zif_abapgit_definitions=>ty_item-obj_name OPTIONAL
-        !iv_line_number  TYPE i OPTIONAL
-      RAISING
-        zcx_abapgit_exception .
   PROTECTED SECTION.
 
     DATA ms_item TYPE zif_abapgit_definitions=>ty_item .
@@ -36,9 +28,6 @@ CLASS zcl_abapgit_objects_super DEFINITION
     METHODS tadir_insert
       IMPORTING
         !iv_package TYPE devclass
-      RAISING
-        zcx_abapgit_exception .
-    METHODS jump_se11
       RAISING
         zcx_abapgit_exception .
     METHODS exists_a_lock_entry_for
@@ -289,38 +278,6 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     ENDIF.
 
     rv_active = boolc( ms_item-inactive = abap_false ).
-  ENDMETHOD.
-
-
-  METHOD jump_adt.
-
-    zcl_abapgit_adt_link=>jump(
-      iv_obj_name     = iv_obj_name
-      iv_obj_type     = iv_obj_type
-      iv_sub_obj_name = iv_sub_obj_name
-      iv_line_number  = iv_line_number ).
-
-  ENDMETHOD.
-
-
-  METHOD jump_se11.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation           = 'SHOW'
-        object_name         = ms_item-obj_name
-        object_type         = ms_item-obj_type
-        devclass            = ms_item-devclass
-        in_new_window       = abap_true
-      EXCEPTIONS
-        not_executed        = 1
-        invalid_object_type = 2
-        OTHERS              = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Jump to SE11 failed (subrc={ sy-subrc } ).| ).
-    ENDIF.
-
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -137,10 +137,10 @@ CLASS zcl_abapgit_gui_page_codi_base IMPLEMENTATION.
 
           lv_line_number = <ls_result>-line.
 
-          zcl_abapgit_objects_super=>jump_adt( iv_obj_name     = ls_item-obj_name
-                                               iv_obj_type     = ls_item-obj_type
-                                               iv_sub_obj_name = ls_sub_item-obj_name
-                                               iv_line_number  = lv_line_number ).
+          zcl_abapgit_objects=>jump(
+            is_item         = ls_item
+            iv_sub_obj_name = ls_sub_item-obj_name
+            iv_line_number  = lv_line_number ).
           RETURN.
 
         ENDIF.


### PR DESCRIPTION
Continue #5114

- Removes jump_adt and jump_se11 from zcl_abapgit_objects_super
- Remove almost all object-specific jump handlers (zif_abapgit_object~jump) since they are covered by GUI Jumper now