### PR TITLE
Requirements dependency check

### DIFF
--- a/src/utils/zcl_abapgit_requirement_helper.clas.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.abap
@@ -106,7 +106,6 @@ CLASS zcl_abapgit_requirement_helper IMPLEMENTATION.
 
     DATA: lt_met_status TYPE ty_requirement_status_tt.
 
-
     lt_met_status = get_requirement_met_status( it_requirements ).
 
     READ TABLE lt_met_status TRANSPORTING NO FIELDS WITH KEY met = abap_false.
@@ -216,13 +215,17 @@ CLASS zcl_abapgit_requirement_helper IMPLEMENTATION.
 
   METHOD version_greater_or_equal.
 
-    DATA: lv_number TYPE n LENGTH 4 ##NEEDED.
+    DATA:
+      lv_installed_release TYPE n LENGTH 4,
+      lv_installed_patch   TYPE n LENGTH 4,
+      lv_required_release  TYPE n LENGTH 4,
+      lv_required_patch    TYPE n LENGTH 4.
 
     TRY.
-        MOVE EXACT: is_status-installed_release TO lv_number,
-                    is_status-installed_patch   TO lv_number,
-                    is_status-required_release  TO lv_number,
-                    is_status-required_patch    TO lv_number.
+        MOVE EXACT: is_status-installed_release TO lv_installed_release,
+                    is_status-installed_patch   TO lv_installed_patch,
+                    is_status-required_release  TO lv_required_release,
+                    is_status-required_patch    TO lv_required_patch.
       CATCH cx_sy_conversion_error.
         " Cannot compare by number, assume requirement not fullfilled (user can force install
         " anyways if this was an error)
@@ -231,12 +234,13 @@ CLASS zcl_abapgit_requirement_helper IMPLEMENTATION.
     ENDTRY.
 
     " Versions are comparable by number, compare release and if necessary patch level
-    IF is_status-installed_release > is_status-required_release
-        OR ( is_status-installed_release = is_status-required_release
-        AND ( is_status-required_patch IS INITIAL OR
-        is_status-installed_patch >= is_status-required_patch ) ).
+    IF lv_installed_release > lv_required_release
+        OR ( lv_installed_release = lv_required_release
+         AND ( lv_required_patch = 0
+            OR lv_installed_patch >= lv_required_patch ) ).
 
       rv_true = abap_true.
+
     ENDIF.
 
   ENDMETHOD.

--- a/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
@@ -1,0 +1,456 @@
+CLASS lcl_helper DEFINITION FINAL.
+
+  PUBLIC SECTION.
+    CLASS-METHODS get_sap_basis_component
+      RETURNING
+        VALUE(rs_result) TYPE cvers_sdu
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+CLASS lcl_helper IMPLEMENTATION.
+
+
+  METHOD get_sap_basis_component.
+
+    DATA:
+      lt_installed TYPE STANDARD TABLE OF cvers_sdu.
+
+    CALL FUNCTION 'DELIVERY_GET_INSTALLED_COMPS'
+      TABLES
+        tt_comptab       = lt_installed
+      EXCEPTIONS
+        no_release_found = 1
+        OTHERS           = 2.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from DELIVERY_GET_INSTALLED_COMPS { sy-subrc }| ).
+    ENDIF.
+
+    READ TABLE lt_installed INTO rs_result
+      WITH KEY component = `SAP_BASIS`.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Component SAP_BASIS not found| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+ENDCLASS.
+
+
+
+CLASS ltcl_lower_release DEFINITION FINAL
+  FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT.
+
+  PUBLIC SECTION.
+
+  PRIVATE SECTION.
+    METHODS empty_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS lower_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS same_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS higher_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+CLASS ltcl_lower_release IMPLEMENTATION.
+
+
+  METHOD empty_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release - 1.
+    ls_requirement-min_patch   = 0.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD lower_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release - 1.
+    ls_requirement-min_patch   = ls_component-extrelease - 1.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD same_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release - 1.
+    ls_requirement-min_patch   = ls_component-extrelease.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD higher_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release - 1.
+    ls_requirement-min_patch   = ls_component-extrelease + 1.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.
+
+
+
+CLASS ltcl_same_release DEFINITION FINAL
+  FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT.
+
+  PUBLIC SECTION.
+
+  PRIVATE SECTION.
+    METHODS empty_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS lower_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS same_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS higher_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+CLASS ltcl_same_release IMPLEMENTATION.
+
+
+  METHOD empty_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release.
+    ls_requirement-min_patch   = 0.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD lower_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release.
+    ls_requirement-min_patch   = ls_component-extrelease - 1.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD same_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release.
+    ls_requirement-min_patch   = ls_component-extrelease.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD higher_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release.
+    ls_requirement-min_patch   = ls_component-extrelease + 1.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_no ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.
+
+
+
+CLASS ltcl_higher_release DEFINITION FINAL
+  FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT.
+
+  PUBLIC SECTION.
+
+  PRIVATE SECTION.
+    METHODS empty_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS lower_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS same_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS higher_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+CLASS ltcl_higher_release IMPLEMENTATION.
+
+
+  METHOD empty_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release + 1.
+    ls_requirement-min_patch   = 0.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_no ).
+
+  ENDMETHOD.
+
+
+  METHOD lower_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release + 1.
+    ls_requirement-min_patch   = ls_component-extrelease - 1.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_no ).
+
+  ENDMETHOD.
+
+
+  METHOD same_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release + 1.
+    ls_requirement-min_patch   = ls_component-extrelease.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_no ).
+
+  ENDMETHOD.
+
+
+  METHOD higher_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release + 1.
+    ls_requirement-min_patch   = ls_component-extrelease + 1.
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_no ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.
+
+
+
+CLASS ltcl_formats DEFINITION FINAL
+  FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT.
+
+  PUBLIC SECTION.
+
+  PRIVATE SECTION.
+    METHODS shorter_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+CLASS ltcl_formats IMPLEMENTATION.
+
+
+  METHOD shorter_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release.
+
+    CALL FUNCTION 'CONVERSION_EXIT_ALPHA_OUTPUT'
+      EXPORTING
+        input  = ls_component-extrelease
+      IMPORTING
+        output = ls_requirement-min_patch.
+
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+      EXPORTING
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.

--- a/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
@@ -407,6 +407,10 @@ CLASS ltcl_formats DEFINITION FINAL
       RAISING
         zcx_abapgit_exception.
 
+    METHODS higher_patch FOR TESTING
+      RAISING
+        zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -426,6 +430,33 @@ CLASS ltcl_formats IMPLEMENTATION.
     ls_requirement-min_release = ls_component-release.
 
     CALL FUNCTION 'CONVERSION_EXIT_ALPHA_OUTPUT'
+      EXPORTING
+        input  = ls_component-extrelease
+      IMPORTING
+        output = ls_requirement-min_patch.
+
+    APPEND ls_requirement TO lt_requirements.
+
+    cl_abap_unit_assert=>assert_equals(
+        act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
+        exp = zif_abapgit_definitions=>c_yes ).
+
+  ENDMETHOD.
+
+
+  METHOD higher_patch.
+
+    DATA:
+      ls_component    TYPE cvers_sdu,
+      lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+      ls_requirement  LIKE LINE OF lt_requirements.
+
+    ls_component = lcl_helper=>get_sap_basis_component( ).
+
+    ls_requirement-component   = ls_component-component.
+    ls_requirement-min_release = ls_component-release.
+
+    CALL FUNCTION 'CONVERSION_EXIT_ALPHA_INPUT'
       EXPORTING
         input  = ls_component-extrelease
       IMPORTING

--- a/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
@@ -86,7 +86,6 @@ CLASS ltcl_lower_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -108,7 +107,6 @@ CLASS ltcl_lower_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -130,7 +128,6 @@ CLASS ltcl_lower_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -152,7 +149,6 @@ CLASS ltcl_lower_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -208,7 +204,6 @@ CLASS ltcl_same_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -230,7 +225,6 @@ CLASS ltcl_same_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -252,7 +246,6 @@ CLASS ltcl_same_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 
@@ -274,7 +267,6 @@ CLASS ltcl_same_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_no ).
 
@@ -330,7 +322,6 @@ CLASS ltcl_higher_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_no ).
 
@@ -352,7 +343,6 @@ CLASS ltcl_higher_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_no ).
 
@@ -374,7 +364,6 @@ CLASS ltcl_higher_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_no ).
 
@@ -396,7 +385,6 @@ CLASS ltcl_higher_release IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_no ).
 
@@ -446,7 +434,6 @@ CLASS ltcl_formats IMPLEMENTATION.
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
-      EXPORTING
         act = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements )
         exp = zif_abapgit_definitions=>c_yes ).
 

--- a/src/utils/zcl_abapgit_requirement_helper.clas.xml
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
- If the requirement patch registered has less than 4 characters (08 instead of 0008) check fails
- Added tests for requirement validation