### PR TITLE
Deserialize textpool for some objects

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -172,7 +172,6 @@ CLASS zcl_abapgit_objects_program DEFINITION PUBLIC INHERITING FROM zcl_abapgit_
       IMPORTING
         !is_progdir TYPE ty_progdir
         !it_source  TYPE abaptxt255_tab
-        !it_tpool   TYPE textpool_table
         !iv_title   TYPE repti
         !iv_package TYPE devclass
       RAISING
@@ -497,7 +496,6 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
       insert_program(
         is_progdir = is_progdir
         it_source  = it_source
-        it_tpool   = it_tpool
         iv_title   = lv_title
         iv_package = iv_package ).
     ENDIF.
@@ -543,13 +541,6 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
           STATE lv_state.          "of the mail program -> insert empty textpool
       ENDIF.
     ELSE.
-      IF lines( it_tpool ) = 1 AND lv_language = mv_language.
-        READ TABLE it_tpool WITH KEY id = 'R' TRANSPORTING NO FIELDS.
-        IF sy-subrc = 0.
-          RETURN. "No action because description in main language is already there
-        ENDIF.
-      ENDIF.
-
       INSERT TEXTPOOL iv_program
         FROM it_tpool
         LANGUAGE lv_language
@@ -622,17 +613,6 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
         PROGRAM TYPE is_progdir-subc.
       IF sy-subrc <> 0.
         zcx_abapgit_exception=>raise( 'Error from INSERT REPORT .. PROGRAM TYPE' ).
-      ENDIF.
-
-      IF it_tpool IS NOT INITIAL.
-        INSERT TEXTPOOL is_progdir-name
-          FROM it_tpool
-          LANGUAGE mv_language
-          STATE 'A'.
-        INSERT TEXTPOOL is_progdir-name
-          FROM it_tpool
-          LANGUAGE mv_language
-          STATE 'I'.
       ENDIF.
 
     ELSEIF sy-subrc > 0.

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -172,6 +172,7 @@ CLASS zcl_abapgit_objects_program DEFINITION PUBLIC INHERITING FROM zcl_abapgit_
       IMPORTING
         !is_progdir TYPE ty_progdir
         !it_source  TYPE abaptxt255_tab
+        !it_tpool   TYPE textpool_table
         !iv_title   TYPE repti
         !iv_package TYPE devclass
       RAISING
@@ -496,6 +497,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
       insert_program(
         is_progdir = is_progdir
         it_source  = it_source
+        it_tpool   = it_tpool
         iv_title   = lv_title
         iv_package = iv_package ).
     ENDIF.
@@ -620,6 +622,17 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
         PROGRAM TYPE is_progdir-subc.
       IF sy-subrc <> 0.
         zcx_abapgit_exception=>raise( 'Error from INSERT REPORT .. PROGRAM TYPE' ).
+      ENDIF.
+
+      IF it_tpool IS NOT INITIAL.
+        INSERT TEXTPOOL is_progdir-name
+          FROM it_tpool
+          LANGUAGE mv_language
+          STATE 'A'.
+        INSERT TEXTPOOL is_progdir-name
+          FROM it_tpool
+          LANGUAGE mv_language
+          STATE 'I'.
       ENDIF.
 
     ELSEIF sy-subrc > 0.


### PR DESCRIPTION
CI tests have shown that some text pool entries are missing i.e. there are diffs after pulling.

Fixes inserting the textpool for objects that are not handled by `RPY_PROGRAM_INSERT`. This applies for example to function groups and exit includes (`zx...`).