### PR TITLE
Visualize difference for EOF

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -285,6 +285,7 @@ CLASS zcl_abapgit_syntax_highlighter IMPLEMENTATION.
       REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>horizontal_tab IN rv_line WITH '&nbsp;&rarr;&nbsp;'.
       REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>cr_lf(1)       IN rv_line WITH '&para;'.
       REPLACE ALL OCCURRENCES OF ` `                                    IN rv_line WITH '&middot;'.
+      REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>form_feed      IN rv_line WITH '<span class="red">&odash;</span>'.
 
       IF strlen( rv_line ) BETWEEN 1 AND 2.
         lv_bom = zcl_abapgit_convert=>string_to_xstring( rv_line ).

--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -285,7 +285,8 @@ CLASS zcl_abapgit_syntax_highlighter IMPLEMENTATION.
       REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>horizontal_tab IN rv_line WITH '&nbsp;&rarr;&nbsp;'.
       REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>cr_lf(1)       IN rv_line WITH '&para;'.
       REPLACE ALL OCCURRENCES OF ` `                                    IN rv_line WITH '&middot;'.
-      REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>form_feed      IN rv_line WITH '<span class="red">&odash;</span>'.
+      REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>form_feed IN rv_line 
+        WITH '<span class="red">&odash;</span>'.
 
       IF strlen( rv_line ) BETWEEN 1 AND 2.
         lv_bom = zcl_abapgit_convert=>string_to_xstring( rv_line ).

--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -285,7 +285,7 @@ CLASS zcl_abapgit_syntax_highlighter IMPLEMENTATION.
       REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>horizontal_tab IN rv_line WITH '&nbsp;&rarr;&nbsp;'.
       REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>cr_lf(1)       IN rv_line WITH '&para;'.
       REPLACE ALL OCCURRENCES OF ` `                                    IN rv_line WITH '&middot;'.
-      REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>form_feed IN rv_line 
+      REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>form_feed IN rv_line
         WITH '<span class="red">&odash;</span>'.
 
       IF strlen( rv_line ) BETWEEN 1 AND 2.

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -506,9 +506,11 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
         off = strlen( lv_old ) - 1 ).
     ENDIF.
 
-    IF lv_new_last = zif_abapgit_definitions=>c_newline AND lv_old_last <> zif_abapgit_definitions=>c_newline.
+    IF lv_new_last = zif_abapgit_definitions=>c_newline AND lv_old_last <> zif_abapgit_definitions=>c_newline
+      AND lv_old IS NOT INITIAL.
       lv_old = lv_old && cl_abap_char_utilities=>form_feed.
-    ELSEIF lv_new_last <> zif_abapgit_definitions=>c_newline AND lv_old_last = zif_abapgit_definitions=>c_newline.
+    ELSEIF lv_new_last <> zif_abapgit_definitions=>c_newline AND lv_old_last = zif_abapgit_definitions=>c_newline
+      AND lv_new IS NOT INITIAL.
       lv_new = lv_new && cl_abap_char_utilities=>form_feed.
     ENDIF.
 

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -277,9 +277,7 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
     mt_diff = compute_and_render( it_new = lt_new
                                   it_old = lt_old ).
 
-    DO 2 TIMES.
-      adjust_diff( ).
-    ENDDO.
+    adjust_diff( ).
 
     calculate_stats( ).
     map_beacons( ).

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -495,12 +495,16 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
 
     " Check if one value contains a final newline but the other not
     " If yes, add a special characters that's visible in diff render
-    lv_new_last = substring(
-      val = lv_new
-      off = strlen( lv_new ) - 1 ).
-    lv_old_last = substring(
-      val = lv_old
-      off = strlen( lv_old ) - 1 ).
+    IF lv_new IS NOT INITIAL.
+      lv_new_last = substring(
+        val = lv_new
+        off = strlen( lv_new ) - 1 ).
+    ENDIF.
+    IF lv_old IS NOT INITIAL.
+      lv_old_last = substring(
+        val = lv_old
+        off = strlen( lv_old ) - 1 ).
+    ENDIF.
 
     IF lv_new_last = zif_abapgit_definitions=>c_newline AND lv_old_last <> zif_abapgit_definitions=>c_newline.
       lv_old = lv_old && cl_abap_char_utilities=>form_feed.


### PR DESCRIPTION
In case there is a difference of the end-of-file ie. line-feed after the final line, this leads to an incomplete diff display.

Here's an example where only the EOF was different:

![image](https://user-images.githubusercontent.com/59966492/159794943-cf7fcbed-0f83-4fcb-bcd1-dd39d678a6f7.png)

After this change, the difference is shown as follows (with and without special characters shown):

![image](https://user-images.githubusercontent.com/59966492/159795054-6387746f-8be7-4b31-9d80-d5d0ec57a2de.png)

![image](https://user-images.githubusercontent.com/59966492/159795116-3aea7cfc-a98e-44b0-9440-f47ab821b843.png)

