### PR TITLE
Add user exit for adjusting display of filenames

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1031,6 +1031,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
   METHOD render_item_files.
 
     DATA: ls_file LIKE LINE OF is_item-files.
+    DATA li_exit TYPE REF TO zif_abapgit_exit.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
@@ -1038,11 +1039,13 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
       RETURN.
     ENDIF.
 
+    li_exit = zcl_abapgit_exit=>get_instance( ).
+
     LOOP AT is_item-files INTO ls_file.
       IF mv_show_folders = abap_true.
-        ri_html->add( |<div>{ ls_file-filename }</div>| ).
+        ri_html->add( |<div>{ li_exit->adjust_display_filename( ls_file-filename ) }</div>| ).
       ELSE.
-        ri_html->add( |<div>{ ls_file-path && ls_file-filename }</div>| ).
+        ri_html->add( |<div>{ li_exit->adjust_display_filename( ls_file-path && ls_file-filename ) }</div>| ).
       ENDIF.
     ENDLOOP.
 

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
+CLASS zcl_abapgit_exit IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -46,6 +46,21 @@ CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
               iv_commit_hash        = iv_commit_hash
             CHANGING
               cv_display_url        = cv_display_url ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~adjust_display_filename.
+
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          rv_filename = gi_exit->adjust_display_filename( iv_filename ).
+          IF rv_filename IS INITIAL.
+            rv_filename = iv_filename.
+          ENDIF.
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -100,4 +100,9 @@ INTERFACE zif_abapgit_exit
       VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
     RAISING
       zcx_abapgit_exception .
+  METHODS adjust_display_filename
+    IMPORTING
+      !iv_filename       TYPE string
+    RETURNING
+      VALUE(rv_filename) TYPE string.
 ENDINTERFACE.


### PR DESCRIPTION
The filenames can become very long, for example, usage of many sub-packages, namespaces, objects like function groups, or BSP/Fiori apps with many sub-objects, or a long path as starting folder. This can make the repository view very busy or render the output as a very wide table (see #5169, #5178).

This exit allows adjusting the filename according to your own rules. 

Closes #5178

Here's an example for suppressing the starting folder and shortening the display of files for sub-objects:

```abap
  METHOD zif_abapgit_exit~adjust_display_filename.

    DATA:
      lv_path TYPE string,
      lv_name TYPE string,
      lv_ext1 TYPE string,
      lv_ext2 TYPE string.

    SPLIT iv_filename AT '.' INTO lv_path lv_name lv_ext1 lv_ext2.

    IF lv_ext2 IS INITIAL.
      " Main object
      rv_filename = iv_filename.
    ELSE.
      " Sub object
      rv_filename = |<span title="{ lv_path }.{ lv_name }">…</span>{ lv_ext1 }.{ lv_ext2 }|.
    ENDIF.

   " Suppress default starting folder
   REPLACE '/src/' IN rv_filename WITH ''.

  ENDMETHOD.
```

Before:

![image](https://user-images.githubusercontent.com/59966492/144936682-04bbb159-5146-4dd5-8894-5d21ba188aab.png)

After (with exit):

![image](https://user-images.githubusercontent.com/59966492/144937287-53ab90da-d99f-4dde-872d-79c3aae2f8e5.png)
