### PR TITLE
UI: Word-wrap long filenames in repo/stage views

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -230,6 +230,7 @@ span.transport-box {
   padding: 2px 4px;
   border: 1px solid;
   border-radius: 4px;
+  display: inline-block;
 }
 
 /* MISC AND REFACTOR */
@@ -310,6 +311,7 @@ table.repo_tab {
 
 .repo_tab td.filename{
   padding-left: 1em;
+  word-break: break-all;
 }
 
 .repo_tab td.object {
@@ -370,6 +372,9 @@ input.stage-filter { width: 18em; }
 }
 .stage_tab td.highlight {
   font-weight: bold;
+}
+.stage_tab td.name {
+  word-break: break-all;
 }
 
 .stage_tab tr:first-child td { border-top: 0px; }


### PR DESCRIPTION
With very long file names, repo and stage views would extend beyond the right border - sometimes off the screen.

Small CSS change to wraps the file names if there's not enough room.

Closes #5418

Before

![image](https://user-images.githubusercontent.com/59966492/161057945-6ab8d6ea-f648-499d-85f8-5d9732a934ec.png)

![image](https://user-images.githubusercontent.com/59966492/161057435-2c6b3da7-d027-4762-ae54-dcaabdabbc8c.png)

After

![image](https://user-images.githubusercontent.com/59966492/161057968-359cdbae-7034-42ba-be24-cd45af154c4e.png)

![image](https://user-images.githubusercontent.com/59966492/161057982-b8447b4a-2caf-46f0-8701-30a3fdb867d8.png)
