### PR TITLE
Correct task name parallel processing

### DIFF
--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -451,14 +451,16 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
   METHOD run_parallel.
 
     DATA: lv_msg  TYPE c LENGTH 100,
+          lv_task TYPE c LENGTH 32,
           lv_free LIKE mv_free.
 
 
     ASSERT mv_free > 0.
 
     DO.
+      lv_task = |{ iv_task }-{ sy-index }|.
       CALL FUNCTION 'Z_ABAPGIT_SERIALIZE_PARALLEL'
-        STARTING NEW TASK iv_task
+        STARTING NEW TASK lv_task
         DESTINATION IN GROUP mv_group
         CALLING on_end_of_task ON END OF TASK
         EXPORTING


### PR DESCRIPTION
When serializing objects in parallel threads, it can happen that there are not sufficient system resources available (free dialog processes). In this case, abapGit can run into error "RFC task <task name> already open". This is caused by reusing the same task name in subsequent tries to serialize an object.

The correction appends a sequential number to the previous task name so each try will result in a unique task name.

Closes #5224.

PS: This does not fix any resource issues but should prevent the error. It will lead to wait situations and longer processing, however.