### PR TITLE
SICF: clear ICFALIASNO

### DIFF
--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -579,6 +579,7 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
     CLEAR ls_icfservice-icfnodguid.
     CLEAR ls_icfservice-icfparguid.
     CLEAR ls_icfservice-icfchildno.
+    CLEAR ls_icfservice-icfaliasno.
     CLEAR ls_icfservice-icf_user.
     CLEAR ls_icfservice-icf_cclnt.
     CLEAR ls_icfservice-icf_mclnt.


### PR DESCRIPTION
SICF external aliases are maintained per system, and not transported by default. 

This change clears the alias counter field `ICFALIASNO`

https://blogs.sap.com/2014/07/12/how-to-configure-a-custom-icf-external-alias-to-access-nwbc/