### PR TITLE
FUGR: Sort includes

### DIFF
--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -626,6 +626,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
       APPEND lv_maintviewname TO rt_includes.
     ENDIF.
 
+    SORT rt_includes.
     IF lines( rt_includes ) > 0.
       " check which includes have their own tadir entry
       " these includes might reside in a different package or might be shared between multiple function groups


### PR DESCRIPTION
In some systems, function modules RS_GET_ALL_INCLUDES returns an include *T00. Where *T00 include is not returned, abapGit adds to the internal table. This results in different sorting order in different systems. Sort to keep the same order. This fixes #5346.