### PR TITLE
Fix status for new sub-packages

### DIFF
--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -142,7 +142,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
+CLASS zcl_abapgit_file_status IMPLEMENTATION.
 
 
   METHOD build_existing.
@@ -694,17 +694,17 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
         it_items    = it_items_idx
         it_state    = it_state_idx ).
 
-      " Check if same file exists in different location
+      " Check if same file exists in different location (not for generic package files)
       READ TABLE it_local ASSIGNING <ls_local>
         WITH KEY file-filename = <ls_remote>-filename.
-      IF sy-subrc = 0.
+      IF sy-subrc = 0 AND <ls_remote>-filename <> zcl_abapgit_filename_logic=>c_package_file.
         <ls_result>-match = abap_false.
         <ls_result>-lstate = zif_abapgit_definitions=>c_state-deleted.
         <ls_result>-rstate = zif_abapgit_definitions=>c_state-unchanged.
         IF <ls_local>-file-sha1 = <ls_remote>-sha1.
           <ls_result>-packmove = abap_true.
         ENDIF.
-      ELSEIF sy-subrc = 4.
+      ELSE.
         " Check if file existed before and was deleted locally
         READ TABLE it_state_idx TRANSPORTING NO FIELDS
           WITH KEY path = <ls_remote>-path filename = <ls_remote>-filename

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -697,8 +697,8 @@ CLASS ltcl_calculate_status DEFINITION FOR TESTING RISK LEVEL HARMLESS
       local_outside_main FOR TESTING RAISING zcx_abapgit_exception,
       complete FOR TESTING RAISING zcx_abapgit_exception,
       only_local2 FOR TESTING RAISING zcx_abapgit_exception,
-      only_remote2 FOR TESTING RAISING zcx_abapgit_exception.
-
+      only_remote2 FOR TESTING RAISING zcx_abapgit_exception,
+      only_remote3 FOR TESTING RAISING zcx_abapgit_exception.
 ENDCLASS.
 
 CLASS ltcl_calculate_status IMPLEMENTATION.
@@ -1163,6 +1163,7 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
 
   METHOD only_remote2.
 
+    " Add local class implementation
     mo_helper->add_local(
       iv_path     = '/src/sub/'
       iv_obj_name = 'ZCL_CLAS'
@@ -1175,7 +1176,6 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_filename = 'zcl_clas.clas.abap'
       iv_sha1     = '332211' ).
 
-
     mo_helper->add_remote(
       iv_path     = '/src/sub/'
       iv_filename = 'zcl_clas.clas.locals_imp.abap'
@@ -1186,13 +1186,58 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_filename = 'zcl_clas.clas.locals_imp.abap'
       iv_sha1     = '1111' ).
 
-    mo_result = mo_helper->run( iv_devclass = '$DIFFERENT$' ).
+    mo_result = mo_helper->run( iv_devclass = '$DIFFERENT' ).
 
     mo_result->assert_lines( 2 ).
 
     cl_abap_unit_assert=>assert_equals(
       act = mo_result->get_line( 2 )-match
       exp = abap_false ).
+
+  ENDMETHOD.
+
+  METHOD only_remote3.
+
+    " Add subpackage remotely
+    mo_helper->add_local(
+      iv_path     = '/src/'
+      iv_obj_name = '$DIFFERENT'
+      iv_obj_type = 'DEVC'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '112233' ).
+
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '112233' ).
+
+    mo_helper->add_remote(
+      iv_path     = '/src/sub/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '332211' ).
+
+    mo_helper->add_state(
+      iv_path     = '/src/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '112233' ).
+
+    mo_result = mo_helper->run( iv_devclass = '$DIFFERENT' ).
+
+    mo_result->assert_lines( 2 ).
+
+    " main package matches
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_result->get_line( 1 )-match
+      exp = abap_true ).
+
+    " subpackage should appear as added remotely
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_result->get_line( 2 )-lstate
+      exp = zif_abapgit_definitions=>c_state-unchanged ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_result->get_line( 2 )-rstate
+      exp = zif_abapgit_definitions=>c_state-added ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
If a sub-package is added remotely, abapGit displays the status incorrectly as "deleted locally". This fix shows it properly as "added remotely".

Before:

![image](https://user-images.githubusercontent.com/59966492/150334224-47f4485d-4e1d-4ee5-acea-d2e8b925769b.png)

After:

![image](https://user-images.githubusercontent.com/59966492/150334254-f68f9862-c1c0-4662-a8c3-8cea650c2eeb.png)
