### PR TITLE
objects: use provided Transport in deserialization of ENHO+SFPF

### DIFF
--- a/src/objects/zcl_abapgit_object_enho.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho.clas.abap
@@ -108,19 +108,26 @@ CLASS zcl_abapgit_object_enho IMPLEMENTATION.
 
     DATA: lv_enh_id     TYPE enhname,
           li_enh_object TYPE REF TO if_enh_object,
-          lx_enh_root   TYPE REF TO cx_enh_root.
+          lx_enh_root   TYPE REF TO cx_enh_root,
+          lv_corrnum    TYPE e070use-ordernum.
 
     IF zif_abapgit_object~exists( ) = abap_false.
       RETURN.
     ENDIF.
+
+    lv_corrnum = zcl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
 
     lv_enh_id = ms_item-obj_name.
     TRY.
         li_enh_object = cl_enh_factory=>get_enhancement(
           enhancement_id = lv_enh_id
           lock           = abap_true ).
-        li_enh_object->delete( nevertheless_delete = abap_true
-                               run_dark            = abap_true ).
+        li_enh_object->delete(
+          EXPORTING
+            nevertheless_delete = abap_true
+            run_dark            = abap_true
+          CHANGING
+            trkorr = lv_corrnum ).
         li_enh_object->unlock( ).
       CATCH cx_enh_root INTO lx_enh_root.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).

--- a/src/objects/zcl_abapgit_object_sfpf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpf.clas.abap
@@ -194,15 +194,19 @@ CLASS zcl_abapgit_object_sfpf IMPLEMENTATION.
   METHOD zif_abapgit_object~delete.
 
     DATA: lv_name    TYPE fpname,
-          lo_wb_form TYPE REF TO cl_fp_wb_form.
+          lo_wb_form TYPE REF TO cl_fp_wb_form,
+          lv_corrnum TYPE e070use-ordernum.
 
 
     lo_wb_form ?= load( ).
 
     lv_name = ms_item-obj_name.
+    lv_corrnum = zcl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
 
     TRY.
-        lo_wb_form->delete( lv_name ).
+        lo_wb_form->delete( i_name = lv_name
+                            i_ordernum = lv_corrnum
+                            i_dark = 'X' ).
       CATCH cx_fp_api.
         zcx_abapgit_exception=>raise( 'SFPI error, delete' ).
     ENDTRY.
@@ -217,11 +221,14 @@ CLASS zcl_abapgit_object_sfpf IMPLEMENTATION.
           lv_name      TYPE fpname,
           li_wb_object TYPE REF TO if_fp_wb_form,
           li_form      TYPE REF TO if_fp_form,
-          lx_fp_err    TYPE REF TO cx_fp_api.
+          lx_fp_err    TYPE REF TO cx_fp_api,
+          lv_corrnum   TYPE e070use-ordernum.
 
 
     lv_name = ms_item-obj_name.
     lv_xstr = cl_ixml_80_20=>render_to_xstring( io_xml->get_raw( ) ).
+
+    lv_corrnum = zcl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
 
     TRY.
         li_form = cl_fp_helper=>convert_xstring_to_form( lv_xstr ).
@@ -232,12 +239,16 @@ CLASS zcl_abapgit_object_sfpf IMPLEMENTATION.
         ENDIF.
 
         IF zif_abapgit_object~exists( ) = abap_true.
-          cl_fp_wb_form=>delete( lv_name ).
+          cl_fp_wb_form=>delete( i_name = lv_name
+                                 i_ordernum = lv_corrnum
+                                 i_dark = 'X' ).
         ENDIF.
 
         tadir_insert( iv_package ).
         li_wb_object = cl_fp_wb_form=>create( i_name = lv_name
-                                              i_form = li_form ).
+                                              i_form = li_form
+                                              i_ordernum = lv_corrnum
+                                              i_dark = 'X' ).
         li_wb_object->save( ).
         li_wb_object->free( ).
       CATCH cx_fp_api INTO lx_fp_err.


### PR DESCRIPTION
I have been working on RFC enabled functions modules for executing
abapGit operations and I found out that transported objects of type ENHO
and SFPF cannot be pulled over my RFC methods because the specified
transport was not used.

This commit simply takes over the approach from other objects where
we already read the transport number.

For SFPF, I had to add "darkmode" which was missing and which is
necessary to avoid any dialogues.

I am not sure if there are other objects with the same problem, so
I might be posting similar patches in future.