### PR TITLE
Avoid double deserialize of text symbols

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -188,12 +188,6 @@ CLASS zcl_abapgit_objects_program DEFINITION PUBLIC INHERITING FROM zcl_abapgit_
         !is_progdir TYPE ty_progdir
       RAISING
         zcx_abapgit_exception .
-    METHODS insert_tpool
-      IMPORTING
-        !is_progdir TYPE ty_progdir
-        !it_tpool   TYPE textpool_table
-      RAISING
-        zcx_abapgit_exception .
 ENDCLASS.
 
 
@@ -630,21 +624,6 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 
     ELSEIF sy-subrc > 0.
       zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD insert_tpool.
-
-    IF NOT it_tpool[] IS INITIAL.
-      INSERT TEXTPOOL is_progdir-name
-        FROM it_tpool
-        LANGUAGE mv_language
-        STATE 'I'.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( 'Error from INSERT TEXTPOOL' ).
-      ENDIF.
     ENDIF.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -198,7 +198,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
+CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 
 
   METHOD add_tpool.
@@ -505,10 +505,6 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
         iv_title   = lv_title
         iv_package = iv_package ).
     ENDIF.
-
-    insert_tpool(
-      is_progdir = is_progdir
-      it_tpool   = it_tpool ).
 
     update_progdir( is_progdir ).
 


### PR DESCRIPTION
Text symbols are already deserialized in `ZCL_ABAPGIT_OBJECTS_PROGRAM->DESERIALIZE_TEXTPOOL`.

https://github.com/abapGit/abapGit/blob/main/src/objects/zcl_abapgit_objects_program.clas.abap#L522