### PR TITLE
Fix dump when checking objects

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -799,6 +799,11 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     DATA: li_obj TYPE REF TO zif_abapgit_object.
 
+    " Might be called for objects without tadir entry
+    IF is_item IS INITIAL.
+      RETURN.
+    ENDIF.
+
     " For unsupported objects, assume object exists
     IF is_type_supported( is_item-obj_type ) = abap_false.
       rv_bool = abap_true.


### PR DESCRIPTION
Dump ASSERTION_FAILED

![image](https://user-images.githubusercontent.com/59966492/145316842-7a612ed9-831b-4917-a04f-66f2a33a977a.png)

"Exists check" might be called for objects without `TADIR` entry (like `NSPC`). 

Regression #4952 which removed the "if" here:
https://github.com/abapGit/abapGit/commit/a72d3314cb839fdc0beaf1609714029a7a478327#diff-4a3135e0f538157951fefdea06986dc644f6005a2af7f6917ff7f7f2f771f622L299