### PR TITLE
refactor github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
     - name: Run npm steps
       run: |
         npm install
-        npm run eslint
-        npm run abaplint
         npm run merge
         npm run merge.ci
     - name: build-merged-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,12 @@ name: build
 
 on:
   push:
-  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
@@ -48,3 +47,30 @@ jobs:
         name: zabapgit_standalone.abap
         path: ./zabapgit.abap
         retention-days: 7
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+    - name: npm run unit
+      run: |
+        npm install
+        npm run unit
+    - name: npm run coverage
+      run: |
+        npm run coverage
+    - name: Update coverage.abapgit.org
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main' && github.repository == 'abapGit/abapGit'
+      with:
+        deploy_key: ${{ secrets.COVERAGE_DEPLOY_KEY }}
+        external_repository: abapGit/coverage.abapgit.org
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
+        publish_branch: main
+        cname: coverage.abapgit.org
+        force_orphan: true
+        publish_dir: ./coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,47 +1,22 @@
 name: test
 
 on:
-  push:
   pull_request:
 
 jobs:
-  unit:
+  test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
         node-version: '16'
+    - name: npm install
+      run: npm install
     - name: npm run unit
-      run: |
-        npm install
-        npm run unit
+      run: npm run unit
     - name: npm run coverage
-      run: |
-        npm run coverage
-    - name: Update coverage.abapgit.org
-      uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main' && github.repository == 'abapGit/abapGit'
-      with:
-        deploy_key: ${{ secrets.COVERAGE_DEPLOY_KEY }}
-        external_repository: abapGit/coverage.abapgit.org
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        publish_branch: main
-        cname: coverage.abapgit.org
-        force_orphan: true
-        publish_dir: ./coverage
-  integration:
-    needs: unit
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
+      run: npm run coverage
     - name: npm run integration
-      run: |
-        npm install
-        npm run integration
+      run: npm run integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,20 @@ on:
   pull_request:
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+    - name: npm install
+      run: |
+        npm install
+        npm run eslint
+        npm run merge
+        npm run merge.ci
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -14,14 +28,6 @@ jobs:
         node-version: '16'
     - name: npm install
       run: npm install
-    - name: npm run eslint
-      run: npm run eslint
-    - name: npm run abaplint
-      run: npm run abaplint
-    - name: test merge
-      run: |
-        npm run merge
-        npm run merge.ci
     - name: npm run unit
       run: npm run unit
     - name: npm run coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,14 @@ jobs:
         node-version: '16'
     - name: npm install
       run: npm install
+    - name: npm run eslint
+      run: npm run eslint
+    - name: npm run abaplint
+      run: npm run abaplint
+    - name: test merge
+      run: |
+        npm run merge
+        npm run merge.ci
     - name: npm run unit
       run: npm run unit
     - name: npm run coverage


### PR DESCRIPTION
The long list of github actions checks is getting annoying, this will be the 3rd attempt(https://github.com/abapGit/abapGit/pull/4880, https://github.com/abapGit/abapGit/pull/5150) trying to fix github actions 😁 

In abapGit, all changes require pull requests and up to date branches before merge, the build is changed to only run on push to main, and its checked on PR that it will succeed.

![image](https://user-images.githubusercontent.com/5888506/154216638-252b4b73-57cd-49a0-9685-da719af22ed0.png)

with this PR the idea is to have two status checks on PR,
![image](https://user-images.githubusercontent.com/5888506/154217112-3b077b64-c32f-4e0d-b19a-479548d829ab.png)
one that checks the build is okay, and one not required with all the crazy stuff