### PR TITLE
DDLS: Avoid dump and show error

### DIFF
--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -320,10 +320,14 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
 
       CATCH cx_root INTO lx_error.
         IF lo_ddl IS NOT INITIAL.
-          CALL METHOD lo_ddl->('IF_DD_DDL_HANDLER~DELETE')
-            EXPORTING
-              name = ms_item-obj_name
-              prid = 0.
+          " Attempt clean-up by catch error if it doesn't work
+          TRY.
+              CALL METHOD lo_ddl->('IF_DD_DDL_HANDLER~DELETE')
+                EXPORTING
+                  name = ms_item-obj_name
+                  prid = 0.
+            CATCH cx_root ##NO_HANDLER.
+          ENDTRY.
         ENDIF.
 
         zcx_abapgit_exception=>raise_with_text( lx_error ).

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -320,7 +320,7 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
 
       CATCH cx_root INTO lx_error.
         IF lo_ddl IS NOT INITIAL.
-          " Attempt clean-up by catch error if it doesn't work
+          " Attempt clean-up but catch error if it doesn't work
           TRY.
               CALL METHOD lo_ddl->('IF_DD_DDL_HANDLER~DELETE')
                 EXPORTING


### PR DESCRIPTION
In case of cyclical dependencies, deserializing `DDLS` was causing a dump. Now, you will get an error message:

Example:

https://github.com/abapGit-tests/DDLS_cyclic.git

![image](https://user-images.githubusercontent.com/59966492/161384702-612bf047-af3e-4663-8394-b7726eeb2271.png)

Ref https://github.com/abapGit/abapGit/issues/4624