### PR TITLE
Rework checksums

### DIFF
--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -142,7 +142,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_file_status IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
 
 
   METHOD build_existing.
@@ -789,7 +789,7 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
       io_dot       = io_repo->get_dot_abapgit( )
       it_local     = lt_local
       it_remote    = lt_remote
-      it_cur_state = io_repo->get_local_checksums_per_file( ) ).
+      it_cur_state = io_repo->zif_abapgit_repo~checksums( )->get_checksums_per_file( ) ).
 
     run_checks(
       ii_log     = ii_log

--- a/src/persist/zcl_abapgit_persist_factory.clas.abap
+++ b/src/persist/zcl_abapgit_persist_factory.clas.abap
@@ -8,6 +8,9 @@ CLASS zcl_abapgit_persist_factory DEFINITION
     CLASS-METHODS get_repo
       RETURNING
         VALUE(ri_repo) TYPE REF TO zif_abapgit_persist_repo .
+    CLASS-METHODS get_repo_cs
+      RETURNING
+        VALUE(ri_repo_cs) TYPE REF TO zif_abapgit_persist_repo_cs .
     CLASS-METHODS get_settings
       RETURNING
         VALUE(ri_settings) TYPE REF TO zif_abapgit_persist_settings .
@@ -15,6 +18,7 @@ CLASS zcl_abapgit_persist_factory DEFINITION
   PRIVATE SECTION.
 
     CLASS-DATA gi_repo TYPE REF TO zif_abapgit_persist_repo .
+    CLASS-DATA gi_repo_cs TYPE REF TO zif_abapgit_persist_repo_cs .
     CLASS-DATA gi_settings TYPE REF TO zif_abapgit_persist_settings .
 ENDCLASS.
 
@@ -33,6 +37,15 @@ CLASS ZCL_ABAPGIT_PERSIST_FACTORY IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD get_repo_cs.
+
+    IF gi_repo_cs IS INITIAL.
+      CREATE OBJECT gi_repo_cs TYPE zcl_abapgit_persistence_repo.
+    ENDIF.
+
+    ri_repo_cs = gi_repo_cs.
+
+  ENDMETHOD.
 
   METHOD get_settings.
 

--- a/src/persist/zcl_abapgit_persist_injector.clas.abap
+++ b/src/persist/zcl_abapgit_persist_injector.clas.abap
@@ -9,6 +9,10 @@ CLASS zcl_abapgit_persist_injector DEFINITION
       IMPORTING
         !ii_repo TYPE REF TO zif_abapgit_persist_repo .
 
+    CLASS-METHODS set_repo_cs
+      IMPORTING
+        !ii_repo_cs TYPE REF TO zif_abapgit_persist_repo_cs .
+
     CLASS-METHODS set_settings
       IMPORTING
         !ii_settings TYPE REF TO zif_abapgit_persist_settings .
@@ -30,6 +34,11 @@ CLASS ZCL_ABAPGIT_PERSIST_INJECTOR IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD set_repo_cs.
+
+    zcl_abapgit_persist_factory=>gi_repo_cs = ii_repo_cs.
+
+  ENDMETHOD.
 
   METHOD set_settings.
 

--- a/src/persist/zcl_abapgit_persistence_db.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_db.clas.abap
@@ -9,6 +9,7 @@ CLASS zcl_abapgit_persistence_db DEFINITION
     CONSTANTS:
       c_type_settings   TYPE zif_abapgit_persistence=>ty_type VALUE 'SETTINGS' ##NO_TEXT,
       c_type_repo       TYPE zif_abapgit_persistence=>ty_type VALUE 'REPO' ##NO_TEXT,
+      c_type_repo_csum  TYPE zif_abapgit_persistence=>ty_type VALUE 'REPO_CS' ##NO_TEXT,
       c_type_background TYPE zif_abapgit_persistence=>ty_type VALUE 'BACKGROUND' ##NO_TEXT,
       c_type_packages   TYPE zif_abapgit_persistence=>ty_type VALUE 'PACKAGES' ##NO_TEXT,
       c_type_user       TYPE zif_abapgit_persistence=>ty_type VALUE 'USER' ##NO_TEXT.
@@ -90,7 +91,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_persistence_db IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_PERSISTENCE_DB IMPLEMENTATION.
 
 
   METHOD add.
@@ -156,14 +157,6 @@ CLASS zcl_abapgit_persistence_db IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD list_by_type.
-    SELECT * FROM (c_tabname)
-      INTO TABLE rt_content
-      WHERE type = iv_type
-      ORDER BY PRIMARY KEY.                               "#EC CI_SUBRC
-  ENDMETHOD.
-
-
   METHOD list_by_keys.
     FIELD-SYMBOLS: <ls_key> LIKE LINE OF it_keys.
     LOOP AT it_keys ASSIGNING <ls_key>.
@@ -172,6 +165,14 @@ CLASS zcl_abapgit_persistence_db IMPLEMENTATION.
       WHERE value = <ls_key> AND
             type  = iv_type.
     ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD list_by_type.
+    SELECT * FROM (c_tabname)
+      INTO TABLE rt_content
+      WHERE type = iv_type
+      ORDER BY PRIMARY KEY.                               "#EC CI_SUBRC
   ENDMETHOD.
 
 
@@ -258,6 +259,4 @@ CLASS zcl_abapgit_persistence_db IMPLEMENTATION.
       iv_ignore_errors = abap_false ).
 
   ENDMETHOD.
-
-
 ENDCLASS.

--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -6,6 +6,7 @@ CLASS zcl_abapgit_persistence_repo DEFINITION
   PUBLIC SECTION.
 
     INTERFACES zif_abapgit_persist_repo .
+    INTERFACES zif_abapgit_persist_repo_cs .
 
     METHODS constructor .
   PROTECTED SECTION.
@@ -308,4 +309,30 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
                    iv_data  = lv_blob ).
 
   ENDMETHOD.
+
+  METHOD zif_abapgit_persist_repo_cs~delete.
+
+    mo_db->delete(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
+      iv_value = iv_key ).
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_persist_repo_cs~read.
+
+    rv_cs_blob = mo_db->read(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
+      iv_value = iv_key ).
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_persist_repo_cs~update.
+
+    mo_db->modify(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
+      iv_value = iv_key
+      iv_data  = iv_cs_blob ).
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -9,6 +9,12 @@ CLASS zcl_abapgit_persistence_repo DEFINITION
     INTERFACES zif_abapgit_persist_repo_cs .
 
     METHODS constructor .
+    METHODS rewrite_repo_meta
+      IMPORTING
+        !iv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_not_found.
   PROTECTED SECTION.
 
   PRIVATE SECTION.
@@ -142,6 +148,27 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD rewrite_repo_meta.
+
+    DATA lv_old_blob TYPE string.
+    DATA lv_new_blob TYPE string.
+    DATA ls_repo_meta TYPE zif_abapgit_persistence=>ty_repo.
+
+    lv_old_blob = mo_db->read(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo
+      iv_value = iv_repo_key ).
+
+    MOVE-CORRESPONDING from_xml( lv_old_blob ) TO ls_repo_meta.
+    lv_new_blob = to_xml( ls_repo_meta ).
+
+    mo_db->update(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo
+      iv_value = iv_repo_key
+      iv_data  = lv_new_blob ).
+
+  ENDMETHOD.
+
+
   METHOD to_xml.
 
     DATA: ls_xml TYPE zif_abapgit_persistence=>ty_repo_xml.
@@ -152,6 +179,34 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
     CALL TRANSFORMATION id
       SOURCE repo = ls_xml
       RESULT XML rv_repo_xml_string.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_repo_cs~delete.
+
+    mo_db->delete(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
+      iv_value = iv_key ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_repo_cs~read.
+
+    rv_cs_blob = mo_db->read(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
+      iv_value = iv_key ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_repo_cs~update.
+
+    mo_db->modify(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
+      iv_value = iv_key
+      iv_data  = iv_cs_blob ).
+
   ENDMETHOD.
 
 
@@ -309,30 +364,4 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
                    iv_data  = lv_blob ).
 
   ENDMETHOD.
-
-  METHOD zif_abapgit_persist_repo_cs~delete.
-
-    mo_db->delete(
-      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
-      iv_value = iv_key ).
-
-  ENDMETHOD.
-
-  METHOD zif_abapgit_persist_repo_cs~read.
-
-    rv_cs_blob = mo_db->read(
-      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
-      iv_value = iv_key ).
-
-  ENDMETHOD.
-
-  METHOD zif_abapgit_persist_repo_cs~update.
-
-    mo_db->modify(
-      iv_type  = zcl_abapgit_persistence_db=>c_type_repo_csum
-      iv_value = iv_key
-      iv_data  = iv_cs_blob ).
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/persist/zif_abapgit_persist_repo_cs.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo_cs.intf.abap
@@ -1,0 +1,23 @@
+INTERFACE zif_abapgit_persist_repo_cs
+  PUBLIC .
+
+  METHODS update
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      !iv_cs_blob TYPE zif_abapgit_persistence=>ty_content-data_str
+    RAISING
+      zcx_abapgit_exception .
+  METHODS delete
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+    RAISING
+      zcx_abapgit_exception .
+  METHODS read
+    IMPORTING
+      !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
+    RETURNING
+      VALUE(rv_cs_blob) TYPE zif_abapgit_persistence=>ty_content-data_str
+    RAISING
+      zcx_abapgit_exception
+      zcx_abapgit_not_found .
+ENDINTERFACE.

--- a/src/persist/zif_abapgit_persist_repo_cs.intf.xml
+++ b/src/persist/zif_abapgit_persist_repo_cs.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_PERSIST_REPO_CS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Repo checksum persistence</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -14,7 +14,7 @@ INTERFACE zif_abapgit_persistence PUBLIC.
     ty_contents TYPE SORTED TABLE OF ty_content WITH UNIQUE KEY type value .
 
   TYPES: BEGIN OF ty_local_checksum,
-           item  TYPE zif_abapgit_definitions=>ty_item,
+           item  TYPE zif_abapgit_definitions=>ty_item_signature,
            files TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
          END OF ty_local_checksum.
 

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -44,7 +44,6 @@ INTERFACE zif_abapgit_persistence PUBLIC.
            deserialized_at TYPE timestampl,
            offline         TYPE abap_bool,
            switched_origin TYPE string,
-           local_checksums TYPE ty_local_checksum_tt,
            dot_abapgit     TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit,
            head_branch     TYPE string,   " HEAD symref of the repo, master branch
            local_settings  TYPE ty_local_settings,
@@ -62,7 +61,6 @@ INTERFACE zif_abapgit_persistence PUBLIC.
       deserialized_at TYPE abap_bool,
       offline         TYPE abap_bool,
       switched_origin TYPE abap_bool,
-      local_checksums TYPE abap_bool,
       dot_abapgit     TYPE abap_bool,
       head_branch     TYPE abap_bool,
       local_settings  TYPE abap_bool,

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -30,7 +30,8 @@ INTERFACE zif_abapgit_persistence PUBLIC.
     END OF ty_local_settings.
 
   TYPES: ty_local_checksum_tt TYPE STANDARD TABLE OF ty_local_checksum WITH DEFAULT KEY.
-  TYPES: ty_local_checksum_by_item_tt TYPE SORTED TABLE OF ty_local_checksum WITH NON-UNIQUE KEY item-obj_type item-obj_name.
+  TYPES: ty_local_checksum_by_item_tt TYPE SORTED TABLE OF ty_local_checksum
+    WITH NON-UNIQUE KEY item-obj_type item-obj_name.
 
   TYPES: BEGIN OF ty_repo_xml,
            url             TYPE string,

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -30,6 +30,7 @@ INTERFACE zif_abapgit_persistence PUBLIC.
     END OF ty_local_settings.
 
   TYPES: ty_local_checksum_tt TYPE STANDARD TABLE OF ty_local_checksum WITH DEFAULT KEY.
+  TYPES: ty_local_checksum_by_item_tt TYPE SORTED TABLE OF ty_local_checksum WITH NON-UNIQUE KEY item-obj_type item-obj_name.
 
   TYPES: BEGIN OF ty_repo_xml,
            url             TYPE string,

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -82,11 +82,6 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-    METHODS create_new_log
-      IMPORTING
-        !iv_title     TYPE string OPTIONAL
-      RETURNING
-        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -621,6 +621,14 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
     ENDLOOP.
     set( it_checksums = lt_checksums ).
+
+
+    DATA li_checksums TYPE REF TO zif_abapgit_repo_checksums.
+    CREATE OBJECT li_checksums TYPE zcl_abapgit_repo_checksums
+      EXPORTING
+        iv_repo_key = ms_data-key.
+    li_checksums->rebuild( ).
+
     reset_status( ).
 
   ENDMETHOD.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -47,7 +47,7 @@ CLASS zcl_abapgit_repo DEFINITION
         zcx_abapgit_exception .
     METHODS update_local_checksums
       IMPORTING
-        !it_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+        !it_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
       RAISING
         zcx_abapgit_exception .
     METHODS rebuild_local_checksums
@@ -881,10 +881,10 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_checksum>  LIKE LINE OF lt_checksums,
                    <ls_file>      LIKE LINE OF <ls_checksum>-files,
                    <ls_local>     LIKE LINE OF lt_local,
-                   <ls_new_state> LIKE LINE OF it_files.
+                   <ls_new_state> LIKE LINE OF it_updated_files.
 
     lt_checksums = get_local_checksums( ).
-    lt_files_idx = it_files.
+    lt_files_idx = it_updated_files.
     SORT lt_files_idx BY path filename. " Sort for binary search
 
     " Loop through current chacksum state, update sha1 for common files

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -611,7 +611,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     LOOP AT lt_local ASSIGNING <ls_local>.
       IF ls_last_item <> <ls_local>-item OR sy-tabix = 1. " First or New item reached ?
         APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_checksum>.
-        <ls_checksum>-item = <ls_local>-item.
+        <ls_checksum>-item = <ls_local>-item. " Assuming local-item type starts with item_signature !
         ls_last_item       = <ls_local>-item.
       ENDIF.
 
@@ -922,10 +922,10 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       ENDIF.
 
       READ TABLE lt_checksums ASSIGNING <ls_checksum> " TODO Optimize
-        WITH KEY item = <ls_local>-item.
+        WITH KEY item = <ls_local>-item. " Assuming local-item type starts with item_signature !
       IF sy-subrc > 0.
         APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_checksum>.
-        <ls_checksum>-item = <ls_local>-item.
+        <ls_checksum>-item = <ls_local>-item. " Assuming local-item type starts with item_signature !
       ENDIF.
 
       APPEND <ls_new_state> TO <ls_checksum>-files.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -82,6 +82,11 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
+    METHODS create_new_log
+      IMPORTING
+        !iv_title     TYPE string OPTIONAL
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -37,6 +37,14 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS get_local_checksums_per_file
       RETURNING
         VALUE(rt_checksums) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
+    METHODS get_dot_abapgit
+      RETURNING
+        VALUE(ro_dot_abapgit) TYPE REF TO zcl_abapgit_dot_abapgit .
+    METHODS set_dot_abapgit
+      IMPORTING
+        !io_dot_abapgit TYPE REF TO zcl_abapgit_dot_abapgit
+      RAISING
+        zcx_abapgit_exception .
     METHODS get_dot_apack
       RETURNING
         VALUE(ro_dot_apack) TYPE REF TO zcl_abapgit_apack_reader .
@@ -51,6 +59,12 @@ CLASS zcl_abapgit_repo DEFINITION
       RAISING
         zcx_abapgit_exception .
     METHODS rebuild_local_checksums
+      RAISING
+        zcx_abapgit_exception .
+    METHODS deserialize
+      IMPORTING
+        !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
+        !ii_log    TYPE REF TO zif_abapgit_log
       RAISING
         zcx_abapgit_exception .
     METHODS find_remote_dot_abapgit
@@ -129,7 +143,6 @@ CLASS zcl_abapgit_repo DEFINITION
         zcx_abapgit_exception .
     METHODS set
       IMPORTING
-        !it_checksums       TYPE zif_abapgit_persistence=>ty_local_checksum_tt OPTIONAL
         !iv_url             TYPE zif_abapgit_persistence=>ty_repo-url OPTIONAL
         !iv_branch_name     TYPE zif_abapgit_persistence=>ty_repo-branch_name OPTIONAL
         !iv_selected_commit TYPE zif_abapgit_persistence=>ty_repo-selected_commit OPTIONAL
@@ -145,9 +158,6 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS reset_remote .
   PRIVATE SECTION.
 
-    METHODS get_local_checksums
-      RETURNING
-        VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt .
     METHODS notify_listener
       IMPORTING
         !is_change_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask
@@ -326,7 +336,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
     APPEND get_dot_abapgit( )->get_signature( ) TO lt_updated_files.
 
-    update_local_checksums( lt_updated_files ).
+    zif_abapgit_repo~checksums( )->update( lt_updated_files ).
 
     " Deserialize data (no save to database, just test for now)
     lt_result = zcl_abapgit_data_factory=>get_deserializer( )->deserialize(
@@ -502,22 +512,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_local_checksums.
-    rt_checksums = ms_data-local_checksums.
-  ENDMETHOD.
-
-
-  METHOD get_local_checksums_per_file.
-
-    FIELD-SYMBOLS <ls_object> LIKE LINE OF ms_data-local_checksums.
-
-    LOOP AT ms_data-local_checksums ASSIGNING <ls_object>.
-      APPEND LINES OF <ls_object>-files TO rt_checksums.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
   METHOD get_local_settings.
 
     rs_settings = ms_data-local_settings.
@@ -585,51 +579,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
         is_meta        = ls_meta_slug
         is_change_mask = is_change_mask ).
     ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD rebuild_local_checksums.
-
-    DATA:
-      lt_remote    TYPE zif_abapgit_definitions=>ty_files_tt,
-      lt_local     TYPE zif_abapgit_definitions=>ty_files_item_tt,
-      ls_last_item TYPE zif_abapgit_definitions=>ty_item,
-      lt_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-
-    FIELD-SYMBOLS:
-      <ls_checksum> LIKE LINE OF lt_checksums,
-      <ls_local>    LIKE LINE OF lt_local.
-
-    lt_local  = get_files_local( ).
-
-    remove_non_code_related_files( CHANGING ct_local_files = lt_local ).
-
-    lt_remote = get_files_remote( ).
-    SORT lt_remote BY path filename.
-
-    LOOP AT lt_local ASSIGNING <ls_local>.
-      IF ls_last_item <> <ls_local>-item OR sy-tabix = 1. " First or New item reached ?
-        APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_checksum>.
-        <ls_checksum>-item = <ls_local>-item. " Assuming local-item type starts with item_signature !
-        ls_last_item       = <ls_local>-item.
-      ENDIF.
-
-      compare_with_remote_checksum( EXPORTING it_remote_files = lt_remote
-                                              is_local_file   = <ls_local>-file
-                                    CHANGING  cs_checksum     = <ls_checksum> ).
-
-    ENDLOOP.
-    set( it_checksums = lt_checksums ).
-
-
-    DATA li_checksums TYPE REF TO zif_abapgit_repo_checksums.
-    CREATE OBJECT li_checksums TYPE zcl_abapgit_repo_checksums
-      EXPORTING
-        iv_repo_key = ms_data-key.
-    li_checksums->rebuild( ).
-
-    reset_status( ).
 
   ENDMETHOD.
 
@@ -724,8 +673,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     DATA: ls_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask.
 
 
-    ASSERT it_checksums IS SUPPLIED
-      OR iv_url IS SUPPLIED
+    ASSERT iv_url IS SUPPLIED
       OR iv_branch_name IS SUPPLIED
       OR iv_selected_commit IS SUPPLIED
       OR iv_head_branch IS SUPPLIED
@@ -736,11 +684,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       OR iv_deserialized_at IS SUPPLIED
       OR iv_switched_origin IS SUPPLIED.
 
-
-    IF it_checksums IS SUPPLIED.
-      ms_data-local_checksums = it_checksums.
-      ls_mask-local_checksums = abap_true.
-    ENDIF.
 
     IF iv_url IS SUPPLIED.
       ms_data-url = iv_url.
@@ -866,81 +809,11 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD update_local_checksums.
+  METHOD zif_abapgit_repo~checksums.
 
-    " ASSUMTION: SHA1 in param is actual and correct.
-    " Push fills it from local files before pushing, deserialize from remote
-    " If this is not true that there is an error somewhere but not here
-
-    DATA: lt_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt,
-          lt_files_idx TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
-          lt_local     TYPE zif_abapgit_definitions=>ty_files_item_tt,
-          lv_chks_row  TYPE i,
-          lv_file_row  TYPE i.
-
-    FIELD-SYMBOLS: <ls_checksum>  LIKE LINE OF lt_checksums,
-                   <ls_file>      LIKE LINE OF <ls_checksum>-files,
-                   <ls_local>     LIKE LINE OF lt_local,
-                   <ls_new_state> LIKE LINE OF it_updated_files.
-
-    lt_checksums = get_local_checksums( ).
-    lt_files_idx = it_updated_files.
-    SORT lt_files_idx BY path filename. " Sort for binary search
-
-    " Loop through current chacksum state, update sha1 for common files
-    LOOP AT lt_checksums ASSIGNING <ls_checksum>.
-      lv_chks_row = sy-tabix.
-
-      LOOP AT <ls_checksum>-files ASSIGNING <ls_file>.
-        lv_file_row = sy-tabix.
-
-        READ TABLE lt_files_idx ASSIGNING <ls_new_state>
-          WITH KEY path = <ls_file>-path filename = <ls_file>-filename
-          BINARY SEARCH.
-        CHECK sy-subrc = 0. " Missing in param table, skip
-
-        IF <ls_new_state>-sha1 IS INITIAL. " Empty input sha1 is a deletion marker
-          DELETE <ls_checksum>-files INDEX lv_file_row.
-        ELSE.
-          <ls_file>-sha1 = <ls_new_state>-sha1.  " Update sha1
-          CLEAR <ls_new_state>-sha1.             " Mark as processed
-        ENDIF.
-      ENDLOOP.
-
-      IF lines( <ls_checksum>-files ) = 0. " Remove empty objects
-        DELETE lt_checksums INDEX lv_chks_row.
-      ENDIF.
-    ENDLOOP.
-
-    DELETE lt_files_idx WHERE sha1 IS INITIAL. " Remove processed
-    IF lines( lt_files_idx ) > 0.
-      lt_local = get_files_local( ).
-      SORT lt_local BY file-path file-filename. " Sort for binary search
-    ENDIF.
-
-    " Add new files - not deleted and not marked as processed above
-    LOOP AT lt_files_idx ASSIGNING <ls_new_state>.
-
-      READ TABLE lt_local ASSIGNING <ls_local>
-        WITH KEY file-path = <ls_new_state>-path file-filename = <ls_new_state>-filename
-        BINARY SEARCH.
-      IF sy-subrc <> 0.
-* if the deserialization fails, the local file might not be there
-        CONTINUE.
-      ENDIF.
-
-      READ TABLE lt_checksums ASSIGNING <ls_checksum> " TODO Optimize
-        WITH KEY item = <ls_local>-item. " Assuming local-item type starts with item_signature !
-      IF sy-subrc > 0.
-        APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_checksum>.
-        <ls_checksum>-item = <ls_local>-item. " Assuming local-item type starts with item_signature !
-      ENDIF.
-
-      APPEND <ls_new_state> TO <ls_checksum>-files.
-    ENDLOOP.
-
-    SORT lt_checksums BY item.
-    set( it_checksums = lt_checksums ).
+    CREATE OBJECT ri_checksums TYPE zcl_abapgit_repo_checksums
+      EXPORTING
+        iv_repo_key = ms_data-key.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -13,6 +13,12 @@ CLASS zcl_abapgit_repo_checksums DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+    METHODS force_write
+      IMPORTING
+        it_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt
+      RAISING
+        zcx_abapgit_exception.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -136,6 +142,15 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD force_write.
+
+    " for migration only for the moment
+
+    save_checksums( it_checksums ).
+
+  ENDMETHOD.
+
+
   METHOD remove_non_code_related_files.
 
     DELETE ct_local_files
@@ -178,6 +193,20 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_repo_checksums~get_checksums_per_file.
+
+    DATA lt_checksums   TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    FIELD-SYMBOLS <ls_object> LIKE LINE OF lt_checksums.
+
+    lt_checksums = zif_abapgit_repo_checksums~get( ).
+
+    LOOP AT lt_checksums ASSIGNING <ls_object>.
+      APPEND LINES OF <ls_object>-files TO rt_checksums.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_repo_checksums~rebuild.
 
     DATA lt_remote    TYPE zif_abapgit_definitions=>ty_files_tt.
@@ -215,19 +244,4 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
     save_checksums( lt_checksums ).
 
   ENDMETHOD.
-
-  METHOD zif_abapgit_repo_checksums~get_checksums_per_file.
-
-    DATA lt_checksums   TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-    FIELD-SYMBOLS <ls_object> LIKE LINE OF lt_checksums.
-
-    lt_checksums = zif_abapgit_repo_checksums~get( ).
-
-    LOOP AT lt_checksums ASSIGNING <ls_object>.
-      APPEND LINES OF <ls_object>-files TO rt_checksums.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -1,0 +1,102 @@
+CLASS zcl_abapgit_repo_checksums DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS serialize
+      IMPORTING
+        it_checksums     TYPE zif_abapgit_persistence=>ty_local_checksum_tt
+      RETURNING
+        VALUE(rv_string) TYPE string.
+
+    METHODS deserialize
+      IMPORTING
+        iv_string           TYPE string
+      RETURNING
+        VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
+
+
+  METHOD deserialize.
+
+    DATA lt_buf_tab TYPE string_table.
+    DATA lv_buf TYPE string.
+    DATA lt_checksums LIKE rt_checksums.
+
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums.
+    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
+
+    SPLIT iv_string AT |\n| INTO TABLE lt_buf_tab.
+
+    LOOP AT lt_buf_tab INTO lv_buf.
+      CHECK lv_buf IS NOT INITIAL. " In fact this is a bug ... it cannot be empty, maybe raise
+
+      IF lv_buf+0(1) = '/'.
+        IF <ls_cs> IS NOT ASSIGNED.
+          " Incorrect checksums struture, maybe raise, though it is not critical for execution
+          RETURN.
+        ENDIF.
+
+        APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
+        SPLIT lv_buf AT space INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
+
+        IF <ls_file>-path IS INITIAL OR <ls_file>-filename IS INITIAL OR <ls_file>-sha1 IS INITIAL..
+          " Incorrect checksums struture, maybe raise, though it is not critical for execution
+          RETURN.
+        ENDIF.
+      ELSE.
+        APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_cs>.
+        SPLIT lv_buf AT space INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
+
+        IF <ls_cs>-item-obj_type IS INITIAL OR <ls_cs>-item-obj_name IS INITIAL OR <ls_cs>-item-devclass IS INITIAL.
+          " Incorrect checksums struture, maybe raise, though it is not critical for execution
+          RETURN.
+        ENDIF.
+
+      ENDIF.
+    ENDLOOP.
+
+    rt_checksums = lt_checksums.
+
+  ENDMETHOD.
+
+
+  METHOD serialize.
+
+    DATA lt_buf_tab TYPE string_table.
+    DATA lv_buf TYPE string.
+
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF it_checksums.
+    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
+
+    LOOP AT it_checksums ASSIGNING <ls_cs>.
+
+      CONCATENATE <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass
+        INTO lv_buf
+        SEPARATED BY space.
+      APPEND lv_buf TO lt_buf_tab.
+
+      LOOP AT <ls_cs>-files ASSIGNING <ls_file>.
+
+        CONCATENATE <ls_file>-path <ls_file>-filename <ls_file>-sha1
+          INTO lv_buf
+          SEPARATED BY space.
+        APPEND lv_buf TO lt_buf_tab.
+
+      ENDLOOP.
+
+    ENDLOOP.
+
+    rv_string = concat_lines_of( table = lt_buf_tab sep = |\n| ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -215,4 +215,19 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
     save_checksums( lt_checksums ).
 
   ENDMETHOD.
+
+  METHOD zif_abapgit_repo_checksums~get_checksums_per_file.
+
+    DATA lt_checksums   TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    FIELD-SYMBOLS <ls_object> LIKE LINE OF lt_checksums.
+
+    lt_checksums = zif_abapgit_repo_checksums~get( ).
+
+    LOOP AT lt_checksums ASSIGNING <ls_object>.
+      APPEND LINES OF <ls_object>-files TO rt_checksums.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -123,13 +123,13 @@ CLASS zcl_abapgit_repo_checksums IMPLEMENTATION.
     DATA lt_remote    TYPE zif_abapgit_definitions=>ty_files_tt.
     DATA lt_local     TYPE ty_local_files_by_item_tt.
     DATA lt_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-    DATA lo_repo      TYPE REF TO zcl_abapgit_repo.
+    DATA li_repo      TYPE REF TO zif_abapgit_repo.
 
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( mv_repo_key ).
+    li_repo = zcl_abapgit_repo_srv=>get_instance( )->get( mv_repo_key ).
     " Should be safe as repo_srv is supposed to be single source of repo instances
 
-    lt_local  = lo_repo->get_files_local( ).
-    lt_remote = lo_repo->get_files_remote( ).
+    lt_local  = li_repo->get_files_local( ).
+    lt_remote = li_repo->get_files_remote( ).
 
     remove_non_code_related_files( CHANGING ct_local_files = lt_local ).
 

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -7,16 +7,39 @@ CLASS zcl_abapgit_repo_checksums DEFINITION
 
     INTERFACES zif_abapgit_repo_checksums.
 
+    METHODS constructor
+      IMPORTING
+        !iv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
-    CLASS-DATA c_splitter TYPE string VALUE `|`.
+    DATA mv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
+CLASS zcl_abapgit_repo_checksums IMPLEMENTATION.
 
+  METHOD constructor.
+    ASSERT iv_repo_key IS NOT INITIAL.
+    mv_repo_key = iv_repo_key.
+  ENDMETHOD.
 
+  METHOD zif_abapgit_repo_checksums~get.
+
+    DATA lv_cs_blob TYPE string.
+
+    TRY.
+        lv_cs_blob = zcl_abapgit_persist_factory=>get_repo_cs( )->read( iv_key = mv_repo_key ).
+      CATCH zcx_abapgit_exception zcx_abapgit_not_found.
+        " Ignore currently, it's not critical for execution, just return empty
+        RETURN.
+    ENDTRY.
+
+    IF lv_cs_blob IS NOT INITIAL.
+      rt_checksums = lcl_checksum_serializer=>deserialize( lv_cs_blob ).
+    ENDIF.
+
+  ENDMETHOD.
 
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -19,6 +19,7 @@ CLASS zcl_abapgit_repo_checksums DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+    CLASS-DATA c_splitter TYPE string VALUE `|`.
 ENDCLASS.
 
 
@@ -42,12 +43,12 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
 
       IF lv_buf+0(1) = '/'.
         IF <ls_cs> IS NOT ASSIGNED.
-          " Incorrect checksums struture, maybe raise, though it is not critical for execution
+          " Incorrect checksums structure, maybe raise, though it is not critical for execution
           RETURN.
         ENDIF.
 
         APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
-        SPLIT lv_buf AT space INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
+        SPLIT lv_buf AT c_splitter INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
 
         IF <ls_file>-path IS INITIAL OR <ls_file>-filename IS INITIAL OR <ls_file>-sha1 IS INITIAL..
           " Incorrect checksums struture, maybe raise, though it is not critical for execution
@@ -55,7 +56,7 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
         ENDIF.
       ELSE.
         APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_cs>.
-        SPLIT lv_buf AT space INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
+        SPLIT lv_buf AT c_splitter INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
 
         IF <ls_cs>-item-obj_type IS INITIAL OR <ls_cs>-item-obj_name IS INITIAL OR <ls_cs>-item-devclass IS INITIAL.
           " Incorrect checksums struture, maybe raise, though it is not critical for execution
@@ -82,14 +83,14 @@ CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
 
       CONCATENATE <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass
         INTO lv_buf
-        SEPARATED BY space.
+        SEPARATED BY c_splitter.
       APPEND lv_buf TO lt_buf_tab.
 
       LOOP AT <ls_cs>-files ASSIGNING <ls_file>.
 
         CONCATENATE <ls_file>-path <ls_file>-filename <ls_file>-sha1
           INTO lv_buf
-          SEPARATED BY space.
+          SEPARATED BY c_splitter.
         APPEND lv_buf TO lt_buf_tab.
 
       ENDLOOP.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -13,7 +13,30 @@ CLASS zcl_abapgit_repo_checksums DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    TYPES:
+      ty_local_files_by_item_tt TYPE SORTED TABLE OF zif_abapgit_definitions=>ty_file_item WITH NON-UNIQUE KEY item.
+
     DATA mv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key.
+
+    METHODS remove_non_code_related_files
+      CHANGING
+        !ct_local_files TYPE ty_local_files_by_item_tt.
+
+    METHODS build_checksums_from_files
+      IMPORTING
+        it_remote    TYPE zif_abapgit_definitions=>ty_files_tt
+        it_local     TYPE ty_local_files_by_item_tt
+        iv_branches_equal TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+
+    METHODS save_checksums
+      IMPORTING
+        it_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt
+      RAISING
+        zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -23,6 +46,59 @@ CLASS zcl_abapgit_repo_checksums IMPLEMENTATION.
   METHOD constructor.
     ASSERT iv_repo_key IS NOT INITIAL.
     mv_repo_key = iv_repo_key.
+  ENDMETHOD.
+
+  METHOD build_checksums_from_files.
+
+    DATA ls_last_item TYPE zif_abapgit_definitions=>ty_item.
+
+    FIELD-SYMBOLS:
+      <ls_checksum> LIKE LINE OF rt_checksums,
+      <ls_local>    LIKE LINE OF it_local.
+
+    FIELD-SYMBOLS:
+      <ls_remote_file> LIKE LINE OF it_remote,
+      <ls_cs_file_sig> LIKE LINE OF <ls_checksum>-files.
+
+    LOOP AT it_local ASSIGNING <ls_local>.
+      IF ls_last_item <> <ls_local>-item OR sy-tabix = 1. " First or New item reached ?
+        APPEND INITIAL LINE TO rt_checksums ASSIGNING <ls_checksum>.
+        <ls_checksum>-item = <ls_local>-item. " Assuming local-item type starts with item_signature !
+        ls_last_item       = <ls_local>-item.
+      ENDIF.
+
+      READ TABLE it_remote ASSIGNING <ls_remote_file>
+        WITH TABLE KEY file_path
+        COMPONENTS
+          path     = <ls_local>-file-path
+          filename = <ls_local>-file-filename.
+      IF sy-subrc <> 0.  " Ignore new local ones
+        CONTINUE.
+      ENDIF.
+
+      APPEND INITIAL LINE TO <ls_checksum>-files ASSIGNING <ls_cs_file_sig>.
+*      <ls_file_sig> = <ls_local>-file. " Assuming <ls_local> starts from file signature
+      MOVE-CORRESPONDING <ls_local>-file TO <ls_cs_file_sig>.
+
+      " If hashes are equal -> local sha1 is OK already (no change)
+      " Else
+      "   if branches equal -> assume changes were local, state - remote sha1
+      "   if remote branch is ahead (not equal) -> assume changes were remote, state - local sha1 (no change)
+      IF <ls_local>-file-sha1 <> <ls_remote_file>-sha1 AND iv_branches_equal = abap_true.
+        <ls_cs_file_sig>-sha1 = <ls_remote_file>-sha1.
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD remove_non_code_related_files.
+
+    DELETE ct_local_files
+      WHERE item IS INITIAL
+      AND NOT ( file-path = zif_abapgit_definitions=>c_root_dir
+      AND file-filename = zif_abapgit_definitions=>c_dot_abapgit ).
+
   ENDMETHOD.
 
   METHOD zif_abapgit_repo_checksums~get.
@@ -39,6 +115,41 @@ CLASS zcl_abapgit_repo_checksums IMPLEMENTATION.
     IF lv_cs_blob IS NOT INITIAL.
       rt_checksums = lcl_checksum_serializer=>deserialize( lv_cs_blob ).
     ENDIF.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_checksums~rebuild.
+
+    DATA lt_remote    TYPE zif_abapgit_definitions=>ty_files_tt.
+    DATA lt_local     TYPE ty_local_files_by_item_tt.
+    DATA lt_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    DATA lo_repo      TYPE REF TO zcl_abapgit_repo.
+
+    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( mv_repo_key ).
+    " Should be safe as repo_srv is supposed to be single source of repo instances
+
+    lt_local  = lo_repo->get_files_local( ).
+    lt_remote = lo_repo->get_files_remote( ).
+
+    remove_non_code_related_files( CHANGING ct_local_files = lt_local ).
+
+    lt_checksums = build_checksums_from_files(
+      it_remote         = lt_remote
+      it_local          = lt_local
+      iv_branches_equal = iv_branches_equal ).
+
+    save_checksums( lt_checksums ).
+
+  ENDMETHOD.
+
+  METHOD save_checksums.
+
+    DATA lv_cs_blob TYPE string.
+
+    lv_cs_blob = lcl_checksum_serializer=>serialize( it_checksums ).
+    zcl_abapgit_persist_factory=>get_repo_cs( )->update(
+      iv_key     = mv_repo_key
+      iv_cs_blob = lv_cs_blob ).
 
   ENDMETHOD.
 

--- a/src/repo/zcl_abapgit_repo_checksums.clas.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.abap
@@ -5,17 +5,8 @@ CLASS zcl_abapgit_repo_checksums DEFINITION
 
   PUBLIC SECTION.
 
-    METHODS serialize
-      IMPORTING
-        it_checksums     TYPE zif_abapgit_persistence=>ty_local_checksum_tt
-      RETURNING
-        VALUE(rv_string) TYPE string.
+    INTERFACES zif_abapgit_repo_checksums.
 
-    METHODS deserialize
-      IMPORTING
-        iv_string           TYPE string
-      RETURNING
-        VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -27,77 +18,5 @@ ENDCLASS.
 CLASS ZCL_ABAPGIT_REPO_CHECKSUMS IMPLEMENTATION.
 
 
-  METHOD deserialize.
 
-    DATA lt_buf_tab TYPE string_table.
-    DATA lv_buf TYPE string.
-    DATA lt_checksums LIKE rt_checksums.
-
-    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums.
-    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
-
-    SPLIT iv_string AT |\n| INTO TABLE lt_buf_tab.
-
-    LOOP AT lt_buf_tab INTO lv_buf.
-      CHECK lv_buf IS NOT INITIAL. " In fact this is a bug ... it cannot be empty, maybe raise
-
-      IF lv_buf+0(1) = '/'.
-        IF <ls_cs> IS NOT ASSIGNED.
-          " Incorrect checksums structure, maybe raise, though it is not critical for execution
-          RETURN.
-        ENDIF.
-
-        APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
-        SPLIT lv_buf AT c_splitter INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
-
-        IF <ls_file>-path IS INITIAL OR <ls_file>-filename IS INITIAL OR <ls_file>-sha1 IS INITIAL..
-          " Incorrect checksums struture, maybe raise, though it is not critical for execution
-          RETURN.
-        ENDIF.
-      ELSE.
-        APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_cs>.
-        SPLIT lv_buf AT c_splitter INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
-
-        IF <ls_cs>-item-obj_type IS INITIAL OR <ls_cs>-item-obj_name IS INITIAL OR <ls_cs>-item-devclass IS INITIAL.
-          " Incorrect checksums struture, maybe raise, though it is not critical for execution
-          RETURN.
-        ENDIF.
-
-      ENDIF.
-    ENDLOOP.
-
-    rt_checksums = lt_checksums.
-
-  ENDMETHOD.
-
-
-  METHOD serialize.
-
-    DATA lt_buf_tab TYPE string_table.
-    DATA lv_buf TYPE string.
-
-    FIELD-SYMBOLS <ls_cs> LIKE LINE OF it_checksums.
-    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
-
-    LOOP AT it_checksums ASSIGNING <ls_cs>.
-
-      CONCATENATE <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass
-        INTO lv_buf
-        SEPARATED BY c_splitter.
-      APPEND lv_buf TO lt_buf_tab.
-
-      LOOP AT <ls_cs>-files ASSIGNING <ls_file>.
-
-        CONCATENATE <ls_file>-path <ls_file>-filename <ls_file>-sha1
-          INTO lv_buf
-          SEPARATED BY c_splitter.
-        APPEND lv_buf TO lt_buf_tab.
-
-      ENDLOOP.
-
-    ENDLOOP.
-
-    rv_string = concat_lines_of( table = lt_buf_tab sep = |\n| ).
-
-  ENDMETHOD.
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
@@ -75,11 +75,15 @@ CLASS lcl_checksum_serializer IMPLEMENTATION.
 
     DATA lt_buf_tab TYPE string_table.
     DATA lv_buf TYPE string.
+    DATA lt_checksums_sorted LIKE it_checksums.
 
     FIELD-SYMBOLS <ls_cs> LIKE LINE OF it_checksums.
     FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
 
-    LOOP AT it_checksums ASSIGNING <ls_cs>.
+    lt_checksums_sorted = it_checksums.
+    SORT lt_checksums_sorted BY item.
+
+    LOOP AT lt_checksums_sorted ASSIGNING <ls_cs>.
 
       CONCATENATE <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass
         INTO lv_buf

--- a/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
@@ -100,7 +100,9 @@ CLASS lcl_checksum_serializer IMPLEMENTATION.
 
     ENDLOOP.
 
-    rv_string = concat_lines_of( table = lt_buf_tab sep = |\n| ).
+    rv_string = concat_lines_of(
+      table = lt_buf_tab
+      sep   = |\n| ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
@@ -4,7 +4,7 @@ CLASS lcl_checksum_serializer DEFINITION
 
   PUBLIC SECTION.
 
-    CLASS-DATA c_splitter TYPE string VALUE `|`.
+    CLASS-DATA gc_splitter TYPE string VALUE `|`.
 
     CLASS-METHODS serialize
       IMPORTING
@@ -48,15 +48,15 @@ CLASS lcl_checksum_serializer IMPLEMENTATION.
         ENDIF.
 
         APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
-        SPLIT lv_buf AT c_splitter INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
+        SPLIT lv_buf AT gc_splitter INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
 
-        IF <ls_file>-path IS INITIAL OR <ls_file>-filename IS INITIAL OR <ls_file>-sha1 IS INITIAL..
+        IF <ls_file>-path IS INITIAL OR <ls_file>-filename IS INITIAL OR <ls_file>-sha1 IS INITIAL.
           " Incorrect checksums struture, maybe raise, though it is not critical for execution
           RETURN.
         ENDIF.
       ELSE.
         APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_cs>.
-        SPLIT lv_buf AT c_splitter INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
+        SPLIT lv_buf AT gc_splitter INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
 
         IF <ls_cs>-item-obj_type IS INITIAL OR <ls_cs>-item-obj_name IS INITIAL OR <ls_cs>-item-devclass IS INITIAL.
           " Incorrect checksums struture, maybe raise, though it is not critical for execution
@@ -83,14 +83,14 @@ CLASS lcl_checksum_serializer IMPLEMENTATION.
 
       CONCATENATE <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass
         INTO lv_buf
-        SEPARATED BY c_splitter.
+        SEPARATED BY gc_splitter.
       APPEND lv_buf TO lt_buf_tab.
 
       LOOP AT <ls_cs>-files ASSIGNING <ls_file>.
 
         CONCATENATE <ls_file>-path <ls_file>-filename <ls_file>-sha1
           INTO lv_buf
-          SEPARATED BY c_splitter.
+          SEPARATED BY gc_splitter.
         APPEND lv_buf TO lt_buf_tab.
 
       ENDLOOP.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
@@ -75,13 +75,12 @@ CLASS lcl_checksum_serializer IMPLEMENTATION.
 
     DATA lt_buf_tab TYPE string_table.
     DATA lv_buf TYPE string.
-    DATA lt_checksums_sorted LIKE it_checksums.
+    DATA lt_checksums_sorted TYPE zif_abapgit_persistence=>ty_local_checksum_by_item_tt.
 
     FIELD-SYMBOLS <ls_cs> LIKE LINE OF it_checksums.
     FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
 
     lt_checksums_sorted = it_checksums.
-    SORT lt_checksums_sorted BY item.
 
     LOOP AT lt_checksums_sorted ASSIGNING <ls_cs>.
 
@@ -104,4 +103,145 @@ CLASS lcl_checksum_serializer IMPLEMENTATION.
     rv_string = concat_lines_of( table = lt_buf_tab sep = |\n| ).
 
   ENDMETHOD.
+ENDCLASS.
+
+**********************************************************************
+* UPDATE CALCULATOR
+**********************************************************************
+
+CLASS lcl_update_calculator DEFINITION
+  FINAL
+  CREATE PUBLIC.
+  PUBLIC SECTION.
+
+    CLASS-METHODS calculate_updated
+      IMPORTING
+        it_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+        it_current_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt
+        it_local_files TYPE zif_abapgit_definitions=>ty_files_item_tt
+      RETURNING
+        VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+
+  PRIVATE SECTION.
+
+    CLASS-METHODS process_updated_files
+      CHANGING
+        ct_update_index TYPE zif_abapgit_definitions=>ty_file_signatures_ts
+        ct_checksums    TYPE zif_abapgit_persistence=>ty_local_checksum_by_item_tt.
+
+    CLASS-METHODS add_new_files
+      IMPORTING
+        it_local        TYPE zif_abapgit_definitions=>ty_files_item_tt
+        it_update_index TYPE zif_abapgit_definitions=>ty_file_signatures_ts
+      CHANGING
+        ct_checksums    TYPE zif_abapgit_persistence=>ty_local_checksum_by_item_tt.
+
+ENDCLASS.
+
+CLASS lcl_update_calculator IMPLEMENTATION.
+
+  METHOD calculate_updated.
+
+    DATA lt_update_index TYPE zif_abapgit_definitions=>ty_file_signatures_ts.
+    DATA lt_checksums_sorted TYPE zif_abapgit_persistence=>ty_local_checksum_by_item_tt.
+
+    lt_checksums_sorted = it_current_checksums.
+    lt_update_index     = it_updated_files.
+
+    process_updated_files(
+      CHANGING
+        ct_update_index = lt_update_index
+        ct_checksums    = lt_checksums_sorted ).
+
+    add_new_files(
+      EXPORTING
+        it_update_index = lt_update_index
+        it_local        = it_local_files
+      CHANGING
+        ct_checksums    = lt_checksums_sorted ).
+
+    rt_checksums = lt_checksums_sorted.
+
+  ENDMETHOD.
+
+  METHOD process_updated_files.
+
+    DATA lv_cs_row  TYPE i.
+    DATA lv_file_row  TYPE i.
+
+    FIELD-SYMBOLS <ls_checksum>  LIKE LINE OF ct_checksums.
+    FIELD-SYMBOLS <ls_file>      LIKE LINE OF <ls_checksum>-files.
+    FIELD-SYMBOLS <ls_new_state> LIKE LINE OF ct_update_index.
+
+    " Loop through current checksum state, update sha1 for common files
+
+    LOOP AT ct_checksums ASSIGNING <ls_checksum>.
+      lv_cs_row = sy-tabix.
+
+      LOOP AT <ls_checksum>-files ASSIGNING <ls_file>.
+        lv_file_row = sy-tabix.
+
+        READ TABLE ct_update_index ASSIGNING <ls_new_state>
+          WITH KEY
+            path     = <ls_file>-path
+            filename = <ls_file>-filename.
+        IF sy-subrc <> 0.
+          CONTINUE. " Missing in updated files -> nothing to update, skip
+        ENDIF.
+
+        IF <ls_new_state>-sha1 IS INITIAL. " Empty input sha1 is a deletion marker
+          DELETE <ls_checksum>-files INDEX lv_file_row.
+        ELSE.
+          <ls_file>-sha1 = <ls_new_state>-sha1.  " Update sha1
+          CLEAR <ls_new_state>-sha1.             " Mark as processed
+        ENDIF.
+      ENDLOOP.
+
+      IF lines( <ls_checksum>-files ) = 0. " Remove empty objects
+        DELETE ct_checksums INDEX lv_cs_row.
+      ENDIF.
+    ENDLOOP.
+
+    DELETE ct_update_index WHERE sha1 IS INITIAL. " Remove processed
+
+  ENDMETHOD.
+
+  METHOD add_new_files.
+
+    DATA lt_local_sorted TYPE zif_abapgit_definitions=>ty_files_item_by_file_tt.
+    DATA ls_checksum LIKE LINE OF ct_checksums.
+    FIELD-SYMBOLS <ls_checksum> LIKE LINE OF ct_checksums.
+    FIELD-SYMBOLS <ls_new_file> LIKE LINE OF it_update_index.
+    FIELD-SYMBOLS <ls_local>    LIKE LINE OF lt_local_sorted.
+
+    lt_local_sorted = it_local.
+
+    " Add new files - not deleted and not marked as processed
+    LOOP AT it_update_index ASSIGNING <ls_new_file>.
+
+      READ TABLE lt_local_sorted ASSIGNING <ls_local>
+        WITH KEY
+          file-path     = <ls_new_file>-path
+          file-filename = <ls_new_file>-filename.
+      IF sy-subrc <> 0.
+        " The file should be in locals, however:
+        " if the deserialization fails, the local file might not be there
+        " in this case now new CS added, and the file will appear to be remote+new
+        CONTINUE.
+      ENDIF.
+
+      READ TABLE ct_checksums ASSIGNING <ls_checksum>
+        WITH KEY
+          item-obj_type = <ls_local>-item-obj_type
+          item-obj_name = <ls_local>-item-obj_name.
+      IF sy-subrc <> 0.
+        MOVE-CORRESPONDING <ls_local>-item TO ls_checksum-item.
+        INSERT ls_checksum INTO TABLE ct_checksums ASSIGNING <ls_checksum>.
+      ENDIF.
+
+      APPEND <ls_new_file> TO <ls_checksum>-files.
+    ENDLOOP.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.locals_imp.abap
@@ -1,0 +1,103 @@
+CLASS lcl_checksum_serializer DEFINITION
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-DATA c_splitter TYPE string VALUE `|`.
+
+    CLASS-METHODS serialize
+      IMPORTING
+        it_checksums     TYPE zif_abapgit_persistence=>ty_local_checksum_tt
+      RETURNING
+        VALUE(rv_string) TYPE string.
+
+    CLASS-METHODS deserialize
+      IMPORTING
+        iv_string           TYPE string
+      RETURNING
+        VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS lcl_checksum_serializer IMPLEMENTATION.
+
+
+  METHOD deserialize.
+
+    DATA lt_buf_tab TYPE string_table.
+    DATA lv_buf TYPE string.
+    DATA lt_checksums LIKE rt_checksums.
+
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums.
+    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
+
+    SPLIT iv_string AT |\n| INTO TABLE lt_buf_tab.
+
+    LOOP AT lt_buf_tab INTO lv_buf.
+      CHECK lv_buf IS NOT INITIAL. " In fact this is a bug ... it cannot be empty, maybe raise
+
+      IF lv_buf+0(1) = '/'.
+        IF <ls_cs> IS NOT ASSIGNED.
+          " Incorrect checksums structure, maybe raise, though it is not critical for execution
+          RETURN.
+        ENDIF.
+
+        APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
+        SPLIT lv_buf AT c_splitter INTO <ls_file>-path <ls_file>-filename <ls_file>-sha1.
+
+        IF <ls_file>-path IS INITIAL OR <ls_file>-filename IS INITIAL OR <ls_file>-sha1 IS INITIAL..
+          " Incorrect checksums struture, maybe raise, though it is not critical for execution
+          RETURN.
+        ENDIF.
+      ELSE.
+        APPEND INITIAL LINE TO lt_checksums ASSIGNING <ls_cs>.
+        SPLIT lv_buf AT c_splitter INTO <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass.
+
+        IF <ls_cs>-item-obj_type IS INITIAL OR <ls_cs>-item-obj_name IS INITIAL OR <ls_cs>-item-devclass IS INITIAL.
+          " Incorrect checksums struture, maybe raise, though it is not critical for execution
+          RETURN.
+        ENDIF.
+
+      ENDIF.
+    ENDLOOP.
+
+    rt_checksums = lt_checksums.
+
+  ENDMETHOD.
+
+
+  METHOD serialize.
+
+    DATA lt_buf_tab TYPE string_table.
+    DATA lv_buf TYPE string.
+
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF it_checksums.
+    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
+
+    LOOP AT it_checksums ASSIGNING <ls_cs>.
+
+      CONCATENATE <ls_cs>-item-obj_type <ls_cs>-item-obj_name <ls_cs>-item-devclass
+        INTO lv_buf
+        SEPARATED BY c_splitter.
+      APPEND lv_buf TO lt_buf_tab.
+
+      LOOP AT <ls_cs>-files ASSIGNING <ls_file>.
+
+        CONCATENATE <ls_file>-path <ls_file>-filename <ls_file>-sha1
+          INTO lv_buf
+          SEPARATED BY c_splitter.
+        APPEND lv_buf TO lt_buf_tab.
+
+      ENDLOOP.
+
+    ENDLOOP.
+
+    rv_string = concat_lines_of( table = lt_buf_tab sep = |\n| ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -1,3 +1,7 @@
+**********************************************************************
+* SERIALIZER
+**********************************************************************
+
 CLASS ltcl_test_checksum_serializer DEFINITION FINAL
   FOR TESTING
   DURATION SHORT
@@ -6,7 +10,7 @@ CLASS ltcl_test_checksum_serializer DEFINITION FINAL
     METHODS serialize FOR TESTING.
     METHODS deserialize FOR TESTING.
 
-    METHODS get_mock
+    CLASS-METHODS get_mock
       EXPORTING
         et_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt
         ev_str       TYPE string.
@@ -97,6 +101,65 @@ CLASS ltcl_test_checksum_serializer IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lt_checksums_act
       exp = lt_checksums_exp ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+**********************************************************************
+* CHECKSUMS
+**********************************************************************
+
+CLASS ltcl_test_checksums DEFINITION FINAL
+  FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_persist_repo_cs.
+
+    METHODS get FOR TESTING.
+
+ENDCLASS.
+
+CLASS ltcl_test_checksums IMPLEMENTATION.
+
+  METHOD get.
+
+    DATA li_cut TYPE REF TO zif_abapgit_repo_checksums.
+    DATA lt_checksums_exp TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums_exp.
+
+    zcl_abapgit_persist_injector=>set_repo_cs( me ).
+
+    ltcl_test_checksum_serializer=>get_mock( IMPORTING et_checksums = lt_checksums_exp ).
+    LOOP AT lt_checksums_exp ASSIGNING <ls_cs>.
+      CLEAR <ls_cs>-item-inactive.
+    ENDLOOP.
+
+    CREATE OBJECT li_cut TYPE zcl_abapgit_repo_checksums
+      EXPORTING
+        iv_repo_key = '1'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->get( )
+      exp = lt_checksums_exp ).
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_persist_repo_cs~delete.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_persist_repo_cs~read.
+
+    IF iv_key = '1'.
+      ltcl_test_checksum_serializer=>get_mock( IMPORTING ev_str = rv_cs_blob ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_persist_repo_cs~update.
 
   ENDMETHOD.
 

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -51,6 +51,9 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
       |DEVC $PKG $PKG\n| &&
       |/ $pkg.devc.xml hash3|.
 
+    ev_str = replace( val = ev_str sub = ` ` with = `|` occ = 0 ).
+    " This way it's easier to read and adjust ¯\_(ツ)_/¯
+
   ENDMETHOD.
 
   METHOD serialize.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -57,8 +57,7 @@ CLASS ltcl_test_checksum_serializer IMPLEMENTATION.
       |/ $pkg.devc.xml hash3\n| &&
       |PROG ZHELLO $PKG\n| &&
       |/ zhello.prog.abap hash1\n| &&
-      |/ zhello.prog.xml hash2|
-    ).
+      |/ zhello.prog.xml hash2| ).
 
   ENDMETHOD.
 

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -29,7 +29,6 @@ CLASS ltcl_test_checksum_serializer IMPLEMENTATION.
     <ls_cs>-item-devclass = '$PKG'.
     <ls_cs>-item-obj_type = 'PROG'.
     <ls_cs>-item-obj_name = 'ZHELLO'.
-    <ls_cs>-item-inactive = 'X'. " should not affect
     APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
     <ls_file>-path     = '/'.
     <ls_file>-filename = 'zhello.prog.abap'.
@@ -85,16 +84,10 @@ CLASS ltcl_test_checksum_serializer IMPLEMENTATION.
     DATA lt_checksums_act TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
     DATA lv_str TYPE string.
 
-    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums_exp.
-
     get_mock(
       IMPORTING
         et_checksums = lt_checksums_exp
         ev_str       = lv_str ).
-
-    LOOP AT lt_checksums_exp ASSIGNING <ls_cs>.
-      CLEAR <ls_cs>-item-inactive.
-    ENDLOOP.
 
     lt_checksums_act = lcl_checksum_serializer=>deserialize( lv_str ).
 
@@ -128,14 +121,10 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
     DATA li_cut TYPE REF TO zif_abapgit_repo_checksums.
     DATA lt_checksums_exp TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums_exp.
 
     zcl_abapgit_persist_injector=>set_repo_cs( me ).
 
     ltcl_test_checksum_serializer=>get_mock( IMPORTING et_checksums = lt_checksums_exp ).
-    LOOP AT lt_checksums_exp ASSIGNING <ls_cs>.
-      CLEAR <ls_cs>-item-inactive.
-    ENDLOOP.
 
     CREATE OBJECT li_cut TYPE zcl_abapgit_repo_checksums
       EXPORTING

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -1,0 +1,104 @@
+CLASS ltcl_test_checksums DEFINITION FINAL
+  FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+  PUBLIC SECTION.
+    METHODS serialize FOR TESTING.
+    METHODS deserialize FOR TESTING.
+
+    METHODS get_mock
+      EXPORTING
+        et_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt
+        ev_str       TYPE string.
+ENDCLASS.
+
+CLASS ltcl_test_checksums IMPLEMENTATION.
+
+  METHOD get_mock.
+
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF et_checksums.
+    FIELD-SYMBOLS <ls_file> LIKE LINE OF <ls_cs>-files.
+
+    CLEAR et_checksums.
+
+    APPEND INITIAL LINE TO et_checksums ASSIGNING <ls_cs>.
+    <ls_cs>-item-devclass = '$PKG'.
+    <ls_cs>-item-obj_type = 'PROG'.
+    <ls_cs>-item-obj_name = 'ZHELLO'.
+    <ls_cs>-item-inactive = 'X'. " should not affect
+    APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
+    <ls_file>-path     = '/'.
+    <ls_file>-filename = 'zhello.prog.abap'.
+    <ls_file>-sha1     = 'hash1'.
+    APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
+    <ls_file>-path     = '/'.
+    <ls_file>-filename = 'zhello.prog.xml'.
+    <ls_file>-sha1     = 'hash2'.
+
+    APPEND INITIAL LINE TO et_checksums ASSIGNING <ls_cs>.
+    <ls_cs>-item-devclass = '$PKG'.
+    <ls_cs>-item-obj_type = 'DEVC'.
+    <ls_cs>-item-obj_name = '$PKG'.
+    APPEND INITIAL LINE TO <ls_cs>-files ASSIGNING <ls_file>.
+    <ls_file>-path     = '/'.
+    <ls_file>-filename = '$pkg.devc.xml'.
+    <ls_file>-sha1     = 'hash3'.
+
+    ev_str =
+      |PROG ZHELLO $PKG\n| &&
+      |/ zhello.prog.abap hash1\n| &&
+      |/ zhello.prog.xml hash2\n| &&
+      |DEVC $PKG $PKG\n| &&
+      |/ $pkg.devc.xml hash3|.
+
+  ENDMETHOD.
+
+  METHOD serialize.
+
+    DATA lt_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    DATA lo_cs TYPE REF TO zcl_abapgit_repo_checksums.
+    DATA lv_act TYPE string.
+    DATA lv_exp TYPE string.
+
+    get_mock(
+      IMPORTING
+        et_checksums = lt_checksums
+        ev_str       = lv_exp ).
+
+    CREATE OBJECT lo_cs.
+    lv_act = lo_cs->serialize( lt_checksums ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_act
+      exp = lv_exp ).
+
+  ENDMETHOD.
+
+  METHOD deserialize.
+
+    DATA lt_checksums_exp TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    DATA lt_checksums_act TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+    DATA lo_cs TYPE REF TO zcl_abapgit_repo_checksums.
+    DATA lv_str TYPE string.
+
+    FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums_exp.
+
+    get_mock(
+      IMPORTING
+        et_checksums = lt_checksums_exp
+        ev_str       = lv_str ).
+
+    LOOP AT lt_checksums_exp ASSIGNING <ls_cs>.
+      CLEAR <ls_cs>-item-inactive.
+    ENDLOOP.
+
+    CREATE OBJECT lo_cs.
+    lt_checksums_act = lo_cs->deserialize( lv_str ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_checksums_act
+      exp = lt_checksums_exp ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -231,6 +231,8 @@ CLASS lcl_repo_mock IMPLEMENTATION.
   METHOD zif_abapgit_repo~get_name.
     rv_name = 'test'.
   ENDMETHOD.
+  METHOD zif_abapgit_repo~checksums.
+  ENDMETHOD.
 
   METHOD zif_abapgit_repo_srv~delete.
   ENDMETHOD.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -213,7 +213,7 @@ CLASS lcl_local_file_builder IMPLEMENTATION.
     DATA ls_item LIKE LINE OF mt_tab.
     DATA lv_tmp TYPE string.
     lv_tmp = iv_str.
-    condense lv_tmp.
+    CONDENSE lv_tmp.
     SPLIT lv_tmp AT space INTO
       ls_item-item-devclass
       ls_item-item-obj_type
@@ -236,7 +236,7 @@ CLASS lcl_remote_file_builder IMPLEMENTATION.
     DATA ls_item LIKE LINE OF mt_tab.
     DATA lv_tmp TYPE string.
     lv_tmp = iv_str.
-    condense lv_tmp.
+    CONDENSE lv_tmp.
     SPLIT lv_tmp AT space INTO
       ls_item-path
       ls_item-filename
@@ -256,7 +256,7 @@ CLASS lcl_file_sig_builder IMPLEMENTATION.
     DATA ls_item LIKE LINE OF mt_tab.
     DATA lv_tmp TYPE string.
     lv_tmp = iv_str.
-    condense lv_tmp.
+    CONDENSE lv_tmp.
     SPLIT lv_tmp AT space INTO
       ls_item-path
       ls_item-filename

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -55,7 +55,7 @@ CLASS ltcl_test_checksum_serializer IMPLEMENTATION.
       |/ $pkg.devc.xml hash3|.
 
     ev_str = replace( val = ev_str sub = ` ` with = `|` occ = 0 ).
-    " This way it's easier to read and adjust ¯\_(ツ)_/¯
+    " This way it's easier to read and adjust :)
 
   ENDMETHOD.
 

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -1,4 +1,4 @@
-CLASS ltcl_test_checksums DEFINITION FINAL
+CLASS ltcl_test_checksum_serializer DEFINITION FINAL
   FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS.
@@ -12,7 +12,7 @@ CLASS ltcl_test_checksums DEFINITION FINAL
         ev_str       TYPE string.
 ENDCLASS.
 
-CLASS ltcl_test_checksums IMPLEMENTATION.
+CLASS ltcl_test_checksum_serializer IMPLEMENTATION.
 
   METHOD get_mock.
 
@@ -59,7 +59,6 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
   METHOD serialize.
 
     DATA lt_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-    DATA lo_cs TYPE REF TO zcl_abapgit_repo_checksums.
     DATA lv_act TYPE string.
     DATA lv_exp TYPE string.
 
@@ -68,8 +67,7 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
         et_checksums = lt_checksums
         ev_str       = lv_exp ).
 
-    CREATE OBJECT lo_cs.
-    lv_act = lo_cs->serialize( lt_checksums ).
+    lv_act = lcl_checksum_serializer=>serialize( lt_checksums ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lv_act
@@ -81,7 +79,6 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
     DATA lt_checksums_exp TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
     DATA lt_checksums_act TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-    DATA lo_cs TYPE REF TO zcl_abapgit_repo_checksums.
     DATA lv_str TYPE string.
 
     FIELD-SYMBOLS <ls_cs> LIKE LINE OF lt_checksums_exp.
@@ -95,8 +92,7 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
       CLEAR <ls_cs>-item-inactive.
     ENDLOOP.
 
-    CREATE OBJECT lo_cs.
-    lt_checksums_act = lo_cs->deserialize( lv_str ).
+    lt_checksums_act = lcl_checksum_serializer=>deserialize( lv_str ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lt_checksums_act

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -111,10 +111,43 @@ CLASS ltcl_test_checksums DEFINITION FINAL
 
     INTERFACES zif_abapgit_persist_repo_cs.
 
+    DATA mv_last_update_key TYPE zif_abapgit_persistence=>ty_repo-key.
+    DATA mv_last_update_cs_blob TYPE zif_abapgit_persistence=>ty_content-data_str.
+
     METHODS get FOR TESTING.
-    METHODS rebuild. " FOR TESTING. TODO
+    METHODS rebuild_simple FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
+
+CLASS ltcl_repo_mock DEFINITION FINAL.
+  PUBLIC SECTION.
+    INTERFACES zif_abapgit_repo.
+    INTERFACES zif_abapgit_repo_srv.
+    DATA mt_local_files TYPE zif_abapgit_definitions=>ty_files_item_tt.
+    DATA mt_remote_files TYPE zif_abapgit_definitions=>ty_files_tt.
+ENDCLASS.
+
+CLASS ltcl_repo_mock IMPLEMENTATION.
+
+  METHOD zif_abapgit_repo_srv~get.
+    IF iv_key = '1'.
+      ri_repo = me.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_files_local.
+    rt_files = mt_local_files.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_files_remote.
+    rt_files = mt_remote_files.
+  ENDMETHOD.
+
+ENDCLASS.
+
+**********************************************************************
+* CHECKSUMS UT
+**********************************************************************
 
 CLASS ltcl_test_checksums IMPLEMENTATION.
 
@@ -137,10 +170,82 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD rebuild.
+  METHOD rebuild_simple.
 
-    " TODO: but needs extraction of zif_repo first
-    " Now repo srv INTERFACE returns repo CLASS INSTANCE (?!)
+    DATA lo_mock TYPE REF TO ltcl_repo_mock.
+    DATA li_cut TYPE REF TO zif_abapgit_repo_checksums.
+    DATA lv_cs_exp TYPE string.
+    DATA ls_l_item LIKE LINE OF lo_mock->mt_local_files.
+    DATA ls_r_file LIKE LINE OF lo_mock->mt_remote_files.
+
+    CREATE OBJECT lo_mock.
+
+    zcl_abapgit_repo_srv=>inject_instance( lo_mock ).
+    zcl_abapgit_persist_injector=>set_repo_cs( me ).
+
+    " Local
+
+    ls_l_item-item-devclass = '$PKG'.
+    ls_l_item-item-obj_type = 'PROG'.
+    ls_l_item-item-obj_name = 'ZHELLO'.
+    ls_l_item-file-path     = '/'.
+    ls_l_item-file-filename = 'zhello.prog.abap'.
+    ls_l_item-file-sha1     = 'hash1'.
+    APPEND ls_l_item TO lo_mock->mt_local_files.
+
+    ls_l_item-item-devclass = '$PKG'.
+    ls_l_item-item-obj_type = 'PROG'.
+    ls_l_item-item-obj_name = 'ZHELLO'.
+    ls_l_item-file-path     = '/'.
+    ls_l_item-file-filename = 'zhello.prog.xml'.
+    ls_l_item-file-sha1     = 'hash2'.
+    APPEND ls_l_item TO lo_mock->mt_local_files.
+
+    ls_l_item-item-devclass = '$PKG'.
+    ls_l_item-item-obj_type = 'DEVC'.
+    ls_l_item-item-obj_name = '$PKG'.
+    ls_l_item-file-path     = '/'.
+    ls_l_item-file-filename = '$pkg.devc.xml'.
+    ls_l_item-file-sha1     = 'hash3'.
+    APPEND ls_l_item TO lo_mock->mt_local_files.
+
+    " Remote
+
+    ls_r_file-path     = '/'.
+    ls_r_file-filename = 'zhello.prog.abap'.
+    ls_r_file-sha1     = 'hash1'.
+    APPEND ls_r_file TO lo_mock->mt_remote_files.
+
+    ls_r_file-path     = '/'.
+    ls_r_file-filename = 'zhello.prog.xml'.
+    ls_r_file-sha1     = 'hash2'.
+    APPEND ls_r_file TO lo_mock->mt_remote_files.
+
+    ls_r_file-path     = '/'.
+    ls_r_file-filename = '$pkg.devc.xml'.
+    ls_r_file-sha1     = 'hash3'.
+    APPEND ls_r_file TO lo_mock->mt_remote_files.
+
+    lv_cs_exp = replace( sub = ` ` with = `|` occ = 0 val =
+      |DEVC $PKG $PKG\n| &&
+      |/ $pkg.devc.xml hash3\n| &&
+      |PROG ZHELLO $PKG\n| &&
+      |/ zhello.prog.abap hash1\n| &&
+      |/ zhello.prog.xml hash2|
+    ).
+
+    CREATE OBJECT li_cut TYPE zcl_abapgit_repo_checksums
+      EXPORTING
+        iv_repo_key = '1'.
+
+    li_cut->rebuild( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mv_last_update_key
+      exp = '1' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mv_last_update_cs_blob
+      exp = lv_cs_exp ).
 
   ENDMETHOD.
 
@@ -157,9 +262,8 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_persist_repo_cs~update.
-
+    mv_last_update_key     = iv_key.
+    mv_last_update_cs_blob = iv_cs_blob.
   ENDMETHOD.
-
-
 
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -138,7 +138,7 @@ ENDCLASS.
 * HELPERS
 **********************************************************************
 
-CLASS ltcl_repo_mock DEFINITION FINAL.
+CLASS lcl_repo_mock DEFINITION FINAL.
   PUBLIC SECTION.
     INTERFACES zif_abapgit_repo.
     INTERFACES zif_abapgit_repo_srv.
@@ -146,7 +146,7 @@ CLASS ltcl_repo_mock DEFINITION FINAL.
     DATA mt_remote_files TYPE zif_abapgit_definitions=>ty_files_tt.
 ENDCLASS.
 
-CLASS ltcl_repo_mock IMPLEMENTATION.
+CLASS lcl_repo_mock IMPLEMENTATION.
 
   METHOD zif_abapgit_repo_srv~get.
     IF iv_key = '1'.
@@ -202,13 +202,13 @@ CLASS ltcl_repo_mock IMPLEMENTATION.
   ENDMETHOD.
 ENDCLASS.
 
-CLASS ltcl_local_file_builder DEFINITION FINAL.
+CLASS lcl_local_file_builder DEFINITION FINAL.
   PUBLIC SECTION.
     DATA mt_tab TYPE zif_abapgit_definitions=>ty_files_item_tt.
-    METHODS add IMPORTING iv_str TYPE STRING.
+    METHODS add IMPORTING iv_str TYPE string.
 ENDCLASS.
 
-CLASS ltcl_local_file_builder IMPLEMENTATION.
+CLASS lcl_local_file_builder IMPLEMENTATION.
   METHOD add.
     DATA ls_item LIKE LINE OF mt_tab.
     DATA lv_tmp TYPE string.
@@ -225,13 +225,13 @@ CLASS ltcl_local_file_builder IMPLEMENTATION.
   ENDMETHOD.
 ENDCLASS.
 
-CLASS ltcl_remote_file_builder DEFINITION FINAL.
+CLASS lcl_remote_file_builder DEFINITION FINAL.
   PUBLIC SECTION.
     DATA mt_tab TYPE zif_abapgit_definitions=>ty_files_tt.
-    METHODS add IMPORTING iv_str TYPE STRING.
+    METHODS add IMPORTING iv_str TYPE string.
 ENDCLASS.
 
-CLASS ltcl_remote_file_builder IMPLEMENTATION.
+CLASS lcl_remote_file_builder IMPLEMENTATION.
   METHOD add.
     DATA ls_item LIKE LINE OF mt_tab.
     DATA lv_tmp TYPE string.
@@ -245,13 +245,13 @@ CLASS ltcl_remote_file_builder IMPLEMENTATION.
   ENDMETHOD.
 ENDCLASS.
 
-CLASS ltcl_file_sig_builder DEFINITION FINAL.
+CLASS lcl_file_sig_builder DEFINITION FINAL.
   PUBLIC SECTION.
     DATA mt_tab TYPE zif_abapgit_definitions=>ty_file_signatures_tt.
-    METHODS add IMPORTING iv_str TYPE STRING.
+    METHODS add IMPORTING iv_str TYPE string.
 ENDCLASS.
 
-CLASS ltcl_file_sig_builder IMPLEMENTATION.
+CLASS lcl_file_sig_builder IMPLEMENTATION.
   METHOD add.
     DATA ls_item LIKE LINE OF mt_tab.
     DATA lv_tmp TYPE string.
@@ -273,7 +273,7 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
   METHOD get.
 
-    DATA lo_mock TYPE REF TO ltcl_repo_mock.
+    DATA lo_mock TYPE REF TO lcl_repo_mock.
     DATA li_cut TYPE REF TO zif_abapgit_repo_checksums.
     DATA lt_checksums_exp TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
 
@@ -295,11 +295,11 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
   METHOD rebuild_simple.
 
-    DATA lo_mock TYPE REF TO ltcl_repo_mock.
+    DATA lo_mock TYPE REF TO lcl_repo_mock.
     DATA li_cut TYPE REF TO zif_abapgit_repo_checksums.
     DATA lv_cs_exp TYPE string.
-    DATA lo_l_builder TYPE REF TO ltcl_local_file_builder.
-    DATA lo_r_builder TYPE REF TO ltcl_remote_file_builder.
+    DATA lo_l_builder TYPE REF TO lcl_local_file_builder.
+    DATA lo_r_builder TYPE REF TO lcl_remote_file_builder.
 
     CREATE OBJECT lo_mock.
     zcl_abapgit_repo_srv=>inject_instance( lo_mock ).
@@ -331,8 +331,7 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
       |/ $pkg.devc.xml hash3\n| &&
       |PROG ZHELLO $PKG\n| &&
       |/ zhello.prog.abap hash1\n| &&
-      |/ zhello.prog.xml hash2|
-    ).
+      |/ zhello.prog.xml hash2| ).
     cl_abap_unit_assert=>assert_equals(
       act = mv_last_update_key
       exp = '1' ).
@@ -344,10 +343,10 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
   METHOD update_simple.
 
-    DATA lo_mock TYPE REF TO ltcl_repo_mock.
+    DATA lo_mock TYPE REF TO lcl_repo_mock.
     DATA li_cut TYPE REF TO zif_abapgit_repo_checksums.
     DATA lv_cs_exp TYPE string.
-    DATA lo_f_builder TYPE REF TO ltcl_file_sig_builder.
+    DATA lo_f_builder TYPE REF TO lcl_file_sig_builder.
 
     CREATE OBJECT lo_mock.
 
@@ -370,8 +369,7 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
       |/ $pkg.devc.xml hash3\n| &&
       |PROG ZHELLO $PKG\n| &&
       |/ zhello.prog.abap hash1\n| &&
-      |/ zhello.prog.xml hashNEW|
-    ).
+      |/ zhello.prog.xml hashNEW| ).
     cl_abap_unit_assert=>assert_equals(
       act = mv_last_update_key
       exp = '1' ).
@@ -423,8 +421,8 @@ CLASS ltcl_update_calculator_test IMPLEMENTATION.
     DATA lt_cs_current TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
     DATA lt_cs_exp TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
     DATA lt_cs_act TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
-    DATA lo_l_builder TYPE REF TO ltcl_local_file_builder.
-    DATA lo_f_builder TYPE REF TO ltcl_file_sig_builder.
+    DATA lo_l_builder TYPE REF TO lcl_local_file_builder.
+    DATA lo_f_builder TYPE REF TO lcl_file_sig_builder.
 
     CREATE OBJECT lo_f_builder.
     lo_f_builder->add( '/ zhello.prog.abap hash1' ).
@@ -440,16 +438,14 @@ CLASS ltcl_update_calculator_test IMPLEMENTATION.
       |/ $pkg.devc.xml hash3\n| &&
       |PROG ZHELLO $PKG\n| &&
       |/ zhello.prog.abap hash1\n| &&
-      |/ zhello.prog.xml hash2|
-    ) ).
+      |/ zhello.prog.xml hash2| ) ).
 
     lt_cs_exp = lcl_checksum_serializer=>deserialize( ltcl_test_checksum_serializer=>space_to_separator(
       |DEVC $PKG $PKG\n| &&
       |/ $pkg.devc.xml hash3\n| &&
       |PROG ZHELLO $PKG\n| &&
       |/ zhello.prog.abap hash1\n| &&
-      |/ zhello.prog.xml hashNEW|
-    ) ).
+      |/ zhello.prog.xml hashNEW| ) ).
 
     lt_cs_act = lcl_update_calculator=>calculate_updated(
       it_current_checksums = lt_cs_current

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -112,6 +112,7 @@ CLASS ltcl_test_checksums DEFINITION FINAL
     INTERFACES zif_abapgit_persist_repo_cs.
 
     METHODS get FOR TESTING.
+    METHODS rebuild. " FOR TESTING. TODO
 
 ENDCLASS.
 
@@ -136,6 +137,13 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD rebuild.
+
+    " TODO: but needs extraction of zif_repo first
+    " Now repo srv INTERFACE returns repo CLASS INSTANCE (?!)
+
+  ENDMETHOD.
+
   METHOD zif_abapgit_persist_repo_cs~delete.
 
   ENDMETHOD.
@@ -151,5 +159,7 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
   METHOD zif_abapgit_persist_repo_cs~update.
 
   ENDMETHOD.
+
+
 
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -162,6 +162,40 @@ CLASS ltcl_repo_mock IMPLEMENTATION.
     rt_files = mt_remote_files.
   ENDMETHOD.
 
+  METHOD zif_abapgit_repo_srv~delete.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo~get_key.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo~get_local_settings.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo~get_name.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo~get_package.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~get_repo_from_package.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~get_repo_from_url.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo~is_offline.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~is_repo_installed.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~list.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~list_favorites.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~new_offline.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~new_online.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~purge.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo~refresh.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~validate_package.
+  ENDMETHOD.
+  METHOD zif_abapgit_repo_srv~validate_url.
+  ENDMETHOD.
 ENDCLASS.
 
 CLASS ltcl_local_file_builder DEFINITION FINAL.
@@ -316,7 +350,6 @@ CLASS ltcl_test_checksums IMPLEMENTATION.
     CREATE OBJECT lo_f_builder.
     lo_f_builder->add( '/ zhello.prog.abap hash1' ).
     lo_f_builder->add( '/ zhello.prog.xml  hashNEW' ).
-*    lo_f_builder->add( '/ $pkg.devc.xml    hash3' ).
 
     CREATE OBJECT li_cut TYPE zcl_abapgit_repo_checksums
       EXPORTING

--- a/src/repo/zcl_abapgit_repo_checksums.clas.xml
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_REPO_CHECKSUMS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit repo files checksum utility</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/repo/zcl_abapgit_repo_cs_migration.clas.abap
+++ b/src/repo/zcl_abapgit_repo_cs_migration.clas.abap
@@ -1,0 +1,113 @@
+CLASS zcl_abapgit_repo_cs_migration DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    CLASS-METHODS run
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_not_found.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    TYPES:
+      tty_repo_ids TYPE SORTED TABLE OF zabapgit-value WITH UNIQUE KEY table_line.
+
+    CLASS-METHODS get_unconverted_repo_ids
+      RETURNING
+        VALUE(rt_repo_ids) TYPE tty_repo_ids.
+    CLASS-METHODS clear_repo_metadata
+      IMPORTING
+        iv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_not_found.
+    CLASS-METHODS convert_checksums
+      IMPORTING
+        iv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_not_found.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_REPO_CS_MIGRATION IMPLEMENTATION.
+
+
+  METHOD clear_repo_metadata.
+
+      DATA lo_repo_persistence TYPE REF TO zcl_abapgit_persistence_repo.
+
+      lo_repo_persistence ?= zcl_abapgit_persist_factory=>get_repo( ).
+      lo_repo_persistence->rewrite_repo_meta( iv_repo_key ).
+
+  ENDMETHOD.
+
+
+  METHOD convert_checksums.
+
+    DATA lo_cs TYPE REF TO zcl_abapgit_repo_checksums.
+    DATA lv_xml TYPE zif_abapgit_persistence=>ty_content-data_str.
+    DATA:
+      BEGIN OF ls_repo_extract,
+        local_checksums TYPE zif_abapgit_persistence=>ty_local_checksum_tt,
+      END OF ls_repo_extract.
+
+    lv_xml = zcl_abapgit_persistence_db=>get_instance( )->read(
+      iv_type  = zcl_abapgit_persistence_db=>c_type_repo
+      iv_value = iv_repo_key ).
+
+    REPLACE ALL OCCURRENCES OF '<_--28C_TYPE_REPO_--29>' IN lv_xml WITH '<REPO>'.
+    REPLACE ALL OCCURRENCES OF '</_--28C_TYPE_REPO_--29>' IN lv_xml WITH '</REPO>'.
+
+    CALL TRANSFORMATION id
+      OPTIONS value_handling = 'accept_data_loss'
+      SOURCE XML lv_xml
+      RESULT repo = ls_repo_extract.
+
+    IF lines( ls_repo_extract-local_checksums ) = 0.
+      RETURN.
+    ENDIF.
+
+    CREATE OBJECT lo_cs EXPORTING iv_repo_key = iv_repo_key.
+    lo_cs->force_write( ls_repo_extract-local_checksums ).
+
+  ENDMETHOD.
+
+
+  METHOD get_unconverted_repo_ids.
+
+    DATA lt_cs_ids TYPE tty_repo_ids.
+    DATA lv_repo_id LIKE LINE OF rt_repo_ids.
+    DATA lv_index TYPE i.
+
+    SELECT value FROM zabapgit INTO TABLE rt_repo_ids WHERE type = zcl_abapgit_persistence_db=>c_type_repo.
+    SELECT value FROM zabapgit INTO TABLE lt_cs_ids WHERE type = zcl_abapgit_persistence_db=>c_type_repo_csum.
+
+    LOOP AT rt_repo_ids INTO lv_repo_id.
+      lv_index = sy-tabix.
+      READ TABLE lt_cs_ids TRANSPORTING NO FIELDS WITH KEY table_line = lv_repo_id.
+      IF sy-subrc = 0. " Already converted
+        DELETE rt_repo_ids INDEX lv_index.
+      ENDIF.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD run.
+
+    DATA lt_repo_ids TYPE tty_repo_ids.
+    DATA lv_repo_id LIKE LINE OF lt_repo_ids.
+
+    lt_repo_ids = get_unconverted_repo_ids( ).
+
+    LOOP AT lt_repo_ids INTO lv_repo_id.
+      convert_checksums( lv_repo_id ).
+      clear_repo_metadata( lv_repo_id ).
+    ENDLOOP.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/repo/zcl_abapgit_repo_cs_migration.clas.abap
+++ b/src/repo/zcl_abapgit_repo_cs_migration.clas.abap
@@ -11,11 +11,11 @@ CLASS zcl_abapgit_repo_cs_migration DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES:
-      tty_repo_ids TYPE SORTED TABLE OF zif_abapgit_persistence=>ty_repo-key WITH UNIQUE KEY table_line.
+      ty_repo_ids TYPE SORTED TABLE OF zif_abapgit_persistence=>ty_repo-key WITH UNIQUE KEY table_line.
 
     CLASS-METHODS get_unconverted_repo_ids
       RETURNING
-        VALUE(rt_repo_ids) TYPE tty_repo_ids.
+        VALUE(rt_repo_ids) TYPE ty_repo_ids.
     CLASS-METHODS clear_repo_metadata
       IMPORTING
         iv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -38,10 +38,10 @@ CLASS ZCL_ABAPGIT_REPO_CS_MIGRATION IMPLEMENTATION.
 
   METHOD clear_repo_metadata.
 
-      DATA lo_repo_persistence TYPE REF TO zcl_abapgit_persistence_repo.
+    DATA lo_repo_persistence TYPE REF TO zcl_abapgit_persistence_repo.
 
-      lo_repo_persistence ?= zcl_abapgit_persist_factory=>get_repo( ).
-      lo_repo_persistence->rewrite_repo_meta( iv_repo_key ).
+    lo_repo_persistence ?= zcl_abapgit_persist_factory=>get_repo( ).
+    lo_repo_persistence->rewrite_repo_meta( iv_repo_key ).
 
   ENDMETHOD.
 
@@ -79,12 +79,16 @@ CLASS ZCL_ABAPGIT_REPO_CS_MIGRATION IMPLEMENTATION.
 
   METHOD get_unconverted_repo_ids.
 
-    DATA lt_cs_ids TYPE tty_repo_ids.
+    DATA lt_cs_ids TYPE ty_repo_ids.
     DATA lv_repo_id LIKE LINE OF rt_repo_ids.
     DATA lv_index TYPE i.
 
-    SELECT value FROM zabapgit INTO TABLE rt_repo_ids WHERE type = zcl_abapgit_persistence_db=>c_type_repo.
-    SELECT value FROM zabapgit INTO TABLE lt_cs_ids WHERE type = zcl_abapgit_persistence_db=>c_type_repo_csum.
+    SELECT value FROM (zcl_abapgit_persistence_db=>c_tabname)
+      INTO TABLE rt_repo_ids
+      WHERE type = zcl_abapgit_persistence_db=>c_type_repo.
+    SELECT value FROM (zcl_abapgit_persistence_db=>c_tabname)
+      INTO TABLE lt_cs_ids
+      WHERE type = zcl_abapgit_persistence_db=>c_type_repo_csum.
 
     LOOP AT rt_repo_ids INTO lv_repo_id.
       lv_index = sy-tabix.
@@ -99,7 +103,7 @@ CLASS ZCL_ABAPGIT_REPO_CS_MIGRATION IMPLEMENTATION.
 
   METHOD run.
 
-    DATA lt_repo_ids TYPE tty_repo_ids.
+    DATA lt_repo_ids TYPE ty_repo_ids.
     DATA lv_repo_id LIKE LINE OF lt_repo_ids.
 
     lt_repo_ids = get_unconverted_repo_ids( ).

--- a/src/repo/zcl_abapgit_repo_cs_migration.clas.abap
+++ b/src/repo/zcl_abapgit_repo_cs_migration.clas.abap
@@ -11,7 +11,7 @@ CLASS zcl_abapgit_repo_cs_migration DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES:
-      tty_repo_ids TYPE SORTED TABLE OF zabapgit-value WITH UNIQUE KEY table_line.
+      tty_repo_ids TYPE SORTED TABLE OF zif_abapgit_persistence=>ty_repo-key WITH UNIQUE KEY table_line.
 
     CLASS-METHODS get_unconverted_repo_ids
       RETURNING

--- a/src/repo/zcl_abapgit_repo_cs_migration.clas.xml
+++ b/src/repo/zcl_abapgit_repo_cs_migration.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_REPO_CS_MIGRATION</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit repo checksums migration</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/repo/zcl_abapgit_repo_online.clas.abap
+++ b/src/repo/zcl_abapgit_repo_online.clas.abap
@@ -75,7 +75,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_online IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
 
   METHOD check_and_create_package.
@@ -313,7 +313,7 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     mv_current_commit = ls_push-branch.
 
-    update_local_checksums( ls_push-updated_files ).
+    zif_abapgit_repo~checksums( )->update( ls_push-updated_files ).
 
     reset_status( ).
 

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -11,6 +11,10 @@ CLASS zcl_abapgit_repo_srv DEFINITION
     CLASS-METHODS get_instance
       RETURNING
         VALUE(ri_srv) TYPE REF TO zif_abapgit_repo_srv .
+    CLASS-METHODS inject_instance
+      IMPORTING
+        ii_srv TYPE REF TO zif_abapgit_repo_srv.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -130,6 +134,9 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
     ri_srv = gi_ref.
   ENDMETHOD.
 
+  METHOD inject_instance.
+    gi_ref = ii_srv.
+  ENDMETHOD.
 
   METHOD instantiate_and_add.
 

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -305,6 +305,7 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
   METHOD zif_abapgit_repo_srv~delete.
 
     zcl_abapgit_persist_factory=>get_repo( )->delete( ii_repo->get_key( ) ).
+    zcl_abapgit_persist_factory=>get_repo_cs( )->delete( ii_repo->get_key( ) ).
 
     " If favorite, remove it
     IF zcl_abapgit_persistence_user=>get_instance( )->is_favorite_repo( ii_repo->get_key( ) ) = abap_true.

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -63,4 +63,10 @@ INTERFACE zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
 
+  METHODS checksums
+    RETURNING
+      VALUE(ri_checksums) TYPE REF TO zif_abapgit_repo_checksums
+    RAISING
+      zcx_abapgit_exception .
+
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo_checksums.intf.abap
+++ b/src/repo/zif_abapgit_repo_checksums.intf.abap
@@ -5,4 +5,10 @@ INTERFACE zif_abapgit_repo_checksums
     RETURNING
       VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
 
+  METHODS rebuild
+    IMPORTING
+      iv_branches_equal TYPE abap_bool DEFAULT abap_false
+    RAISING
+      zcx_abapgit_exception.
+
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo_checksums.intf.abap
+++ b/src/repo/zif_abapgit_repo_checksums.intf.abap
@@ -1,4 +1,8 @@
 INTERFACE zif_abapgit_repo_checksums
   PUBLIC.
 
+  METHODS get
+    RETURNING
+      VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
+
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo_checksums.intf.abap
+++ b/src/repo/zif_abapgit_repo_checksums.intf.abap
@@ -1,0 +1,4 @@
+INTERFACE zif_abapgit_repo_checksums
+  PUBLIC.
+
+ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo_checksums.intf.abap
+++ b/src/repo/zif_abapgit_repo_checksums.intf.abap
@@ -5,6 +5,10 @@ INTERFACE zif_abapgit_repo_checksums
     RETURNING
       VALUE(rt_checksums) TYPE zif_abapgit_persistence=>ty_local_checksum_tt.
 
+  METHODS get_checksums_per_file
+    RETURNING
+      VALUE(rt_checksums) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
+
   METHODS rebuild
     IMPORTING
       iv_branches_equal TYPE abap_bool DEFAULT abap_false

--- a/src/repo/zif_abapgit_repo_checksums.intf.abap
+++ b/src/repo/zif_abapgit_repo_checksums.intf.abap
@@ -11,4 +11,10 @@ INTERFACE zif_abapgit_repo_checksums
     RAISING
       zcx_abapgit_exception.
 
+  METHODS update
+    IMPORTING
+      !it_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+    RAISING
+      zcx_abapgit_exception.
+
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo_checksums.intf.xml
+++ b/src/repo/zif_abapgit_repo_checksums.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_REPO_CHECKSUMS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit repo checksums interface</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/db/zcl_abapgit_gui_page_db.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db.clas.abap
@@ -150,6 +150,7 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
           ls_match  TYPE submatch_result,
           lv_cnt    TYPE i.
 
+    DATA lt_lines TYPE string_table.
 
     CASE is_data-type.
       WHEN zcl_abapgit_persistence_db=>c_type_repo.
@@ -186,6 +187,20 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
         rv_text = 'Global Settings'.
       WHEN zcl_abapgit_persistence_db=>c_type_packages.
         rv_text = 'Local Package Details'.
+      WHEN zcl_abapgit_persistence_db=>c_type_repo_csum.
+        IF strlen( is_data-data_str ) > 0.
+          SPLIT is_data-data_str AT cl_abap_char_utilities=>newline INTO TABLE lt_lines.
+          READ TABLE lt_lines INDEX 1 INTO rv_text.
+          rv_text = |{ rv_text } ({ lines( lt_lines ) } lines)|.
+
+          IF strlen( rv_text ) >= 250.
+            rv_text = rv_text(250).
+          ENDIF.
+          rv_text = escape(
+            val    = rv_text
+            format = cl_abap_format=>e_html_attr ).
+        ENDIF.
+
       WHEN OTHERS.
         IF strlen( is_data-data_str ) >= 250.
           rv_text = is_data-data_str(250).

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -95,7 +95,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
     CLASS-METHODS render_repo_palette
       IMPORTING
         iv_action         TYPE string
-        iv_only_favorites TYPE abap_bool
       RETURNING
         VALUE(ri_html)    TYPE REF TO zif_abapgit_html
       RAISING
@@ -199,7 +198,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
 
   METHOD advanced_submenu.
@@ -803,11 +802,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       <ls_repo>     LIKE LINE OF lt_repo_list,
       <lr_repo_obj> LIKE LINE OF lt_repo_obj_list.
 
-    IF iv_only_favorites = abap_true.
-      lt_repo_obj_list = zcl_abapgit_repo_srv=>get_instance( )->list_favorites( ).
-    ELSE.
-      lt_repo_obj_list = zcl_abapgit_repo_srv=>get_instance( )->list( ).
-    ENDIF.
+    lt_repo_obj_list = zcl_abapgit_repo_srv=>get_instance( )->list( ).
 
     LOOP AT lt_repo_obj_list ASSIGNING <lr_repo_obj>.
       ls_repo_data = <lr_repo_obj>->ms_data.

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -85,8 +85,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
 
     ri_html->add( mo_repo_overview->zif_abapgit_gui_renderable~render( ) ).
 
-    register_deferred_script( zcl_abapgit_gui_chunk_lib=>render_repo_palette(
-      iv_action = c_actions-select ) ).
+    register_deferred_script( zcl_abapgit_gui_chunk_lib=>render_repo_palette( c_actions-select ) ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -37,7 +37,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
 
 
   METHOD build_main_menu.
@@ -86,8 +86,7 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
     ri_html->add( mo_repo_overview->zif_abapgit_gui_renderable~render( ) ).
 
     register_deferred_script( zcl_abapgit_gui_chunk_lib=>render_repo_palette(
-      iv_action = c_actions-select
-      iv_only_favorites = mv_only_favorites ) ).
+      iv_action = c_actions-select ) ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -189,7 +189,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -1256,8 +1256,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     ri_html->set_title( cl_abap_typedescr=>describe_by_object_ref( me )->get_relative_name( ) ).
     ri_html->add( zcl_abapgit_gui_chunk_lib=>render_repo_palette(
-      iv_action = zif_abapgit_definitions=>c_action-go_repo
-      iv_only_favorites = abap_true ) ).
+      iv_action = zif_abapgit_definitions=>c_action-go_repo ) ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -216,7 +216,8 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       iv_main_lang_only = is_repo_params-main_lang_only ).
 
     " Make sure there're no leftovers from previous repos
-    ro_repo->rebuild_local_checksums( ).
+    ro_repo->zif_abapgit_repo~checksums( )->rebuild( ).
+    ro_repo->reset_status( ). " TODO refactor later
 
     toggle_favorite( ro_repo->get_key( ) ).
 
@@ -243,7 +244,8 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       iv_main_lang_only = is_repo_params-main_lang_only ).
 
     " Make sure there're no leftovers from previous repos
-    ro_repo->rebuild_local_checksums( ).
+    ro_repo->zif_abapgit_repo~checksums( )->rebuild( ).
+    ro_repo->reset_status( ). " TODO refactor later
 
     toggle_favorite( ro_repo->get_key( ) ).
 
@@ -528,7 +530,8 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
     ENDIF.
 
-    lo_repo->rebuild_local_checksums( ).
+    lo_repo->zif_abapgit_repo~checksums( )->rebuild( ).
+    lo_repo->reset_status( ). " TODO refactor later
 
     COMMIT WORK AND WAIT.
 

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -4,13 +4,16 @@
 
 FORM run.
 
-  DATA: lx_exception TYPE REF TO zcx_abapgit_exception.
+  DATA lx_exception TYPE REF TO zcx_abapgit_exception.
+  DATA lx_not_found TYPE REF TO zcx_abapgit_not_found.
 
   TRY.
       zcl_abapgit_migrations=>run( ).
       PERFORM open_gui.
     CATCH zcx_abapgit_exception INTO lx_exception.
       MESSAGE lx_exception TYPE 'E'.
+    CATCH zcx_abapgit_not_found INTO lx_not_found.
+      MESSAGE lx_not_found TYPE 'E'.
   ENDTRY.
 
 ENDFORM.                    "run

--- a/src/zcl_abapgit_migrations.clas.abap
+++ b/src/zcl_abapgit_migrations.clas.abap
@@ -12,7 +12,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_migrations IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_MIGRATIONS IMPLEMENTATION.
 
 
   METHOD run.
@@ -23,6 +23,8 @@ CLASS zcl_abapgit_migrations IMPLEMENTATION.
     " Create ZIF_APACK_MANIFEST interface
     zcl_abapgit_apack_migration=>run( ).
 
-  ENDMETHOD.
+    " Migrate checksums from repo metadata to separate DB object
+    zcl_abapgit_repo_cs_migration=>run( ).
 
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_migrations.clas.abap
+++ b/src/zcl_abapgit_migrations.clas.abap
@@ -4,7 +4,9 @@ CLASS zcl_abapgit_migrations DEFINITION
 
   PUBLIC SECTION.
     CLASS-METHODS run
-      RAISING zcx_abapgit_exception.
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_not_found.
 
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -97,6 +97,8 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     ty_files_item_tt TYPE STANDARD TABLE OF ty_file_item WITH DEFAULT KEY .
   TYPES:
+    ty_files_item_by_file_tt TYPE SORTED TABLE OF ty_file_item WITH UNIQUE KEY file-path file-filename.
+  TYPES:
     ty_yes_no         TYPE c LENGTH 1,
     ty_yes_no_partial TYPE c LENGTH 1.
   TYPES:

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -74,10 +74,15 @@ INTERFACE zif_abapgit_definitions
       comment   TYPE string,
     END OF ty_comment .
   TYPES:
-    BEGIN OF ty_item,
+    BEGIN OF ty_item_signature,
       obj_type TYPE tadir-object,
       obj_name TYPE tadir-obj_name,
       devclass TYPE devclass,
+    END OF ty_item_signature .
+  TYPES:
+    BEGIN OF ty_item.
+      INCLUDE TYPE ty_item_signature.
+  TYPES:
       inactive TYPE abap_bool,
     END OF ty_item .
   TYPES:

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -258,7 +258,7 @@
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_created_when_confirm", "note": "Void type: SCOMPKDTLN"},
 
       {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksum_serializer"},
-      {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksums"},
+      {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksums", "method": "rebuild_simple"},
       {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_update_calculator_test"}
     ]
   }

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -255,7 +255,11 @@
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "raise_error_if_package_exists", "note": "Void type: SCOMPKDTLN"},
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_given_in_popup", "note": "Void type: SCOMPKDTLN"},
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_not_created_when_canc", "note": "Void type: SCOMPKDTLN"},
-      {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_created_when_confirm", "note": "Void type: SCOMPKDTLN"}
+      {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_created_when_confirm", "note": "Void type: SCOMPKDTLN"},
+
+      {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksum_serializer"},
+      {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksums"},
+      {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_update_calculator_test"}
     ]
   }
 }

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -259,6 +259,7 @@
 
       {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksum_serializer"},
       {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksums", "method": "rebuild_simple"},
+      {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_test_checksums", "method": "rebuild_w_dot_abapgit"},
       {"object": "ZCL_ABAPGIT_REPO_CHECKSUMS", "class": "ltcl_update_calculator_test"}
     ]
   }


### PR DESCRIPTION
The concept:
- separate checksums from repo metadata -> DBType `REPO_CS`
- `|` separated text file instead of XML. Why `|` - I was planning to use just space, but there are abap objects with space in a standard system. Also with `:`, and with `#` and with tab (!!!) and also with `|` - but just one ... well, I had to stop somewhere to still keep it readable
- decouple checksums as much as possible
- also fix some subtle bugs

# update 2022-03-26

Conceptually I tried not to change the functionality. So from user perspective all remain the same, this is more a refactoring. I noticed some potential bugs on the way but that can be solved later. Also the CS class is now unit-testable which suggests a better process to fix bugs.

- potentially solves #5154, due to the fact that checksums are not a prt of repo meta anymore. Though needs a real test (this item was my personal motivator for the change, hehe ;P ). See `chunk_lib->render_repo_palette`
- `zif_abapgit_repo_checksums` and `zcl_abapgit_repo_checksums` respectively incapsulates all the checksum related stuff. So the repo class is free from checksums logic (except factory method `checksums()`).
  - the class contains local classes `lcl_checksum_serializer` for the serializeing logic and `lcl_update_calculator` for the local/remote comparison logic. The comparison logic is the same as before though a bit destructured into a couple of methods
  - zcl_repo - minus 193 code lines, yey !
  - all covered with UTs (though not extremely intensively, leaves room to improve)
- `zif_abapgit_persist_repo_cs` repserens the db logic, implemented in `zcl_abapgit_persistence_repo` (why not?)
  - `zcl_abapgit_persist_factory` can create `get_repo_cs`, though in high level code it is supposed to use `zif_repo->checksums( )`
- checksums data is stored in `ZABAPGIT` table under `REPO_CS` type. The structure is:

```
#repo_name#abapgit
@
/|.abapgit.xml|7c0506a2af34fd1b42027e0288198a00d933d3d4
CLAS|ZCL_ABAPGIT_ADT_LINK|$ABAPGIT_UTILS
/src/utils/|zcl_abapgit_adt_link.clas.abap|909437692c00ea4b93c708d2572eb4f014756b2e
/src/utils/|zcl_abapgit_adt_link.clas.xml|b171192bcffce8241f08dbd70ed2d5bcfab17f76
CLAS|ZCL_ABAPGIT_AJSON|$ABAPGIT_JSON
/src/json/|zcl_abapgit_ajson.clas.abap|f2806341d814073d58046b1388fc9005665c5085
/src/json/|zcl_abapgit_ajson.clas.locals_imp.abap|b9eb49aabf187f1ed3a27b09f3da69199480ab83
/src/json/|zcl_abapgit_ajson.clas.testclasses.abap|1b9df4a8526fcb01bc31cc818e3256e75e155292

```
- Key spec:
  - `#key#value` is metadata. Currently added repo name meta purely for debug and possibility to see the first line in the DB_VIEW page to identify the CS without cross searching the metadata. Potentially metadata can be used in future for something else too
  - line starting from `/` are files
  - grouped by lines not started from `/` - OBJ_TYPE/OBJ_NAME/PACKAGE tripple, exception is `@` - root "object" without object attached (for `.abapgit` and Ko)
  - separator is `|`, appears there are objects in SAP containing spaces, tabs (!!), and some other nice looking symbols ... well ...
- DB page shows checksums properly

![2022-03-26_13h46_55](https://user-images.githubusercontent.com/15635498/160238098-754319d8-7b97-48fa-8bcd-35b1a763f4e5.png)
![2022-03-26_13h46_39](https://user-images.githubusercontent.com/15635498/160238101-073b9944-6bb8-4ad2-a326-100dac60fcb2.png)

Further plans and doubts:
- caching: now CS is always loaded from DB on demand. Maybe it is OK. Or maybe no. No idea, time will show.
- next step is removing the `list_favorites` from repo_srv. But separately as it might initiate discussions
- **Migration !** I think there is no need for specific migration. Errors in checksums are currently ignored. So on next pull/push the checksums will be just recalculated. This is IMHO. Though of course it may lead to some minor confusion on the way (all `MM` statuses). Maybe this area can be improved, ideas welcomed.
