### PR TITLE
UI: Transport popup

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -1038,13 +1038,23 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
   METHOD zif_abapgit_popups~popup_transport_request.
 
-    DATA: lt_e071  TYPE STANDARD TABLE OF e071,
-          lt_e071k TYPE STANDARD TABLE OF e071k.
+    DATA: lt_e071    TYPE STANDARD TABLE OF e071,
+          lt_e071k   TYPE STANDARD TABLE OF e071k,
+          lv_order   TYPE trkorr,
+          ls_e070use TYPE e070use.
+
+    " If default transport is set and its type matches, then use it as default for the popup
+    ls_e070use = zcl_abapgit_default_transport=>get_instance( )->get( ).
+
+    IF ls_e070use-trfunction = is_transport_type-request.
+      lv_order = ls_e070use-ordernum.
+    ENDIF.
 
     CALL FUNCTION 'TRINT_ORDER_CHOICE'
       EXPORTING
         wi_order_type          = is_transport_type-request
         wi_task_type           = is_transport_type-task
+        wi_order               = lv_order
       IMPORTING
         we_order               = rv_transport
       TABLES


### PR DESCRIPTION
If default transport is set and its type matches to what is required, then use it as default for the transport popup.

This will make it easier for example if a pull or uninstall failed and needs to be repeated since you want to continue using the same transport.