### PR TITLE
Check if package name is allowed

### DIFF
--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -80,7 +80,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
+CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
 
   METHOD add.
@@ -622,26 +622,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
           li_repo    TYPE REF TO zif_abapgit_repo,
           lv_reason  TYPE string.
 
-    IF iv_package IS INITIAL.
-      zcx_abapgit_exception=>raise( 'add, package empty' ).
-    ENDIF.
-
-    IF iv_package = '$TMP'.
-      zcx_abapgit_exception=>raise( 'not possible to use $TMP, create new (local) package' ).
-    ENDIF.
-
-    " Check if package name is allowed
-    cl_package_helper=>check_package_name(
-      EXPORTING
-        i_package_name       = iv_package
-      EXCEPTIONS
-        undefined_name       = 1
-        wrong_name_prefix    = 2
-        reserved_local_name  = 3
-        invalid_package_name = 4 ).
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Package name { iv_package } not valid| ).
-    ENDIF.
+    zcl_abapgit_sap_package=>validate_name( iv_package ).
 
     " Check if package owned by SAP is allowed (new packages are ok, since they are created automatically)
     SELECT SINGLE as4user FROM tdevc

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -630,6 +630,19 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'not possible to use $TMP, create new (local) package' ).
     ENDIF.
 
+    " Check if package name is allowed
+    cl_package_helper=>check_package_name(
+      EXPORTING
+        i_package_name       = iv_package
+      EXCEPTIONS
+        undefined_name       = 1
+        wrong_name_prefix    = 2
+        reserved_local_name  = 3
+        invalid_package_name = 4 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Package name { iv_package } not valid| ).
+    ENDIF.
+
     " Check if package owned by SAP is allowed (new packages are ok, since they are created automatically)
     SELECT SINGLE as4user FROM tdevc
       INTO lv_as4user

--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -9,6 +9,12 @@ CLASS zcl_abapgit_sap_package DEFINITION
 
     INTERFACES: zif_abapgit_sap_package.
 
+    CLASS-METHODS validate_name
+      IMPORTING
+        !iv_package TYPE devclass
+      RAISING
+        zcx_abapgit_exception .
+
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA: mv_package TYPE devclass.
@@ -22,6 +28,32 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
 
   METHOD constructor.
     mv_package = iv_package.
+  ENDMETHOD.
+
+
+  METHOD validate_name.
+
+    IF iv_package IS INITIAL.
+      zcx_abapgit_exception=>raise( 'Package name must not be empty' ).
+    ENDIF.
+
+    IF iv_package = '$TMP'.
+      zcx_abapgit_exception=>raise( 'It is not possible to use $TMP, use a different (local) package' ).
+    ENDIF.
+
+    " Check if package name is allowed
+    cl_package_helper=>check_package_name(
+      EXPORTING
+        i_package_name       = iv_package
+      EXCEPTIONS
+        undefined_name       = 1
+        wrong_name_prefix    = 2
+        reserved_local_name  = 3
+        invalid_package_name = 4 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Package name { iv_package } is not valid| ).
+    ENDIF.
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
When validating SAP packages, it now checks the naming conventions and detects for example invalid characters already in the HTML form:

![image](https://user-images.githubusercontent.com/59966492/160903959-a11528b8-d9b1-4a9f-800a-29632a98f9db.png)
