### PR TITLE
CHDO: Avoid double pull and fix uninstall

### DIFF
--- a/src/objects/zcl_abapgit_object_chdo.clas.abap
+++ b/src/objects/zcl_abapgit_object_chdo.clas.abap
@@ -275,6 +275,8 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
     INSERT tcdobts FROM TABLE ls_change_object-objects_text.
     INSERT tcdrps  FROM TABLE ls_change_object-reports_generated.
 
+    tadir_insert( iv_package ).
+
     after_import( ).
 
     corr_insert( iv_package ).

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -1054,6 +1054,12 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     DATA: lv_area     TYPE rs38l-area,
           lt_includes TYPE ty_sobj_name_tt.
 
+    " FUGR related to change documents will be deleted by CHDO
+    SELECT SINGLE fgrp FROM tcdrps INTO lv_area WHERE fgrp = ms_item-obj_name.
+    IF sy-subrc = 0.
+      RETURN.
+    ENDIF.
+
     lt_includes = includes( ).
 
     lv_area = ms_item-obj_name.


### PR DESCRIPTION
Change documents left a diff when pulled once that would go away after second pull. In debugging warning CD 763 could be seen "No TADIR entry found'. The `tadir` entry is now created properly.

![image](https://user-images.githubusercontent.com/59966492/161446906-4be059d7-05ed-4df3-a2ed-93c4ac376565.png)

Uninstall would fail with "Function group ... does not exist". Reason was that the function group was already deleted by `chdo` object. The deletion of such generated function groups is now skipped.

![image](https://user-images.githubusercontent.com/59966492/161446911-a2cd5b56-c675-4d3d-bd85-2c7243e13eaa.png)
