### PR TITLE
Repo view: Shorten path

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1178,11 +1178,11 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     rv_path = iv_path.
 
-    " If starting folder is at least two levels deep, replace it with /.../
+    " If starting folder is at least two levels deep, replace it with ~
     FIND ALL OCCURRENCES OF '/' IN mv_starting_folder MATCH COUNT lv_folders.
     IF lv_folders > 2.
       REPLACE mv_starting_folder IN rv_path WITH
-        |<span title="{ mv_starting_folder }">/.../</span>|.
+        |<span title="{ mv_starting_folder }">~/</span>|.
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
If files are shown and the starting folder is at least two levels deep (for example `/exercises/practice/`), then the display of the path will be shortened by replacing the starting folder with `/.../`. If you hover over the `/.../`, it will show the original path.

Before:

![image](https://user-images.githubusercontent.com/59966492/143888927-f87f73ec-ddc1-4b96-b357-68ae103093e5.png)

After:

![image](https://user-images.githubusercontent.com/59966492/143888913-a5d0fc81-633d-4fa5-826e-f755cd9b72b5.png)
