### PR TITLE
Set window title for log viewer

### DIFF
--- a/src/ui/zcl_abapgit_log_viewer.clas.abap
+++ b/src/ui/zcl_abapgit_log_viewer.clas.abap
@@ -312,6 +312,8 @@ CLASS zcl_abapgit_log_viewer IMPLEMENTATION.
         lo_functions = lo_alv->get_functions( ).
         lo_functions->set_all( ).
 
+        lo_alv->get_display_settings( )->set_list_header( |abapGit Log Viewer| ).
+
         lo_columns = lo_alv->get_columns( ).
 
         lo_columns->set_optimize( ).


### PR DESCRIPTION
Otherwise the popup gets sy-title which looks odd when called externally via RFC (for example in CI).

![image](https://user-images.githubusercontent.com/5270359/151710456-2cce9933-90aa-49bd-9a2c-744f1d2fade5.png)
