### PR TITLE
TOBJ - fix xslt serialization dump due to empty numc value

### DIFF
--- a/src/objects/zcl_abapgit_object_tobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_tobj.clas.abap
@@ -319,6 +319,12 @@ CLASS ZCL_ABAPGIT_OBJECT_TOBJ IMPLEMENTATION.
 
     ls_tobj = read_extra( ls_objh-objectname ).
 
+    IF ls_tobj-tvdir-detail = ``.
+      " to prevent xslt serialization error,
+      " force clear if numc field is empty
+      CLEAR ls_tobj-tvdir-detail.
+    ENDIF.
+
     io_xml->add( iv_name = 'TOBJ'
                  ig_data = ls_tobj ).
 


### PR DESCRIPTION
Colleague encountered an error during serialization.

![image](https://user-images.githubusercontent.com/5097067/148075938-3020705d-79f5-4075-9826-9de2c4b74d66.png)
![image](https://user-images.githubusercontent.com/5097067/148075917-a515fd6a-ff27-4f60-82e6-39e99d3b8d39.png)
![image](https://user-images.githubusercontent.com/5097067/148076000-69e4530a-c24b-4eaf-97b4-dc8bfa18664b.png)

The serialization code looks like it should work, but `initial_components = suppress` which is there does not help in this case.
```abap
      CALL TRANSFORMATION id
        OPTIONS initial_components = 'suppress'
        SOURCE (lt_stab)
        RESULT XML li_doc.
```

note that this is likely data corruption and not a real situation, i can't figure out how to even set numc to an empty value