### PR TITLE
abaplint config: no use of cl_aunit_assert

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -124,6 +124,7 @@
         "^cl_blue_wb_utility$", "^boole_d$",
         "^cl_srvd_wb_object_data$", "^cx_aff_", "^cl_aff_", "^if_aff_",
         "^cl_wb_object_operator_factory$",
+        "^cl_aunit_assert$"
         "^cx_wb_object_operation_error$",
         "^if_srvd_types$",
         "^if_wb_adt_plugin_resource_co$",

--- a/abaplint.json
+++ b/abaplint.json
@@ -124,7 +124,7 @@
         "^cl_blue_wb_utility$", "^boole_d$",
         "^cl_srvd_wb_object_data$", "^cx_aff_", "^cl_aff_", "^if_aff_",
         "^cl_wb_object_operator_factory$",
-        "^cl_aunit_assert$"
+        "^cl_aunit_assert$",
         "^cx_wb_object_operation_error$",
         "^if_srvd_types$",
         "^if_wb_adt_plugin_resource_co$",


### PR DESCRIPTION
cl_aunit_assert is obsolete since sometime before 702

ref https://github.com/abapGit/abapGit/issues/4227