### PR TITLE
UI: Center Popups

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -235,16 +235,18 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
     APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
     <ls_column>-name = 'MESSAGE'.
     <ls_column>-text = 'Message'.
+    <ls_column>-length = 60.
     APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
     <ls_column>-name = 'DATETIME'.
     <ls_column>-text = 'Datetime'.
+    <ls_column>-length = 17.
 
     li_popups = zcl_abapgit_ui_factory=>get_popups( ).
     li_popups->popup_to_select_from_list(
       EXPORTING
         it_list               = it_value_tab
         iv_title              = |Checkout Commit|
-        iv_end_column         = 83
+        iv_end_column         = 100
         iv_striped_pattern    = abap_true
         iv_optimize_col_width = abap_false
         iv_selection_mode     = if_salv_c_selection_mode=>single
@@ -995,5 +997,4 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
     gui_services( )->get_hotkeys_ctl( )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
 
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -457,9 +457,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     ENDIF.
 
     set_starting_position(
-      EXPORTING
-        iv_width  = 24
-        iv_height = lines( lt_selection ) ).
+      iv_width  = 24
+      iv_height = lines( lt_selection ) ).
 
     CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
       EXPORTING
@@ -586,9 +585,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     ENDLOOP.
 
     set_starting_position(
-      EXPORTING
-        iv_width  = 74
-        iv_height = lines( it_pulls ) ).
+      iv_width  = 74
+      iv_height = lines( lt_selection ) ).
 
     CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
       EXPORTING
@@ -719,9 +717,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
   METHOD zif_abapgit_popups~popup_to_confirm.
 
     set_starting_position(
-      EXPORTING
-        iv_width  = 65
-        iv_height = 5 ).
+      iv_width  = 65
+      iv_height = 5 ).
 
     CALL FUNCTION 'POPUP_TO_CONFIRM'
       EXPORTING
@@ -840,9 +837,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     ASSERT sy-subrc = 0.
 
     set_starting_position(
-      EXPORTING
-        iv_width  = iv_end_column - iv_start_column
-        iv_height = iv_end_line - iv_start_line ).
+      iv_width  = iv_end_column - iv_start_column
+      iv_height = iv_end_line - iv_start_line ).
 
     TRY.
         cl_salv_table=>factory( IMPORTING r_salv_table = mo_select_list_popup
@@ -1008,9 +1004,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_field> TYPE sval.
 
     set_starting_position(
-      EXPORTING
-        iv_width  = 120
-        iv_height = lines( ct_fields ) ).
+      iv_width  = 120
+      iv_height = lines( ct_fields ) ).
 
     CALL FUNCTION 'POPUP_GET_VALUES'
       EXPORTING

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -22,6 +22,11 @@ CLASS zcl_abapgit_popups DEFINITION
     DATA mr_table TYPE REF TO data .
     DATA mv_cancel TYPE abap_bool VALUE abap_false.
     DATA mo_table_descr TYPE REF TO cl_abap_tabledescr .
+    DATA:
+      BEGIN OF ms_start_pos,
+        col TYPE i,
+        row TYPE i,
+      END OF ms_start_pos.
 
     METHODS add_field
       IMPORTING
@@ -65,6 +70,13 @@ CLASS zcl_abapgit_popups DEFINITION
         !ct_fields         TYPE ty_lt_fields
       RAISING
         zcx_abapgit_exception .
+    METHODS set_starting_position
+      IMPORTING
+        !iv_width  TYPE i
+        !iv_height TYPE i
+      RAISING
+        zcx_abapgit_exception .
+
 ENDCLASS.
 
 
@@ -327,6 +339,32 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD set_starting_position.
+
+    CONSTANTS:
+      lc_min_size TYPE i VALUE 10,
+      lc_min_pos  TYPE i VALUE 5.
+
+    " Magic math to approximate starting position of popup
+    IF sy-scols > lc_min_size AND iv_width > 0.
+      ms_start_pos-col = nmax(
+        val1 = ( sy-scols - iv_width ) / 2
+        val2 = lc_min_pos ).
+    ELSE.
+      ms_start_pos-col = lc_min_pos.
+    ENDIF.
+
+    IF sy-srows > lc_min_size AND iv_height > 0.
+      ms_start_pos-row = nmax(
+        val1 = ( sy-srows - iv_height ) / 2 - 1
+        val2 = lc_min_pos ).
+    ELSE.
+      ms_start_pos-row = lc_min_pos.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_popups~branch_list_popup.
 
     DATA: lo_branches    TYPE REF TO zcl_abapgit_git_branch_list,
@@ -418,12 +456,17 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       <ls_sel>-varoption = zif_abapgit_popups=>c_new_branch_label.
     ENDIF.
 
+    set_starting_position(
+      EXPORTING
+        iv_width  = 24
+        iv_height = lines( lt_selection ) ).
+
     CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
       EXPORTING
         textline1  = 'Select branch'
         titel      = 'Select branch'
-        start_col  = 30
-        start_row  = 5
+        start_col  = ms_start_pos-col
+        start_row  = ms_start_pos-row
         cursorline = lv_default
       IMPORTING
         answer     = lv_answer
@@ -542,12 +585,17 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       <ls_sel>-varoption = |{ <ls_pull>-number } - { <ls_pull>-title } @{ <ls_pull>-user }|.
     ENDLOOP.
 
+    set_starting_position(
+      EXPORTING
+        iv_width  = 74
+        iv_height = lines( it_pulls ) ).
+
     CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
       EXPORTING
         textline1 = 'Select pull request'
         titel     = 'Select pull request'
-        start_col = 30
-        start_row = 5
+        start_col = ms_start_pos-col
+        start_row = ms_start_pos-row
       IMPORTING
         answer    = lv_answer
       TABLES
@@ -670,6 +718,11 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
   METHOD zif_abapgit_popups~popup_to_confirm.
 
+    set_starting_position(
+      EXPORTING
+        iv_width  = 65
+        iv_height = 5 ).
+
     CALL FUNCTION 'POPUP_TO_CONFIRM'
       EXPORTING
         titlebar              = iv_titlebar
@@ -680,6 +733,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
         icon_button_2         = iv_icon_button_2
         default_button        = iv_default_button
         display_cancel_button = iv_display_cancel_button
+        start_column          = ms_start_pos-col
+        start_row             = ms_start_pos-row
       IMPORTING
         answer                = rv_answer
       EXCEPTIONS
@@ -784,6 +839,11 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     ASSIGN mr_table->* TO <lt_table>.
     ASSERT sy-subrc = 0.
 
+    set_starting_position(
+      EXPORTING
+        iv_width  = iv_end_column - iv_start_column
+        iv_height = iv_end_line - iv_start_line ).
+
     TRY.
         cl_salv_table=>factory( IMPORTING r_salv_table = mo_select_list_popup
                                 CHANGING  t_table = <lt_table> ).
@@ -800,10 +860,10 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
         mo_select_list_popup->set_screen_status( pfstatus = lv_pfstatus
                                                  report = 'SAPMSVIM' ).
 
-        mo_select_list_popup->set_screen_popup( start_column = iv_start_column
-                                                end_column   = iv_end_column
-                                                start_line   = iv_start_line
-                                                end_line     = iv_end_line ).
+        mo_select_list_popup->set_screen_popup( start_column = ms_start_pos-col
+                                                end_column   = ms_start_pos-col + iv_end_column - iv_start_column
+                                                start_line   = ms_start_pos-row
+                                                end_line     = ms_start_pos-row + iv_end_line - iv_start_line ).
 
         lo_events = mo_select_list_popup->get_event( ).
 
@@ -947,10 +1007,17 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     DATA lv_answer TYPE c LENGTH 1.
     FIELD-SYMBOLS: <ls_field> TYPE sval.
 
+    set_starting_position(
+      EXPORTING
+        iv_width  = 120
+        iv_height = lines( ct_fields ) ).
+
     CALL FUNCTION 'POPUP_GET_VALUES'
       EXPORTING
         no_value_check = iv_no_value_check
         popup_title    = iv_popup_title
+        start_column   = ms_start_pos-col
+        start_row      = ms_start_pos-row
       IMPORTING
         returncode     = lv_answer
       TABLES


### PR DESCRIPTION
GUI popups were showing up all over the screen. On bigger screens, they often display outside the abapGit HTML frame.

With this change, most popups will show nicely centered or close to it (some fine tuning might still be required).

Notes: 
- Some popups like the one prompting for a transport request do not allow to influence the screen position. 
- Follow-up: Consolidate "Tag Popups" from `ZCL_ABAPGIT_TAG_POPUPS` to `ZCL_ABAPGIT_POPUPS` and adjust accordingly.

Before:

![SAPgui_545](https://user-images.githubusercontent.com/59966492/149826509-42da2bc8-9a83-4726-80c9-de3de242caa2.gif)

After:

![SAPgui_543](https://user-images.githubusercontent.com/59966492/149826489-c0960516-7b31-46ae-ac9b-5b4cc28f53cc.gif)
