### PR TITLE
Repo view: Set minimum width of status column

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -316,7 +316,7 @@ table.repo_tab {
   text-align: right;
   padding-left: 0.5em;
   padding-right: 0.7em;
-  min-width: 100px;
+  min-width: 70px;
 }
 .repo_tab th.cmd .icon{
   padding-right: 8px;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -316,6 +316,7 @@ table.repo_tab {
   text-align: right;
   padding-left: 0.5em;
   padding-right: 0.7em;
+  min-width: 100px;
 }
 .repo_tab th.cmd .icon{
   padding-right: 8px;


### PR DESCRIPTION
As seen in https://github.com/abapGit/abapGit/issues/5178, if the repo view table is very wide, the status column might not wide enough and be wrapped. 

Change ensures a minimum width of the column.