### PR TITLE
TABL: Properly show inactive objects

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -915,7 +915,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~is_active.
-    rv_active = is_active( ).
+    rv_active = is_active_ddic( ).
   ENDMETHOD.
 
 
@@ -935,6 +935,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
   METHOD zif_abapgit_object~serialize.
 
     DATA: lv_name   TYPE ddobjname,
+          lv_state  TYPE ddgotstate,
           ls_dd02v  TYPE dd02v,
           ls_dd09l  TYPE dd09l,
           lt_dd03p  TYPE ty_dd03p_tt,
@@ -961,6 +962,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
         name          = lv_name
         langu         = mv_language
       IMPORTING
+        gotstate      = lv_state
         dd02v_wa      = ls_dd02v
         dd09l_wa      = ls_dd09l
       TABLES
@@ -978,8 +980,9 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error from DDIF_TABL_GET' ).
     ENDIF.
 
-    IF ls_dd02v IS INITIAL.
-      zcx_abapgit_exception=>raise( |No active version found for { ms_item-obj_type } { ms_item-obj_name }| ).
+    " Check if any active version was returned
+    IF lv_state <> 'A'.
+      RETURN.
     ENDIF.
 
     CLEAR: ls_dd02v-as4user,

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -794,13 +794,21 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     CASE is_step-step_id.
       WHEN zif_abapgit_object=>gc_step_id-ddic.
-        zcl_abapgit_objects_activation=>activate( abap_true ).
+        zcl_abapgit_objects_activation=>activate(
+          iv_ddic = abap_true
+          ii_log  = ii_log ).
       WHEN zif_abapgit_object=>gc_step_id-abap.
-        zcl_abapgit_objects_activation=>activate( abap_false ).
+        zcl_abapgit_objects_activation=>activate(
+          iv_ddic = abap_false
+          ii_log  = ii_log ).
       WHEN zif_abapgit_object=>gc_step_id-late.
         " late can have both DDIC (like TABL with REF TO) and non-DDIC objects
-        zcl_abapgit_objects_activation=>activate( abap_true ).
-        zcl_abapgit_objects_activation=>activate( abap_false ).
+        zcl_abapgit_objects_activation=>activate(
+          iv_ddic = abap_true
+          ii_log  = ii_log ).
+        zcl_abapgit_objects_activation=>activate(
+          iv_ddic = abap_false
+          ii_log  = ii_log ).
     ENDCASE.
 
 *   Call postprocessing

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -794,21 +794,13 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     CASE is_step-step_id.
       WHEN zif_abapgit_object=>gc_step_id-ddic.
-        zcl_abapgit_objects_activation=>activate(
-          iv_ddic = abap_true
-          ii_log  = ii_log ).
+        zcl_abapgit_objects_activation=>activate( abap_true ).
       WHEN zif_abapgit_object=>gc_step_id-abap.
-        zcl_abapgit_objects_activation=>activate(
-          iv_ddic = abap_false
-          ii_log  = ii_log ).
+        zcl_abapgit_objects_activation=>activate( abap_false ).
       WHEN zif_abapgit_object=>gc_step_id-late.
         " late can have both DDIC (like TABL with REF TO) and non-DDIC objects
-        zcl_abapgit_objects_activation=>activate(
-          iv_ddic = abap_true
-          ii_log  = ii_log ).
-        zcl_abapgit_objects_activation=>activate(
-          iv_ddic = abap_false
-          ii_log  = ii_log ).
+        zcl_abapgit_objects_activation=>activate( abap_true ).
+        zcl_abapgit_objects_activation=>activate( abap_false ).
     ENDCASE.
 
 *   Call postprocessing

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -1007,6 +1007,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
   METHOD serialize.
 
     DATA: li_obj         TYPE REF TO zif_abapgit_object,
+          lx_error       TYPE REF TO zcx_abapgit_exception,
           li_xml         TYPE REF TO zif_abapgit_xml_output,
           lo_files       TYPE REF TO zcl_abapgit_objects_files,
           ls_i18n_params TYPE zif_abapgit_definitions=>ty_i18n_params.
@@ -1038,7 +1039,12 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     li_xml->i18n_params( ls_i18n_params ).
 
-    li_obj->serialize( li_xml ).
+    TRY.
+        li_obj->serialize( li_xml ).
+      CATCH zcx_abapgit_exception INTO lx_error.
+        rs_files_and_item-item-inactive = boolc( li_obj->is_active( ) = abap_false ).
+        RAISE EXCEPTION lx_error.
+    ENDTRY.
 
     IF lo_files->is_json_metadata( ) = abap_false.
       lo_files->add_xml( ii_xml      = li_xml

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -80,6 +80,11 @@ CLASS zcl_abapgit_objects_super DEFINITION
         !ii_xml TYPE REF TO zif_abapgit_xml_input
       RAISING
         zcx_abapgit_exception .
+    METHODS is_active_ddic
+      RETURNING
+        VALUE(rv_active) TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -278,6 +283,37 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     ENDIF.
 
     rv_active = boolc( ms_item-inactive = abap_false ).
+  ENDMETHOD.
+
+
+  METHOD is_active_ddic.
+
+    DATA:
+      lv_type  TYPE ddobjtyp,
+      lv_name  TYPE ddobjname,
+      lv_state TYPE ddgotstate.
+
+    ms_item-inactive = abap_false.
+
+    lv_type = ms_item-obj_type.
+    lv_name = ms_item-obj_name.
+
+    CALL FUNCTION 'DDIF_STATE_GET'
+      EXPORTING
+        type          = lv_type
+        name          = lv_name
+        state         = 'A'
+      IMPORTING
+        gotstate      = lv_state
+      EXCEPTIONS
+        illegal_input = 1
+        OTHERS        = 2.
+    IF sy-subrc <> 0 OR lv_state <> 'A'.
+      ms_item-inactive = abap_true.
+    ENDIF.
+
+    rv_active = boolc( ms_item-inactive = abap_false ).
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Current `is_active` check is insufficient for DDIC objects and can't detect "new" or "partically active" objects.

Introduces a new `is_active_ddic` method in `zcl_abapgit_objects_super` which should be used by all DDIC types (follow-up). 

![image](https://user-images.githubusercontent.com/59966492/151868869-97f45191-dea3-4ab4-bfd5-28a6f10ae07b.png)

Closes #5294