### PR TITLE
W3xx: Avoid diffs of parameters

### DIFF
--- a/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
@@ -141,6 +141,9 @@ CLASS zcl_abapgit_object_w3xx_super IMPLEMENTATION.
     DELETE ct_params WHERE name = c_param_names-version.
     DELETE ct_params WHERE name = c_param_names-filesize.
 
+    " Avoid diffs due to different order
+    SORT ct_params.
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
It's possible that systems return parameters unsorted causing diffs. 

Example:

![image](https://user-images.githubusercontent.com/59966492/146687884-3068c0fe-0f11-466f-8e81-b0b2da3d4999.png)

Sorting the parameters will avoid this.