### PR TITLE
Patch: Fix link hints

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1378,11 +1378,12 @@ LinkHints.prototype.deployHintContainers = function() {
     if (hintTargets[i].nodeName === "INPUT" || hintTargets[i].nodeName === "TEXTAREA") {
       // does not work if inside the input node
       if (hintTargets[i].type === "checkbox" || hintTargets[i].type === "radio") {
-        if (hintTargets[i].nextElementSibling.nodeName === "LABEL" ) {
+        if (hintTargets[i].nextElementSibling && hintTargets[i].nextElementSibling.nodeName === "LABEL" ) {
           // insert at end of label
           hintTargets[i].nextElementSibling.appendChild(hint.container);
         } else {
-          // skip because something changed in ZCL_ABAPGIT_HTML_FORM
+          // inserting right after
+          hintTargets[i].insertAdjacentElement("afterend", hint.container);
         }
       } else {
         // inserting right after


### PR DESCRIPTION
Regression from #5175 - link hints don't work anymore on Patch page

before
![grafik](https://user-images.githubusercontent.com/17437789/144600702-b5cb6102-ded9-4c32-83dd-c1f43ce694da.png)

![grafik](https://user-images.githubusercontent.com/17437789/144600376-19c3c6f5-d2db-45cb-9767-4b1f10bc5283.png)

![grafik](https://user-images.githubusercontent.com/17437789/144600638-43d5b872-c169-4910-b77f-910933da2cff.png)


after
![grafik](https://user-images.githubusercontent.com/17437789/144600613-b709fbb6-02a9-48af-94f1-8cc06736ef97.png)
