### PR TITLE
Separate zif_abapgit_repo

### DIFF
--- a/src/cts/zcl_abapgit_transport.clas.abap
+++ b/src/cts/zcl_abapgit_transport.clas.abap
@@ -64,7 +64,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_transport IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_TRANSPORT IMPLEMENTATION.
 
 
   METHOD add_all_objects_to_trans_req.
@@ -147,7 +147,7 @@ CLASS zcl_abapgit_transport IMPLEMENTATION.
       <lv_package> TYPE devclass,
       <ls_object>  TYPE tadir.
 
-    lo_repo     = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lo_repo    ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     lv_package  = lo_repo->get_package( ).
     lt_packages = zcl_abapgit_factory=>get_sap_package( lv_package )->list_subpackages( ).
     INSERT lv_package INTO TABLE lt_packages.
@@ -292,6 +292,33 @@ CLASS zcl_abapgit_transport IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD show_log.
+
+    DATA: li_log     TYPE REF TO zif_abapgit_log,
+          lv_message TYPE string.
+    FIELD-SYMBOLS: <ls_log> TYPE sprot_u.
+
+    CREATE OBJECT li_log TYPE zcl_abapgit_log
+      EXPORTING
+        iv_title = iv_title.
+
+    LOOP AT it_log ASSIGNING <ls_log>.
+
+      MESSAGE ID <ls_log>-ag TYPE <ls_log>-severity NUMBER <ls_log>-msgnr
+       WITH <ls_log>-var1 <ls_log>-var2 <ls_log>-var3 <ls_log>-var4
+       INTO lv_message.
+
+      li_log->add(
+          iv_msg  = lv_message
+          iv_type = <ls_log>-severity ).
+
+    ENDLOOP.
+
+    zcl_abapgit_log_viewer=>show_log( li_log ).
+
+  ENDMETHOD.
+
+
   METHOD to_tadir.
     DATA: lt_requests TYPE trwbo_requests.
 
@@ -351,32 +378,4 @@ CLASS zcl_abapgit_transport IMPLEMENTATION.
       iv_show_log       = iv_show_log_popup ).
 
   ENDMETHOD.
-
-
-  METHOD show_log.
-
-    DATA: li_log     TYPE REF TO zif_abapgit_log,
-          lv_message TYPE string.
-    FIELD-SYMBOLS: <ls_log> TYPE sprot_u.
-
-    CREATE OBJECT li_log TYPE zcl_abapgit_log
-      EXPORTING
-        iv_title = iv_title.
-
-    LOOP AT it_log ASSIGNING <ls_log>.
-
-      MESSAGE ID <ls_log>-ag TYPE <ls_log>-severity NUMBER <ls_log>-msgnr
-       WITH <ls_log>-var1 <ls_log>-var2 <ls_log>-var3 <ls_log>-var4
-       INTO lv_message.
-
-      li_log->add(
-          iv_msg  = lv_message
-          iv_type = <ls_log>-severity ).
-
-    ENDLOOP.
-
-    zcl_abapgit_log_viewer=>show_log( li_log ).
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -16,7 +16,6 @@ CLASS zcl_abapgit_repo DEFINITION
       get_files_local FOR zif_abapgit_repo~get_files_local,
       get_files_remote FOR zif_abapgit_repo~get_files_remote,
       get_local_settings FOR zif_abapgit_repo~get_local_settings,
-      create_new_log FOR zif_abapgit_repo~create_new_log,
       refresh FOR zif_abapgit_repo~refresh.
 
     METHODS constructor
@@ -98,6 +97,11 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
+    METHODS create_new_log
+      IMPORTING
+        !iv_title     TYPE string OPTIONAL
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .
@@ -187,7 +191,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 
   METHOD bind_listener.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -15,7 +15,13 @@ CLASS zcl_abapgit_repo DEFINITION
       get_package FOR zif_abapgit_repo~get_package,
       get_files_local FOR zif_abapgit_repo~get_files_local,
       get_files_remote FOR zif_abapgit_repo~get_files_remote,
+      get_local_settings FOR zif_abapgit_repo~get_local_settings,
+      create_new_log FOR zif_abapgit_repo~create_new_log,
       refresh FOR zif_abapgit_repo~refresh.
+
+    METHODS constructor
+      IMPORTING
+        !is_data TYPE zif_abapgit_persistence=>ty_repo .
 
     METHODS bind_listener
       IMPORTING
@@ -30,9 +36,6 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_delete_checks
       RAISING
         zcx_abapgit_exception .
-    METHODS constructor
-      IMPORTING
-        !is_data TYPE zif_abapgit_persistence=>ty_repo .
     METHODS get_local_checksums_per_file
       RETURNING
         VALUE(rt_checksums) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
@@ -74,9 +77,6 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS set_files_remote
       IMPORTING
         !it_files TYPE zif_abapgit_definitions=>ty_files_tt .
-    METHODS get_local_settings
-      RETURNING
-        VALUE(rs_settings) TYPE zif_abapgit_persistence=>ty_repo-local_settings .
     METHODS set_local_settings
       IMPORTING
         !is_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings
@@ -98,11 +98,6 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-    METHODS create_new_log
-      IMPORTING
-        !iv_title     TYPE string OPTIONAL
-      RETURNING
-        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -14,7 +14,8 @@ CLASS zcl_abapgit_repo DEFINITION
       is_offline FOR zif_abapgit_repo~is_offline,
       get_package FOR zif_abapgit_repo~get_package,
       get_files_local FOR zif_abapgit_repo~get_files_local,
-      get_files_remote FOR zif_abapgit_repo~get_files_remote.
+      get_files_remote FOR zif_abapgit_repo~get_files_remote,
+      refresh FOR zif_abapgit_repo~refresh.
 
     METHODS bind_listener
       IMPORTING
@@ -55,13 +56,6 @@ CLASS zcl_abapgit_repo DEFINITION
       IMPORTING
         !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
         !ii_log    TYPE REF TO zif_abapgit_log
-      RAISING
-        zcx_abapgit_exception .
-    METHODS refresh
-      IMPORTING
-        !iv_drop_cache TYPE abap_bool DEFAULT abap_false
-        !iv_drop_log   TYPE abap_bool DEFAULT abap_true
-          PREFERRED PARAMETER iv_drop_cache
       RAISING
         zcx_abapgit_exception .
     METHODS update_local_checksums

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -5,7 +5,16 @@ CLASS zcl_abapgit_repo DEFINITION
 
   PUBLIC SECTION.
 
-    DATA ms_data TYPE zif_abapgit_persistence=>ty_repo READ-ONLY.
+    INTERFACES zif_abapgit_repo.
+
+    ALIASES ms_data FOR zif_abapgit_repo~ms_data.
+    ALIASES:
+      get_key FOR zif_abapgit_repo~get_key,
+      get_name FOR zif_abapgit_repo~get_name,
+      is_offline FOR zif_abapgit_repo~is_offline,
+      get_package FOR zif_abapgit_repo~get_package,
+      get_files_local FOR zif_abapgit_repo~get_files_local,
+      get_files_remote FOR zif_abapgit_repo~get_files_remote.
 
     METHODS bind_listener
       IMPORTING
@@ -23,35 +32,9 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS constructor
       IMPORTING
         !is_data TYPE zif_abapgit_persistence=>ty_repo .
-    METHODS get_key
-      RETURNING
-        VALUE(rv_key) TYPE zif_abapgit_persistence=>ty_value .
-    METHODS get_name
-      RETURNING
-        VALUE(rv_name) TYPE string
-      RAISING
-        zcx_abapgit_exception .
-    METHODS get_files_local
-      IMPORTING
-        !ii_log         TYPE REF TO zif_abapgit_log OPTIONAL
-        !ii_obj_filter  TYPE REF TO zif_abapgit_object_filter OPTIONAL
-      RETURNING
-        VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_item_tt
-      RAISING
-        zcx_abapgit_exception .
     METHODS get_local_checksums_per_file
       RETURNING
         VALUE(rt_checksums) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
-    METHODS get_files_remote
-      IMPORTING
-        ii_obj_filter   TYPE REF TO zif_abapgit_object_filter OPTIONAL
-      RETURNING
-        VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_tt
-      RAISING
-        zcx_abapgit_exception .
-    METHODS get_package
-      RETURNING
-        VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
     METHODS get_dot_abapgit
       RETURNING
         VALUE(ro_dot_abapgit) TYPE REF TO zcl_abapgit_dot_abapgit .
@@ -94,9 +77,6 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(ro_dot) TYPE REF TO zcl_abapgit_dot_abapgit
       RAISING
         zcx_abapgit_exception .
-    METHODS is_offline
-      RETURNING
-        VALUE(rv_offline) TYPE abap_bool .
     METHODS set_files_remote
       IMPORTING
         !it_files TYPE zif_abapgit_definitions=>ty_files_tt .

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -97,7 +97,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
-    lo_repo ?= ii_repo. " Hack, refactor later
+    lo_repo ?= ii_repo. " TODO, refactor later
     lo_repo->bind_listener( me ).
     APPEND ii_repo TO mt_list.
 
@@ -590,7 +590,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
     DATA: lx_error TYPE REF TO zcx_abapgit_exception.
     DATA lo_repo TYPE REF TO zcl_abapgit_repo.
 
-    lo_repo ?= ii_repo. " Hack, remove later
+    lo_repo ?= ii_repo. " TODO, remove later
     ri_log = lo_repo->create_new_log( 'Uninstall Log' ).
 
     IF ii_repo->get_local_settings( )-write_protected = abap_true.

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -588,8 +588,10 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     DATA: lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
     DATA: lx_error TYPE REF TO zcx_abapgit_exception.
+    DATA lo_repo TYPE REF TO zcl_abapgit_repo.
 
-    ri_log = ii_repo->create_new_log( 'Uninstall Log' ).
+    lo_repo ?= ii_repo. " Hack, remove later
+    ri_log = lo_repo->create_new_log( 'Uninstall Log' ).
 
     IF ii_repo->get_local_settings( )-write_protected = abap_true.
       zcx_abapgit_exception=>raise( 'Cannot purge. Local code is write-protected by repo config' ).

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -1,0 +1,38 @@
+INTERFACE zif_abapgit_repo
+  PUBLIC .
+
+  DATA ms_data TYPE zif_abapgit_persistence=>ty_repo READ-ONLY.
+
+  METHODS get_key
+    RETURNING
+      VALUE(rv_key) TYPE zif_abapgit_persistence=>ty_value .
+  METHODS get_name
+    RETURNING
+      VALUE(rv_name) TYPE string
+    RAISING
+      zcx_abapgit_exception .
+  METHODS is_offline
+    RETURNING
+      VALUE(rv_offline) TYPE abap_bool .
+  METHODS get_package
+    RETURNING
+      VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
+
+  METHODS get_files_local
+    IMPORTING
+      !ii_log         TYPE REF TO zif_abapgit_log OPTIONAL
+      !ii_obj_filter  TYPE REF TO zif_abapgit_object_filter OPTIONAL
+    RETURNING
+      VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_item_tt
+    RAISING
+      zcx_abapgit_exception .
+  METHODS get_files_remote
+    IMPORTING
+      ii_obj_filter   TYPE REF TO zif_abapgit_object_filter OPTIONAL
+    RETURNING
+      VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_tt
+    RAISING
+      zcx_abapgit_exception .
+
+
+ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -33,6 +33,13 @@ INTERFACE zif_abapgit_repo
       VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_tt
     RAISING
       zcx_abapgit_exception .
+  METHODS refresh
+    IMPORTING
+      !iv_drop_cache TYPE abap_bool DEFAULT abap_false
+      !iv_drop_log   TYPE abap_bool DEFAULT abap_true
+        PREFERRED PARAMETER iv_drop_cache
+    RAISING
+      zcx_abapgit_exception .
 
 
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -44,10 +44,4 @@ INTERFACE zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
 
-  METHODS create_new_log
-    IMPORTING
-      !iv_title     TYPE string OPTIONAL
-    RETURNING
-      VALUE(ri_log) TYPE REF TO zif_abapgit_log .
-
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -17,6 +17,9 @@ INTERFACE zif_abapgit_repo
   METHODS get_package
     RETURNING
       VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
+  METHODS get_local_settings
+    RETURNING
+      VALUE(rs_settings) TYPE zif_abapgit_persistence=>ty_repo-local_settings .
 
   METHODS get_files_local
     IMPORTING
@@ -37,9 +40,14 @@ INTERFACE zif_abapgit_repo
     IMPORTING
       !iv_drop_cache TYPE abap_bool DEFAULT abap_false
       !iv_drop_log   TYPE abap_bool DEFAULT abap_true
-        PREFERRED PARAMETER iv_drop_cache
+    PREFERRED PARAMETER iv_drop_cache
     RAISING
       zcx_abapgit_exception .
 
+  METHODS create_new_log
+    IMPORTING
+      !iv_title     TYPE string OPTIONAL
+    RETURNING
+      VALUE(ri_log) TYPE REF TO zif_abapgit_log .
 
 ENDINTERFACE.

--- a/src/repo/zif_abapgit_repo.intf.xml
+++ b/src/repo/zif_abapgit_repo.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_REPO</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit repository</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/repo/zif_abapgit_repo_srv.intf.abap
+++ b/src/repo/zif_abapgit_repo_srv.intf.abap
@@ -3,18 +3,18 @@ INTERFACE zif_abapgit_repo_srv
 
 
   TYPES:
-    ty_repo_list TYPE STANDARD TABLE OF REF TO zcl_abapgit_repo WITH DEFAULT KEY .
+    ty_repo_list TYPE STANDARD TABLE OF REF TO zif_abapgit_repo WITH DEFAULT KEY .
 
   METHODS delete
     IMPORTING
-      !io_repo TYPE REF TO zcl_abapgit_repo
+      !ii_repo TYPE REF TO zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
   METHODS get
     IMPORTING
       !iv_key        TYPE zif_abapgit_persistence=>ty_value
     RETURNING
-      VALUE(ro_repo) TYPE REF TO zcl_abapgit_repo
+      VALUE(ri_repo) TYPE REF TO zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
   METHODS is_repo_installed
@@ -26,11 +26,15 @@ INTERFACE zif_abapgit_repo_srv
     RAISING
       zcx_abapgit_exception .
   METHODS list
-    RETURNING VALUE(rt_list) TYPE ty_repo_list
-    RAISING zcx_abapgit_exception .
+    RETURNING
+      VALUE(rt_list) TYPE ty_repo_list
+    RAISING
+      zcx_abapgit_exception .
   METHODS list_favorites
-    RETURNING VALUE(rt_list) TYPE ty_repo_list
-    RAISING zcx_abapgit_exception .
+    RETURNING
+      VALUE(rt_list) TYPE ty_repo_list
+    RAISING
+      zcx_abapgit_exception .
   METHODS new_offline
     IMPORTING
       !iv_url            TYPE string
@@ -38,7 +42,7 @@ INTERFACE zif_abapgit_repo_srv
       !iv_folder_logic   TYPE string DEFAULT zif_abapgit_dot_abapgit=>c_folder_logic-full
       !iv_main_lang_only TYPE abap_bool DEFAULT abap_false
     RETURNING
-      VALUE(ro_repo)     TYPE REF TO zcl_abapgit_repo_offline
+      VALUE(ri_repo)     TYPE REF TO zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
   METHODS new_online
@@ -51,12 +55,12 @@ INTERFACE zif_abapgit_repo_srv
       !iv_ign_subpkg     TYPE abap_bool DEFAULT abap_false
       !iv_main_lang_only TYPE abap_bool DEFAULT abap_false
     RETURNING
-      VALUE(ro_repo)     TYPE REF TO zcl_abapgit_repo_online
+      VALUE(ri_repo)     TYPE REF TO zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
   METHODS purge
     IMPORTING
-      !io_repo      TYPE REF TO zcl_abapgit_repo
+      !ii_repo      TYPE REF TO zif_abapgit_repo
       !is_checks    TYPE zif_abapgit_definitions=>ty_delete_checks
     RETURNING
       VALUE(ri_log) TYPE REF TO zif_abapgit_log
@@ -80,7 +84,7 @@ INTERFACE zif_abapgit_repo_srv
       !iv_package    TYPE devclass
       !iv_ign_subpkg TYPE abap_bool DEFAULT abap_false
     EXPORTING
-      VALUE(eo_repo) TYPE REF TO zcl_abapgit_repo
+      VALUE(ei_repo) TYPE REF TO zif_abapgit_repo
       !ev_reason     TYPE string
     RAISING
       zcx_abapgit_exception .
@@ -88,7 +92,7 @@ INTERFACE zif_abapgit_repo_srv
     IMPORTING
       !iv_url    TYPE string
     EXPORTING
-      !eo_repo   TYPE REF TO zcl_abapgit_repo
+      !ei_repo   TYPE REF TO zif_abapgit_repo
       !ev_reason TYPE string
     RAISING
       zcx_abapgit_exception .

--- a/src/ui/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_data.clas.abap
@@ -71,7 +71,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
 
 
   METHOD build_where.
@@ -97,7 +97,7 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
     ms_control-page_title = 'Data'.
 
-    mo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     mi_config = mo_repo->get_data_config( ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -183,7 +183,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -604,7 +604,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
         lo_persistence_user = zcl_abapgit_persistence_user=>get_instance( ).
 
         mv_key = iv_key.
-        mo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+        mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
         mv_cur_dir = '/'. " Root
 
         mv_hide_files = lo_persistence_user->get_hide_files( ).
@@ -806,7 +806,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     TRY.
         " Reinit, for the case of type change
-        mo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( mo_repo->get_key( ) ).
+        mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( mo_repo->get_key( ) ).
 
         mv_are_changes_recorded_in_tr = zcl_abapgit_factory=>get_sap_package( mo_repo->get_package( )
           )->are_changes_recorded_in_tr_req( ).

--- a/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -170,7 +170,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REMO IMPLEMENTATION.
 
 
   METHOD checkout_commit_build_list.
@@ -651,7 +651,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       " Remember key, switch, retrieve new instance (todo, refactor #2244)
       lv_key = ms_repo_current-key.
       mo_repo->switch_repo_type( ms_repo_new-offline ).
-      mo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
+      mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
     ENDIF.
 
     IF mo_repo->is_offline( ) = abap_true.

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -11,7 +11,7 @@ CLASS zcl_abapgit_gui_page_tag DEFINITION PUBLIC FINAL
 
     METHODS:
       constructor
-        IMPORTING io_repo TYPE REF TO zcl_abapgit_repo
+        IMPORTING ii_repo TYPE REF TO zif_abapgit_repo
         RAISING   zcx_abapgit_exception,
 
       zif_abapgit_gui_event_handler~on_event REDEFINITION.
@@ -76,7 +76,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
   METHOD constructor.
     super->constructor( ).
 
-    mo_repo_online ?= io_repo.
+    mo_repo_online ?= ii_repo.
 
     ms_control-page_title = 'Tag'.
     mv_selected_type = c_tag_type-lightweight.

--- a/src/ui/zcl_abapgit_services_abapgit.clas.abap
+++ b/src/ui/zcl_abapgit_services_abapgit.clas.abap
@@ -53,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_abapgit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_ABAPGIT IMPLEMENTATION.
 
 
   METHOD check_sapgui.
@@ -273,7 +273,7 @@ CLASS zcl_abapgit_services_abapgit IMPLEMENTATION.
     LOOP AT lt_repo_list ASSIGNING <lo_repo>.
 
       IF <lo_repo>->get_package( ) IN lt_r_package.
-        lo_repo = <lo_repo>.
+        lo_repo ?= <lo_repo>.
         EXIT.
       ENDIF.
 

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -59,7 +59,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_git IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_GIT IMPLEMENTATION.
 
 
   METHOD commit.
@@ -192,7 +192,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
     DATA: lo_repo TYPE REF TO zcl_abapgit_repo.
 
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
 
     lo_repo->refresh( ).
 
@@ -205,7 +205,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
 
     DATA lo_repo TYPE REF TO zcl_abapgit_repo.
 
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
 
     IF lo_repo->get_local_settings( )-write_protected = abap_true.
       zcx_abapgit_exception=>raise( 'Cannot pull. Local code is write-protected in repo settings' ).

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -101,7 +101,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
   METHOD check_package.
 
     DATA:
-      lo_repo     TYPE REF TO zcl_abapgit_repo,
+      li_repo     TYPE REF TO zif_abapgit_repo,
       li_repo_srv TYPE REF TO zif_abapgit_repo_srv,
       lv_reason   TYPE string.
 
@@ -113,10 +113,10 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
         iv_package    = is_repo_params-package
         iv_ign_subpkg = is_repo_params-ignore_subpackages
       IMPORTING
-        eo_repo    = lo_repo
+        ei_repo    = li_repo
         ev_reason  = lv_reason ).
 
-    IF lo_repo IS BOUND.
+    IF li_repo IS BOUND.
       zcx_abapgit_exception=>raise( lv_reason ).
     ENDIF.
 
@@ -209,7 +209,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
     check_package( is_repo_params ).
 
     " create new repo and add to favorites
-    ro_repo = zcl_abapgit_repo_srv=>get_instance( )->new_offline(
+    ro_repo ?= zcl_abapgit_repo_srv=>get_instance( )->new_offline(
       iv_url            = is_repo_params-url
       iv_package        = is_repo_params-package
       iv_folder_logic   = is_repo_params-folder_logic
@@ -233,7 +233,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
     check_package( is_repo_params ).
 
-    ro_repo = zcl_abapgit_repo_srv=>get_instance( )->new_online(
+    ro_repo ?= zcl_abapgit_repo_srv=>get_instance( )->new_online(
       iv_url            = is_repo_params-url
       iv_branch_name    = is_repo_params-branch_name
       iv_package        = is_repo_params-package
@@ -433,7 +433,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
           lv_message   TYPE string.
 
 
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     lv_repo_name = lo_repo->get_name( ).
 
     lv_package = lo_repo->get_package( ).
@@ -467,7 +467,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
     ENDIF.
 
     ri_log = zcl_abapgit_repo_srv=>get_instance( )->purge(
-      io_repo   = lo_repo
+      ii_repo   = lo_repo
       is_checks = ls_checks ).
 
     COMMIT WORK.
@@ -501,7 +501,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Not authorized' ).
     ENDIF.
 
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
 
     lv_question = 'This will rebuild and overwrite local repo checksums.'.
 
@@ -538,16 +538,16 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
   METHOD remove.
 
     DATA: lv_answer    TYPE c LENGTH 1,
-          lo_repo      TYPE REF TO zcl_abapgit_repo,
+          li_repo      TYPE REF TO zif_abapgit_repo,
           lv_package   TYPE devclass,
           lv_question  TYPE c LENGTH 200,
           lv_repo_name TYPE string,
           lv_message   TYPE string.
 
 
-    lo_repo      = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
-    lv_repo_name = lo_repo->get_name( ).
-    lv_package   = lo_repo->get_package( ).
+    li_repo      = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lv_repo_name = li_repo->get_name( ).
+    lv_package   = li_repo->get_package( ).
     lv_question  = |This will remove the repository reference to the package { lv_package
       }. All objects will safely remain in the system.|.
 
@@ -565,7 +565,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
     ENDIF.
 
-    zcl_abapgit_repo_srv=>get_instance( )->delete( lo_repo ).
+    zcl_abapgit_repo_srv=>get_instance( )->delete( li_repo ).
 
     COMMIT WORK.
 


### PR DESCRIPTION
I think the code will benefit from separating repo interface. This PR intend to start it, quick and dirty separation of main repo function without much refactoring but to introduce the interface and enable further improvents. In particular unit tests for #5328.

Main approach and criteria: make zif_abapgit_repo_srv methods to use repo interface rather than repo class. 