### PR TITLE
Activate transformations before programs

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -186,8 +186,6 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
 
   METHOD activate_new.
 
-    DATA: lt_objects TYPE TABLE OF dwinactiv.
-
     IF gt_objects IS INITIAL.
       RETURN.
     ENDIF.
@@ -198,21 +196,7 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
 
     ELSE.
 
-      " Activate transformations first
-      lt_objects = gt_objects.
-      DELETE gt_objects WHERE object <> 'XSLT'.
-      IF gt_objects IS NOT INITIAL.
-        activate_old( ii_log ).
-      ENDIF.
-
-      " Activate other objects
-      gt_objects = lt_objects.
-      DELETE gt_objects WHERE object = 'XSLT'.
-      IF gt_objects IS NOT INITIAL.
-        activate_old( ii_log ).
-      ENDIF.
-
-      gt_objects = lt_objects.
+      activate_old( ii_log ).
 
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -79,6 +79,12 @@ CLASS zcl_abapgit_object_clas DEFINITION
           zcx_abapgit_exception.
 
   PRIVATE SECTION.
+    METHODS deserialize_pre_ddic
+      IMPORTING
+        ii_xml     TYPE REF TO zif_abapgit_xml_input
+        iv_package TYPE devclass
+      RAISING
+        zcx_abapgit_exception.
     METHODS:
       is_class_locked
         RETURNING VALUE(rv_is_class_locked) TYPE abap_bool
@@ -215,6 +221,23 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
         iv_language      = ls_i18n_lines-language
         iv_no_masterlang = abap_true ).
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_pre_ddic.
+
+    DATA(ls_vseoclass) = VALUE vseoclass( ).
+
+    ii_xml->read( EXPORTING iv_name = 'VSEOCLASS'
+                  CHANGING  cg_data = ls_vseoclass ).
+
+    mi_object_oriented_object_fct->create(
+      EXPORTING
+        iv_package    = iv_package
+        it_attributes = VALUE #( )
+      CHANGING
+        cg_properties = ls_vseoclass ).
 
   ENDMETHOD.
 
@@ -629,15 +652,25 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
   METHOD zif_abapgit_object~deserialize.
 
-    deserialize_abap( ii_xml     = io_xml
-                      iv_package = iv_package ).
+    IF iv_step = zif_abapgit_object=>gc_step_id-abap.
 
-    deserialize_tpool( io_xml ).
+      deserialize_abap( ii_xml     = io_xml
+                        iv_package = iv_package ).
 
-    deserialize_sotr( ii_ml     = io_xml
-                      iv_package = iv_package ).
+      deserialize_tpool( io_xml ).
 
-    deserialize_docu( io_xml ).
+      deserialize_sotr( ii_ml     = io_xml
+                        iv_package = iv_package ).
+
+      deserialize_docu( io_xml ).
+
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-pre_ddic.
+
+      IF zif_abapgit_object~exists( ) = abap_false.
+        deserialize_pre_ddic( ii_xml = io_xml iv_package = iv_package ).
+      ENDIF.
+
+    ENDIF.
 
   ENDMETHOD.
 
@@ -656,6 +689,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_deserialize_steps.
+    APPEND zif_abapgit_object=>gc_step_id-pre_ddic TO rt_steps.
     APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -209,11 +209,11 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
                   CHANGING cg_data = ls_dd04v ).
 
     " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-refkind = 'R'
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-datatype = 'REF'
       AND is_abapclass_or_abapinterface( ls_dd04v-domname ) = abap_true.
 
-      ls_dd04v-domname = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-refkind <> 'R'.
+      ls_dd04v-rollname = 'OBJECT'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-datatype <> 'REF'.
       RETURN. " already active
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -198,13 +198,6 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD04V'
                   CHANGING cg_data = ls_dd04v ).
 
-    " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND is_ref_to_class_or_interface( ls_dd04v ) = abap_true.
-      ls_dd04v-domname = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND is_ref_to_class_or_interface( ls_dd04v ) = abap_false.
-      RETURN. " already active
-    ENDIF.
-
     corr_insert( iv_package = iv_package
                  ig_object_class = 'DICT' ).
 
@@ -265,7 +258,6 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -212,7 +212,7 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
     IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-datatype = 'REF'
       AND is_abapclass_or_abapinterface( ls_dd04v-domname ) = abap_true.
 
-      ls_dd04v-rollname = 'OBJECT'.
+      ls_dd04v-domname = 'OBJECT'.
     ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-datatype <> 'REF'.
       RETURN. " already active
     ENDIF.

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -209,11 +209,11 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
                   CHANGING cg_data = ls_dd04v ).
 
     " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-datatype = 'REF'
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-refkind = 'R'
       AND is_abapclass_or_abapinterface( ls_dd04v-domname ) = abap_true.
 
       ls_dd04v-domname = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-datatype <> 'REF'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-refkind <> 'R'.
       RETURN. " already active
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -41,6 +41,12 @@ CLASS zcl_abapgit_object_intf DEFINITION PUBLIC FINAL INHERITING FROM zcl_abapgi
 
     DATA mi_object_oriented_object_fct TYPE REF TO zif_abapgit_oo_object_fnc .
 
+    METHODS deserialize_pre_ddic
+      IMPORTING
+        ii_xml     TYPE REF TO zif_abapgit_xml_input
+        iv_package TYPE devclass
+      RAISING
+        zcx_abapgit_exception.
     METHODS serialize_xml
       IMPORTING
         !io_xml TYPE REF TO zif_abapgit_xml_output
@@ -131,6 +137,23 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
         iv_language      = ls_i18n_lines-language
         iv_no_masterlang = abap_true ).
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_pre_ddic.
+    DATA: ls_vseointerf   TYPE vseointerf,
+          ls_clskey       TYPE seoclskey.
+
+    ls_clskey-clsname = ms_item-obj_name.
+    ii_xml->read( EXPORTING iv_name = 'VSEOINTERF'
+                  CHANGING cg_data = ls_vseointerf ).
+
+    mi_object_oriented_object_fct->create(
+      EXPORTING
+        iv_package    = iv_package
+      CHANGING
+        cg_properties = ls_vseointerf ).
 
   ENDMETHOD.
 
@@ -344,6 +367,8 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'VSEOINTERF'
                   CHANGING cg_data = ls_vseointerf ).
 
+    IF iv_step = zif_abapgit_object=>gc_step_id-abap.
+
     IF ls_vseointerf-clsproxy = abap_true.
       " Proxy interfaces are managed via SPRX
       deserialize_proxy( iv_transport ).
@@ -354,6 +379,14 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
                       iv_package = iv_package ).
 
     deserialize_docu( io_xml ).
+
+    ELSE.
+
+      IF zif_abapgit_object~exists( ) = abap_false.
+        deserialize_pre_ddic( ii_xml = io_xml iv_package = iv_package ).
+      ENDIF.
+
+    ENDIF.
   ENDMETHOD.
 
 
@@ -385,6 +418,7 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_deserialize_steps.
+    APPEND zif_abapgit_object=>gc_step_id-pre_ddic TO rt_steps.
     APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -750,7 +750,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
       ENDIF.
 
       " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-      LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE comptype = 'R'.
+      LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE datatype = 'REF'.
         IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
           <ls_dd03p>-rollname = 'OBJECT'.
         ELSE.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -750,7 +750,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
       ENDIF.
 
       " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-      LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE datatype = 'REF'.
+      LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE comptype = 'R'.
         IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
           <ls_dd03p>-rollname = 'OBJECT'.
         ELSE.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -749,15 +749,6 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
         <lg_roworcolst> = 'C'. "Reverse fix from serialize
       ENDIF.
 
-      " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-      LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE comptype = 'R' AND ( reftype = 'C' OR reftype = 'I' ).
-        IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
-          <ls_dd03p>-rollname = 'OBJECT'.
-        ELSE.
-          lv_refs = abap_true.
-        ENDIF.
-      ENDLOOP.
-
       " Number fields sequentially and fill table name
       LOOP AT lt_dd03p ASSIGNING <ls_dd03p>.
         <ls_dd03p>-position   = sy-tabix.
@@ -905,7 +896,6 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -48,9 +48,9 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
                   CHANGING cg_data = ls_dd40v ).
 
     " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-datatype = 'REF'.
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-rowkind = 'R'.
       ls_dd40v-rowtype = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-datatype <> 'REF'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-rowkind = 'R'.
       RETURN. " already active
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -48,9 +48,9 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
                   CHANGING cg_data = ls_dd40v ).
 
     " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-rowkind = 'R'.
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-datatype = 'REF'.
       ls_dd40v-rowtype = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-rowkind <> 'R'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-datatype <> 'REF'.
       RETURN. " already active
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -50,7 +50,7 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
     " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
     IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-rowkind = 'R'.
       ls_dd40v-rowtype = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-rowkind = 'R'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-rowkind <> 'R'.
       RETURN. " already active
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -65,13 +65,6 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD40V'
                   CHANGING cg_data = ls_dd40v ).
 
-    " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND is_ref_to_class_or_interface( ls_dd40v ) = abap_true.
-      ls_dd40v-rowtype = 'OBJECT'.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND is_ref_to_class_or_interface( ls_dd40v ) = abap_false.
-      RETURN. " already active
-    ENDIF.
-
     io_xml->read( EXPORTING iv_name = 'DD42V'
                   CHANGING cg_data = lt_dd42v ).
     io_xml->read( EXPORTING iv_name = 'DD43V'
@@ -140,7 +133,6 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_xslt.clas.abap
+++ b/src/objects/zcl_abapgit_object_xslt.clas.abap
@@ -99,14 +99,8 @@ CLASS zcl_abapgit_object_xslt IMPLEMENTATION.
     DATA: lv_source     TYPE string,
           lo_xslt       TYPE REF TO cl_o2_api_xsltdesc,
           lv_len        TYPE i,
-          ls_attributes TYPE o2xsltattr.
-
-    " Transformation might depend on other objects like a class
-    " We attempt to activate it in late step
-    IF iv_step = zif_abapgit_object=>gc_step_id-late.
-      zcl_abapgit_objects_activation=>add_item( ms_item ).
-      RETURN.
-    ENDIF.
+          ls_attributes TYPE o2xsltattr,
+          lt_errors     type o2xslterrt.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
@@ -159,7 +153,21 @@ CLASS zcl_abapgit_object_xslt IMPLEMENTATION.
 
     lo_xslt->set_changeable( abap_false ).
 
-    zcl_abapgit_objects_activation=>add_item( ms_item ).
+    lo_xslt->activate(
+      EXPORTING
+        i_force             = abap_true
+        i_suppress_load_gen = abap_true
+      IMPORTING
+        e_error_list        = lt_errors
+      EXCEPTIONS
+        generate_error      = 1
+        storage_error       = 2
+        syntax_errors       = 3
+        xtc_not_available   = 4
+        OTHERS              = 5 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from XSLT activate, { sy-subrc }| ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -183,7 +191,6 @@ CLASS zcl_abapgit_object_xslt IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
-    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -866,6 +866,12 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_step>    TYPE LINE OF zif_abapgit_objects=>ty_step_data_tt.
 
     APPEND INITIAL LINE TO rt_steps ASSIGNING <ls_step>.
+    <ls_step>-step_id      = zif_abapgit_object=>gc_step_id-pre_ddic.
+    <ls_step>-descr        = 'Create empty classes/interfaces used by DDIC'.
+    <ls_step>-syntax_check = abap_false.
+    <ls_step>-order        = 0.
+
+    APPEND INITIAL LINE TO rt_steps ASSIGNING <ls_step>.
     <ls_step>-step_id      = zif_abapgit_object=>gc_step_id-ddic.
     <ls_step>-descr        = 'Deserialize DDIC Objects'.
     <ls_step>-syntax_check = abap_false.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -867,7 +867,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     APPEND INITIAL LINE TO rt_steps ASSIGNING <ls_step>.
     <ls_step>-step_id      = zif_abapgit_object=>gc_step_id-pre_ddic.
-    <ls_step>-descr        = 'Create empty classes/interfaces used by DDIC'.
+    <ls_step>-descr        = 'Pre-process DDIC Objects'.
     <ls_step>-syntax_check = abap_false.
     <ls_step>-order        = 0.
 

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -8,6 +8,7 @@ INTERFACE zif_abapgit_object
       abap TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `ABAP`,
       ddic TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `DDIC`,
       late TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `LATE`,
+      pre_ddic TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `PRE_DDIC`,
     END OF gc_step_id.
 
   CONSTANTS c_abap_version_sap_cp TYPE progdir-uccheck VALUE '5' ##NO_TEXT.


### PR DESCRIPTION
Fix #5365 

To reproduce the error, and explanations:
- A program refers to a class, which refers to a transformation, which refers to a class.
- During the activation step "ABAP":
  - the classes are written directly with active status although they have syntax errors (like using an attribute of a class referred by a Data Element or a DDIC Structure component),
  - then the inactive objects (programs and transformations) are activated. The transformation which refers to a class may be activated even if the class has a syntax error. The program which uses a class with syntax error cannot be activated.

Fix:
- activate the transformations before the programs