### PR TITLE
Fix lost remote on favorite refresh

### DIFF
--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -43,7 +43,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -131,6 +131,16 @@ CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_repo_from_content.
+    MOVE-CORRESPONDING from_xml( is_content-data_str ) TO rs_result.
+    IF rs_result-local_settings-write_protected = abap_false AND
+       zcl_abapgit_factory=>get_environment( )->is_repo_object_changes_allowed( ) = abap_false.
+      rs_result-local_settings-write_protected = abap_true.
+    ENDIF.
+    rs_result-key = is_content-value.
+  ENDMETHOD.
+
+
   METHOD to_xml.
 
     DATA: ls_xml TYPE zif_abapgit_persistence=>ty_repo_xml.
@@ -184,6 +194,22 @@ CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_persist_repo~exists.
+
+    DATA lt_keys TYPE zif_abapgit_persistence=>ty_repo_keys.
+    DATA lt_content TYPE zif_abapgit_persistence=>ty_contents.
+
+    APPEND iv_key TO lt_keys.
+
+    lt_content = mo_db->list_by_keys(
+      it_keys = lt_keys
+      iv_type = zcl_abapgit_persistence_db=>c_type_repo ).
+
+    rv_yes = boolc( lines( lt_content ) > 0 ).
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_persist_repo~list.
 
     DATA: lt_content TYPE zif_abapgit_persistence=>ty_contents,
@@ -199,6 +225,7 @@ CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
 
   ENDMETHOD.
 
+
   METHOD zif_abapgit_persist_repo~list_favorites.
     DATA: lt_content TYPE zif_abapgit_persistence=>ty_contents,
           ls_content LIKE LINE OF lt_content,
@@ -213,7 +240,6 @@ CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
       INSERT ls_repo INTO TABLE rt_repos.
     ENDLOOP.
   ENDMETHOD.
-
 
 
   METHOD zif_abapgit_persist_repo~lock.
@@ -282,15 +308,4 @@ CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
                    iv_data  = lv_blob ).
 
   ENDMETHOD.
-
-
-  METHOD get_repo_from_content.
-    MOVE-CORRESPONDING from_xml( is_content-data_str ) TO rs_result.
-    IF rs_result-local_settings-write_protected = abap_false AND
-       zcl_abapgit_factory=>get_environment( )->is_repo_object_changes_allowed( ) = abap_false.
-      rs_result-local_settings-write_protected = abap_true.
-    ENDIF.
-    rs_result-key = is_content-value.
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -226,7 +226,7 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_persist_repo~list_favorites.
+  METHOD zif_abapgit_persist_repo~list_by_keys.
     DATA: lt_content TYPE zif_abapgit_persistence=>ty_contents,
           ls_content LIKE LINE OF lt_content,
           ls_repo    LIKE LINE OF rt_repos.

--- a/src/persist/zif_abapgit_persist_repo.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo.intf.abap
@@ -20,6 +20,11 @@ INTERFACE zif_abapgit_persist_repo
       !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
     RAISING
       zcx_abapgit_exception .
+  METHODS exists
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+    RETURNING
+      VALUE(rv_yes) TYPE abap_bool.
   METHODS list
     RETURNING
       VALUE(rt_repos) TYPE zif_abapgit_persistence=>ty_repos
@@ -29,7 +34,7 @@ INTERFACE zif_abapgit_persist_repo
     IMPORTING it_keys         TYPE zif_abapgit_persistence=>ty_repo_keys
     RETURNING VALUE(rt_repos) TYPE zif_abapgit_persistence=>ty_repos
     RAISING
-              zcx_abapgit_exception .
+      zcx_abapgit_exception .
   METHODS lock
     IMPORTING
       !iv_mode TYPE enqmode

--- a/src/persist/zif_abapgit_persist_repo.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo.intf.abap
@@ -30,9 +30,11 @@ INTERFACE zif_abapgit_persist_repo
       VALUE(rt_repos) TYPE zif_abapgit_persistence=>ty_repos
     RAISING
       zcx_abapgit_exception .
-  METHODS list_favorites
-    IMPORTING it_keys         TYPE zif_abapgit_persistence=>ty_repo_keys
-    RETURNING VALUE(rt_repos) TYPE zif_abapgit_persistence=>ty_repos
+  METHODS list_by_keys
+    IMPORTING
+      it_keys         TYPE zif_abapgit_persistence=>ty_repo_keys
+    RETURNING
+      VALUE(rt_repos) TYPE zif_abapgit_persistence=>ty_repos
     RAISING
       zcx_abapgit_exception .
   METHODS lock

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -82,7 +82,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
 
   METHOD add.
@@ -147,16 +147,6 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_repo_srv~list_favorites.
-
-    IF mv_init = abap_false OR mv_only_favorites = abap_false.
-      refresh_favorites( ).
-    ENDIF.
-
-    rt_list = mt_list.
-
-  ENDMETHOD.
-
 
   METHOD refresh_all.
 
@@ -176,19 +166,43 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
   ENDMETHOD.
 
+
   METHOD refresh_favorites.
 
     DATA: lt_list           TYPE zif_abapgit_persistence=>ty_repos,
           lt_user_favorites TYPE zif_abapgit_persist_user=>ty_favorites.
 
-    FIELD-SYMBOLS: <ls_list> LIKE LINE OF lt_list.
+    DATA lo_repo TYPE REF TO zcl_abapgit_repo.
+    DATA lv_repo_index TYPE i.
+    DATA lo_repo_db TYPE REF TO zif_abapgit_persist_repo.
 
-    CLEAR mt_list.
+    FIELD-SYMBOLS: <ls_repo_record> LIKE LINE OF lt_list.
 
+    lo_repo_db        = zcl_abapgit_persist_factory=>get_repo( ).
     lt_user_favorites = zcl_abapgit_persistence_user=>get_instance( )->get_favorites( ).
-    lt_list = zcl_abapgit_persist_factory=>get_repo( )->list_favorites( lt_user_favorites ).
-    LOOP AT lt_list ASSIGNING <ls_list>.
-      instantiate_and_add( <ls_list> ).
+    lt_list           = lo_repo_db->list_favorites( lt_user_favorites ).
+
+    SORT lt_list BY package.
+
+    LOOP AT mt_list INTO lo_repo.
+      lv_repo_index = sy-tabix.
+
+      READ TABLE lt_list TRANSPORTING NO FIELDS WITH KEY package = lo_repo->get_package( ).
+      IF sy-subrc = 0.
+        DELETE lt_list INDEX sy-tabix.
+        CONTINUE. " Leave the repo be
+      ELSE.
+        IF lo_repo_db->exists( lo_repo->get_key( ) ) = abap_false.
+          " Not a fav, and also does not exist, probably uninstalled
+          DELETE mt_list INDEX lv_repo_index.
+        ENDIF.
+      ENDIF.
+
+    ENDLOOP.
+
+    " Create remaining (new) favs
+    LOOP AT lt_list ASSIGNING <ls_repo_record>.
+      instantiate_and_add( <ls_repo_record> ).
     ENDLOOP.
 
     mv_init = abap_true.
@@ -441,6 +455,30 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_repo_srv~list_favorites.
+
+    DATA lt_user_favorites TYPE zif_abapgit_persist_user=>ty_favorites.
+    DATA lo_repo TYPE REF TO zcl_abapgit_repo.
+
+    lt_user_favorites = zcl_abapgit_persistence_user=>get_instance( )->get_favorites( ).
+    SORT lt_user_favorites BY table_line.
+
+    IF mv_init = abap_false OR mv_only_favorites = abap_false.
+      refresh_favorites( ).
+    ENDIF.
+
+    LOOP AT mt_list INTO lo_repo.
+      READ TABLE lt_user_favorites
+        TRANSPORTING NO FIELDS
+        WITH KEY table_line = lo_repo->get_key( ).
+      IF sy-subrc = 0.
+        APPEND lo_repo TO rt_list.
+      ENDIF.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_repo_srv~new_offline.
 
     DATA: ls_repo        TYPE zif_abapgit_persistence=>ty_repo,
@@ -636,5 +674,4 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -191,11 +191,9 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
       IF sy-subrc = 0.
         DELETE lt_list INDEX sy-tabix.
         CONTINUE. " Leave the repo be
-      ELSE.
-        IF lo_repo_db->exists( lo_repo->get_key( ) ) = abap_false.
-          " Not a fav, and also does not exist, probably uninstalled
-          DELETE mt_list INDEX lv_repo_index.
-        ENDIF.
+      ELSEIF lo_repo_db->exists( lo_repo->get_key( ) ) = abap_false.
+        " Not a fav, and also does not exist, probably uninstalled
+        DELETE mt_list INDEX lv_repo_index.
       ENDIF.
 
     ENDLOOP.

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -180,7 +180,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     lo_repo_db        = zcl_abapgit_persist_factory=>get_repo( ).
     lt_user_favorites = zcl_abapgit_persistence_user=>get_instance( )->get_favorites( ).
-    lt_list           = lo_repo_db->list_favorites( lt_user_favorites ).
+    lt_list           = lo_repo_db->list_by_keys( lt_user_favorites ).
 
     SORT lt_list BY package.
 


### PR DESCRIPTION
There was a subtle bug which actually caused me and my team some troubles recently.
If I **don't have favorites** and try to update an offile repo (via zip), then the diff is displayed but pull does not work (in fact it starts deleting all objects ... and tables ... with data ...).

This happens because `zcl_abapgit_repo_srv->list_favorites` (and `refresh_favorites`) - which are called in particular for repo palette, at the end of rendering, **after** diff was rendered - so this `refresh_favorites` **re-instantiates** repo instances ... consequently it looses `mt_remote` before executing the next command - pull in this case.

The issue is quite easily reproduced. Offline repo -> Import from zip -> see diffs (at object list) -> do any next command e.g. drill down to diff page or pull.

So, the change is as follow:
- don't reinstantiate repos, just reconcile them with the actual fav list

Doubts:
- reconciliation is done not by repo_id or url - which do not guarantee uniqueness (?!) - but by package. Which seems to be double checked when new repo added. But it seems strange to me that URL is not checked in the same manner ...
- some code duplication was introduced due to the current code structure. I think in the long run we should remove the `list_favorites` at all and load all repos. It is the page who should filter the repos to display. (I know there is an issue with checksums. Maybe I'll try to find time to straighten it a bit.)

In addition I renamed the `zif_abapgit_persist_repo~list_favorites` to `list_by_keys`. Because the method receives the list of repos externally and does not know anything about favs inside, so semantics was incorrect. Couldn't pass by this refactoring, sorry ;P

and some SE80 reordrings (no changes to `get_repo_from_content`) ...
