### PR TITLE
JUMP: Switch execution order - first specific then generic

### DIFF
--- a/src/objects/zcl_abapgit_object_aifc.clas.abap
+++ b/src/objects/zcl_abapgit_object_aifc.clas.abap
@@ -447,6 +447,9 @@ CLASS ZCL_ABAPGIT_OBJECT_AIFC IMPLEMENTATION.
     APPEND ls_param TO lt_params.
 
     SUBMIT (lv_report) WITH SELECTION-TABLE lt_params AND RETURN.
+
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_area.clas.abap
+++ b/src/objects/zcl_abapgit_object_area.clas.abap
@@ -224,7 +224,6 @@ CLASS zcl_abapgit_object_area IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    zcx_abapgit_exception=>raise( |Jump to AREA is not yet supported| ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_asfc.clas.abap
+++ b/src/objects/zcl_abapgit_object_asfc.clas.abap
@@ -90,9 +90,6 @@ CLASS zcl_abapgit_object_asfc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_auth.clas.abap
+++ b/src/objects/zcl_abapgit_object_auth.clas.abap
@@ -155,6 +155,7 @@ CLASS ZCL_ABAPGIT_OBJECT_AUTH IMPLEMENTATION.
         EXPORTING
           id_field    = mv_fieldname
           id_wbo_mode = abap_false.
+      rv_exit = abap_true.
     ENDIF.
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_avar.clas.abap
+++ b/src/objects/zcl_abapgit_object_avar.clas.abap
@@ -187,7 +187,6 @@ CLASS ZCL_ABAPGIT_OBJECT_AVAR IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    zcx_abapgit_exception=>raise( |Jump to AVAR is not supported| ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_avas.clas.abap
+++ b/src/objects/zcl_abapgit_object_avas.clas.abap
@@ -201,9 +201,6 @@ CLASS ZCL_ABAPGIT_OBJECT_AVAS IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |Todo, AVAS jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_chdo.clas.abap
+++ b/src/objects/zcl_abapgit_object_chdo.clas.abap
@@ -343,6 +343,8 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
       iv_tcode   = 'SCDO'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cmod.clas.abap
+++ b/src/objects/zcl_abapgit_object_cmod.clas.abap
@@ -156,7 +156,6 @@ CLASS ZCL_ABAPGIT_OBJECT_CMOD IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    zcx_abapgit_exception=>raise( |Jump to CMOD is not supported| ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cus0.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus0.clas.abap
@@ -155,6 +155,8 @@ CLASS zcl_abapgit_object_cus0 IMPLEMENTATION.
         i_display    = abap_true
       CHANGING
         img_activity = lv_img_activity.
+
+    rv_exit = abap_true.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cus2.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus2.clas.abap
@@ -137,9 +137,6 @@ CLASS zcl_abapgit_object_cus2 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -399,11 +399,10 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
       IMPORTING
         typekind = lv_ddtypekind.
 
-    CASE lv_ddtypekind.
-      WHEN 'STOB'.
-        open_adt_stob( ms_item-obj_name ).
-        rv_exit = abap_true.
-    ENDCASE.
+    IF lv_ddtypekind = 'STOB'.
+      open_adt_stob( ms_item-obj_name ).
+      rv_exit = abap_true.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -402,8 +402,7 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
     CASE lv_ddtypekind.
       WHEN 'STOB'.
         open_adt_stob( ms_item-obj_name ).
-      WHEN OTHERS.
-        zcx_abapgit_exception=>raise( 'DDLS Jump Error' ).
+        rv_exit = abap_true.
     ENDCASE.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_dial.clas.abap
+++ b/src/objects/zcl_abapgit_object_dial.clas.abap
@@ -171,9 +171,7 @@ CLASS zcl_abapgit_object_dial IMPLEMENTATION.
         object_not_found = 1
         OTHERS           = 2.
 
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
+    rv_exit = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_doct.clas.abap
+++ b/src/objects/zcl_abapgit_object_doct.clas.abap
@@ -144,6 +144,8 @@ CLASS zcl_abapgit_object_doct IMPLEMENTATION.
       iv_tcode   = 'SE61'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_docv.clas.abap
+++ b/src/objects/zcl_abapgit_object_docv.clas.abap
@@ -149,9 +149,6 @@ CLASS zcl_abapgit_object_docv IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( 'todo, jump DOCV' ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dsys.clas.abap
+++ b/src/objects/zcl_abapgit_object_dsys.clas.abap
@@ -213,9 +213,7 @@ CLASS zcl_abapgit_object_dsys IMPLEMENTATION.
         object_not_found = 2
         OTHERS           = 3.
 
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
+    rv_exit = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_fdt0.clas.abap
+++ b/src/objects/zcl_abapgit_object_fdt0.clas.abap
@@ -669,6 +669,8 @@ CLASS zcl_abapgit_object_fdt0 IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Could not open BRF+ Workbench' ).
     ENDIF.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_form.clas.abap
+++ b/src/objects/zcl_abapgit_object_form.clas.abap
@@ -387,6 +387,8 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
       iv_tcode   = 'SE71'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_g4ba.clas.abap
+++ b/src/objects/zcl_abapgit_object_g4ba.clas.abap
@@ -90,9 +90,6 @@ CLASS zcl_abapgit_object_g4ba IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_g4bs.clas.abap
+++ b/src/objects/zcl_abapgit_object_g4bs.clas.abap
@@ -90,9 +90,6 @@ CLASS zcl_abapgit_object_g4bs IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_idoc.clas.abap
+++ b/src/objects/zcl_abapgit_object_idoc.clas.abap
@@ -217,6 +217,8 @@ CLASS zcl_abapgit_object_idoc IMPLEMENTATION.
       iv_tcode   = 'WE30'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iext.clas.abap
+++ b/src/objects/zcl_abapgit_object_iext.clas.abap
@@ -172,6 +172,8 @@ CLASS zcl_abapgit_object_iext IMPLEMENTATION.
       iv_tcode   = 'WE30'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_iobj.clas.abap
@@ -336,7 +336,6 @@ CLASS ZCL_ABAPGIT_OBJECT_IOBJ IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    zcx_abapgit_exception=>raise( |Jump to InfoObjects is not yet supported| ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwmo.clas.abap
@@ -115,6 +115,8 @@ CLASS zcl_abapgit_object_iwmo IMPLEMENTATION.
       iv_tcode   = '/IWBEP/REG_MODEL'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwom.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwom.clas.abap
@@ -90,9 +90,6 @@ CLASS zcl_abapgit_object_iwom IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwpr.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwpr.clas.abap
@@ -95,6 +95,8 @@ CLASS zcl_abapgit_object_iwpr IMPLEMENTATION.
       WITH i_prname = ms_item-obj_name
       AND RETURN.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwsg.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwsg.clas.abap
@@ -90,9 +90,6 @@ CLASS zcl_abapgit_object_iwsg IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwsv.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwsv.clas.abap
@@ -115,6 +115,8 @@ CLASS zcl_abapgit_object_iwsv IMPLEMENTATION.
       iv_tcode   = '/IWBEP/REG_SERVICE'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwvb.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwvb.clas.abap
@@ -96,6 +96,8 @@ CLASS zcl_abapgit_object_iwvb IMPLEMENTATION.
       WITH ip_avers = ms_item-obj_name+32(4)
       AND RETURN.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_jobd.clas.abap
+++ b/src/objects/zcl_abapgit_object_jobd.clas.abap
@@ -155,6 +155,8 @@ CLASS zcl_abapgit_object_jobd IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_nrob.clas.abap
+++ b/src/objects/zcl_abapgit_object_nrob.clas.abap
@@ -252,6 +252,8 @@ CLASS zcl_abapgit_object_nrob IMPLEMENTATION.
       iv_tcode   = 'SNRO'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_nspc.clas.abap
+++ b/src/objects/zcl_abapgit_object_nspc.clas.abap
@@ -303,9 +303,9 @@ CLASS ZCL_ABAPGIT_OBJECT_NSPC IMPLEMENTATION.
         unknown_field_in_dba_sellist = 12
         view_not_found               = 13
         OTHERS                       = 14.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
+
+    rv_exit = boolc( sy-subrc = 0 ).
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_pers.clas.abap
+++ b/src/objects/zcl_abapgit_object_pers.clas.abap
@@ -198,6 +198,8 @@ CLASS zcl_abapgit_object_pers IMPLEMENTATION.
       iv_tcode   = 'PERSREG'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_scp1.clas.abap
+++ b/src/objects/zcl_abapgit_object_scp1.clas.abap
@@ -435,6 +435,8 @@ CLASS zcl_abapgit_object_scp1 IMPLEMENTATION.
 
     SUBMIT scpr3 AND RETURN.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_scvi.clas.abap
+++ b/src/objects/zcl_abapgit_object_scvi.clas.abap
@@ -156,9 +156,6 @@ CLASS zcl_abapgit_object_scvi IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -323,9 +323,9 @@ CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
         jump_se43( ).
       WHEN 'GHIER'.
         jump_sbach04( ).
-      WHEN OTHERS.
-        zcx_abapgit_exception=>raise( |Jump for type { ls_head-type } not implemented| ).
     ENDCASE.
+
+    rv_exit = abap_true.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -321,11 +321,11 @@ CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
     CASE ls_head-type.
       WHEN 'BMENU'.
         jump_se43( ).
+        rv_exit = abap_true.
       WHEN 'GHIER'.
         jump_sbach04( ).
+        rv_exit = abap_true.
     ENDCASE.
-
-    rv_exit = abap_true.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_shi5.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi5.clas.abap
@@ -147,6 +147,9 @@ CLASS zcl_abapgit_object_shi5 IMPLEMENTATION.
         originals_only       = abap_true
       TABLES
         show_only_extensions = lt_extension.
+
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_shi8.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi8.clas.abap
@@ -124,7 +124,6 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI8 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    zcx_abapgit_exception=>raise( |TODO: Jump SHI8| ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_shma.clas.abap
+++ b/src/objects/zcl_abapgit_object_shma.clas.abap
@@ -250,6 +250,8 @@ CLASS zcl_abapgit_object_shma IMPLEMENTATION.
       iv_tcode   = 'SHMA'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -556,6 +556,8 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
       iv_tcode   = 'SICF'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_splo.clas.abap
+++ b/src/objects/zcl_abapgit_object_splo.clas.abap
@@ -95,7 +95,6 @@ CLASS ZCL_ABAPGIT_OBJECT_SPLO IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    zcx_abapgit_exception=>raise( 'todo, jump, SPLO' ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sppf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sppf.clas.abap
@@ -90,9 +90,6 @@ CLASS ZCL_ABAPGIT_OBJECT_SPPF IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -390,6 +390,8 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
       iv_tcode   = 'SMARTFORMS'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ssst.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssst.clas.abap
@@ -204,6 +204,8 @@ CLASS zcl_abapgit_object_ssst IMPLEMENTATION.
       iv_tcode   = 'SMARTSTYLES'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_stvi.clas.abap
+++ b/src/objects/zcl_abapgit_object_stvi.clas.abap
@@ -159,9 +159,6 @@ CLASS ZCL_ABAPGIT_OBJECT_STVI IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_styl.clas.abap
+++ b/src/objects/zcl_abapgit_object_styl.clas.abap
@@ -163,6 +163,8 @@ CLASS zcl_abapgit_object_styl IMPLEMENTATION.
       iv_tcode   = 'SE72'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sucu.clas.abap
+++ b/src/objects/zcl_abapgit_object_sucu.clas.abap
@@ -90,9 +90,6 @@ CLASS zcl_abapgit_object_sucu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-
-    zcx_abapgit_exception=>raise( |TODO: Jump| ).
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_susc.clas.abap
+++ b/src/objects/zcl_abapgit_object_susc.clas.abap
@@ -232,6 +232,8 @@ CLASS zcl_abapgit_object_susc IMPLEMENTATION.
       EXPORTING
         objclass = lv_objclass.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_suso.clas.abap
+++ b/src/objects/zcl_abapgit_object_suso.clas.abap
@@ -310,6 +310,8 @@ CLASS zcl_abapgit_object_suso IMPLEMENTATION.
       EXPORTING
         object = mv_objectname.
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_tobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_tobj.clas.abap
@@ -256,9 +256,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TOBJ IMPLEMENTATION.
         jump_not_possible = 1
         OTHERS            = 2.
 
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Jump not possible. Subrc={ sy-subrc } from TR_OBJECT_JUMP_TO_TOOL| ).
-    ENDIF.
+    rv_exit = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -838,6 +838,8 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
       iv_tcode      = 'SE93'
       it_bdcdata    = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_udmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_udmo.clas.abap
@@ -738,6 +738,8 @@ CLASS zcl_abapgit_object_udmo IMPLEMENTATION.
       iv_tcode   = 'SD11'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ueno.clas.abap
+++ b/src/objects/zcl_abapgit_object_ueno.clas.abap
@@ -618,6 +618,8 @@ CLASS zcl_abapgit_object_ueno IMPLEMENTATION.
       iv_tcode   = 'SD11'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_vcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_vcls.clas.abap
@@ -250,6 +250,8 @@ CLASS zcl_abapgit_object_vcls IMPLEMENTATION.
       iv_tcode   = 'SE54'
       it_bdcdata = lt_bcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
@@ -421,6 +421,8 @@ CLASS zcl_abapgit_object_w3xx_super IMPLEMENTATION.
       iv_tcode   = 'SMW0'
       it_bdcdata = lt_bdcdata ).
 
+    rv_exit = abap_true.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -977,16 +977,20 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |Object { is_item-obj_type } { is_item-obj_name } doesn't exist| ).
     ENDIF.
 
-    " Open object in new window
-    lv_exit = zcl_abapgit_ui_factory=>get_gui_jumper( )->jump(
-      is_item         = is_item
-      iv_sub_obj_name = iv_sub_obj_name
-      iv_sub_obj_type = iv_sub_obj_type
-      iv_line_number  = iv_line_number ).
+    " First priority object-specific handler
+    lv_exit = li_obj->jump( ).
 
-    " If all fails, try object-specific handler
-    IF lv_exit IS INITIAL.
-      li_obj->jump( ).
+    IF lv_exit = abap_false.
+      " Open object in new window with generic jumper
+      lv_exit = zcl_abapgit_ui_factory=>get_gui_jumper( )->jump(
+        is_item         = is_item
+        iv_sub_obj_name = iv_sub_obj_name
+        iv_sub_obj_type = iv_sub_obj_type
+        iv_line_number  = iv_line_number ).
+    ENDIF.
+
+    IF lv_exit = abap_false.
+      zcx_abapgit_exception=>raise( |Jump to { is_item-obj_type } { is_item-obj_name } not possible| ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_objects_bridge.clas.abap
+++ b/src/objects/zcl_abapgit_objects_bridge.clas.abap
@@ -220,6 +220,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_BRIDGE IMPLEMENTATION.
   METHOD zif_abapgit_object~jump.
 
     CALL METHOD mo_plugin->('ZIF_ABAPGITP_PLUGIN~JUMP').
+    rv_exit = abap_true.
 
   ENDMETHOD.
 

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -54,6 +54,8 @@ INTERFACE zif_abapgit_object
     RAISING
       zcx_abapgit_exception .
   METHODS jump
+    RETURNING
+      VALUE(rv_exit) TYPE abap_bool
     RAISING
       zcx_abapgit_exception .
   METHODS get_metadata


### PR DESCRIPTION
With this change execution order of the jump logic is switched. At first we execute the object specific `JUMP` and if that's not successful we execute the generic handler. Therefore we introduce a new returning parameter `RV_EXIT` which controls whether the generic handler should be skipped or not.

fixes #5335 