### PR TITLE
Fix vimium links

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1349,6 +1349,11 @@ LinkHints.prototype.deployHintContainers = function() {
   //   <span class="pending">12</span><span>3</span>
   // </span>
   for (var i = 0, N = hintTargets.length; i < N; i++) {
+    // skip hidden fields
+    if (hintTargets[i].type === "HIDDEN") {
+      continue;
+    }
+
     var hint = {};
     hint.container     = document.createElement("span");
     hint.pendingSpan   = document.createElement("span");
@@ -1371,8 +1376,18 @@ LinkHints.prototype.deployHintContainers = function() {
     hint.container.dataset.code = codeCounter.toString(); // not really needed, more for debug
 
     if (hintTargets[i].nodeName === "INPUT" || hintTargets[i].nodeName === "TEXTAREA") {
-      // does not work if inside the input, so appending right after
-      hintTargets[i].insertAdjacentElement("afterend", hint.container);
+      // does not work if inside the input node
+      if (hintTargets[i].type === "checkbox" || hintTargets[i].type === "radio") {
+        if (hintTargets[i].nextElementSibling.nodeName === "LABEL" ) { 
+          // insert at end of label 
+          hintTargets[i].nextElementSibling.appendChild(hint.container);
+        } else {
+          // skip because something changed in ZCL_ABAPGIT_HTML_FORM
+        }
+      } else {
+        // inserting right after
+        hintTargets[i].insertAdjacentElement("afterend", hint.container);
+      }
     } else {
       hintTargets[i].appendChild(hint.container);
     }
@@ -1454,7 +1469,7 @@ LinkHints.prototype.hintActivate = function (hint) {
     this.activatedDropdown = hint.parent.parentElement;
     this.activatedDropdown.classList.toggle("force-nav-hover");
     hint.parent.focus();
-  } else if (hint.parent.type === "checkbox") {
+  } else if (hint.parent.type === "checkbox" || hint.parent.type === "radio") {
     this.toggleCheckbox(hint);
   } else if (hint.parent.type === "submit") {
     hint.parent.click();

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1378,8 +1378,8 @@ LinkHints.prototype.deployHintContainers = function() {
     if (hintTargets[i].nodeName === "INPUT" || hintTargets[i].nodeName === "TEXTAREA") {
       // does not work if inside the input node
       if (hintTargets[i].type === "checkbox" || hintTargets[i].type === "radio") {
-        if (hintTargets[i].nextElementSibling.nodeName === "LABEL" ) { 
-          // insert at end of label 
+        if (hintTargets[i].nextElementSibling.nodeName === "LABEL" ) {
+          // insert at end of label
           hintTargets[i].nextElementSibling.appendChild(hint.container);
         } else {
           // skip because something changed in ZCL_ABAPGIT_HTML_FORM


### PR DESCRIPTION
- No Vimium links for hidden fields
- Fix Vimium link for radio selections 
- Move link box to end of labels (fixes the unwanted line-breaks between input control and label)

Closes #5038 (for @christianguenter2 😉)
 
Example:

![image](https://user-images.githubusercontent.com/59966492/144265192-cc1af35a-85d3-4102-a5ec-956ec55d153d.png)

