### PR TITLE
Repo View: Remove file path in folder view

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1039,7 +1039,11 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     ENDIF.
 
     LOOP AT is_item-files INTO ls_file.
-      ri_html->add( |<div>{ ls_file-path && ls_file-filename }</div>| ).
+      IF mv_show_folders = abap_true.
+        ri_html->add( |<div>{ ls_file-filename }</div>| ).
+      ELSE.
+        ri_html->add( |<div>{ ls_file-path && ls_file-filename }</div>| ).
+      ENDIF.
     ENDLOOP.
 
   ENDMETHOD.


### PR DESCRIPTION
No need to show the path for files when in folder view.

Before:

![image](https://user-images.githubusercontent.com/59966492/142953809-eea1a7b1-ae98-41fe-8acb-30fab199e73d.png)

After:

![image](https://user-images.githubusercontent.com/59966492/142953823-d01eac9b-d85c-4488-bd41-fb494b4e4aea.png)
