### PR TITLE
Always use active version for DOCU CL

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_base.clas.abap
@@ -14,8 +14,9 @@ CLASS zcl_abapgit_oo_base DEFINITION
         RETURNING VALUE(rt_vseoattrib) TYPE seoo_attributes_r.
 
   PRIVATE SECTION.
-
+    CONSTANTS c_docu_state_active TYPE dokstate VALUE 'A'. " See include SDOC_CONSTANTS
     DATA mv_skip_test_classes TYPE abap_bool .
+
 ENDCLASS.
 
 
@@ -54,6 +55,7 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
         langu         = iv_language
         object        = iv_object_name
         no_masterlang = iv_no_masterlang
+        state         = c_docu_state_active
       TABLES
         line          = it_lines
       EXCEPTIONS
@@ -153,20 +155,21 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
     CALL FUNCTION 'DOCU_GET'
       EXPORTING
-        id                = 'CL'
-        langu             = iv_language
-        object            = lv_object
+        id                     = 'CL'
+        langu                  = iv_language
+        object                 = lv_object
+        version_active_or_last = space " retrieve active version
       IMPORTING
-        dokstate          = lv_state
+        dokstate               = lv_state
       TABLES
-        line              = lt_lines
+        line                   = lt_lines
       EXCEPTIONS
-        no_docu_on_screen = 1
-        no_docu_self_def  = 2
-        no_docu_temp      = 3
-        ret_code          = 4
-        OTHERS            = 5.
-    IF sy-subrc = 0 AND lv_state = 'R'.
+        no_docu_on_screen      = 1
+        no_docu_self_def       = 2
+        no_docu_temp           = 3
+        ret_code               = 4
+        OTHERS                 = 5.
+    IF sy-subrc = 0 AND lv_state = c_docu_state_active.
       rt_lines = lt_lines.
     ELSE.
       CLEAR rt_lines.

--- a/src/objects/oo/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_base.clas.abap
@@ -66,6 +66,21 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
     ENDIF.
   ENDMETHOD.
 
+  METHOD zif_abapgit_oo_object_fnc~delete_documentation.
+    CALL FUNCTION 'DOCU_DEL'
+      EXPORTING
+        id       = 'CL'
+        langu    = iv_language
+        object   = iv_object_name
+        typ      = 'E'
+      EXCEPTIONS
+        ret_code = 1
+        OTHERS   = 2.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( 'Error from DOCU_DEL' ).
+    ENDIF.
+  ENDMETHOD.
+
 
   METHOD zif_abapgit_oo_object_fnc~create_sotr.
     ASSERT 0 = 1. "Subclass responsibility

--- a/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
@@ -74,6 +74,12 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
         iv_no_masterlang TYPE abap_bool OPTIONAL
       RAISING
         zcx_abapgit_exception,
+    delete_documentation
+      IMPORTING
+        iv_object_name TYPE dokhl-object
+        iv_language    TYPE spras
+      RAISING
+        zcx_abapgit_exception,
     get_includes
       IMPORTING
         iv_object_name     TYPE sobj_name

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -188,11 +188,14 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'LINES'
                   CHANGING cg_data = lt_lines ).
 
+    lv_object = ms_item-obj_name.
+
     IF lines( lt_lines ) = 0.
+      mi_object_oriented_object_fct->delete_documentation(
+        iv_object_name = lv_object
+        iv_language    = mv_language ).
       RETURN.
     ENDIF.
-
-    lv_object = ms_item-obj_name.
 
     mi_object_oriented_object_fct->create_documentation(
       it_lines       = lt_lines

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -87,11 +87,14 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'LINES'
                   CHANGING cg_data = lt_lines ).
 
+    lv_object = ms_item-obj_name.
+
     IF lines( lt_lines ) = 0.
+      mi_object_oriented_object_fct->delete_documentation(
+        iv_object_name = lv_object
+        iv_language    = mv_language ).
       RETURN.
     ENDIF.
-
-    lv_object = ms_item-obj_name.
 
     mi_object_oriented_object_fct->create_documentation(
       it_lines       = lt_lines


### PR DESCRIPTION
Currently the latest version is used to read class documentation and raw (saved but inactive) is used for saving. This change makes read and write access always use the active version.

SDOC_CONSTANTS:
![image](https://user-images.githubusercontent.com/5270359/145725702-0adb3f2d-4498-4737-b0bb-728765f01f06.png)

Might fix #5196, pending feedback

I couldn't find a test case for this in abapGit-tests. I'll create one.