### PR TITLE
DEVC: Raise error for main/structure packages

### DIFF
--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -482,8 +482,12 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       CHANGING
         cg_data = ls_package_data ).
 
-    IF mv_local_devclass(1) = '$' AND ls_package_data-mainpack IS NOT INITIAL.
-      zcx_abapgit_exception=>raise( |{ iv_package } is main or structure package and cannot be used in locally| ).
+    IF mv_local_devclass(1) = '$'.
+      IF ls_package_data-mainpack = 'X'.
+        zcx_abapgit_exception=>raise( |Main package { iv_package } cannot be used in locally| ).
+      ELSEIF ls_package_data-mainpack = 'S'.
+        zcx_abapgit_exception=>raise( |Structure package { iv_package } cannot be used in locally| ).
+      ENDIF.
     ENDIF.
 
     li_package = get_package( ).

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -484,9 +484,9 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
     IF mv_local_devclass(1) = '$'.
       IF ls_package_data-mainpack = 'X'.
-        zcx_abapgit_exception=>raise( |Main package { iv_package } cannot be used in locally| ).
+        zcx_abapgit_exception=>raise( |Main package { iv_package } cannot be used locally| ).
       ELSEIF ls_package_data-mainpack = 'S'.
-        zcx_abapgit_exception=>raise( |Structure package { iv_package } cannot be used in locally| ).
+        zcx_abapgit_exception=>raise( |Structure package { iv_package } cannot be used locally| ).
       ENDIF.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -484,9 +484,9 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
     IF mv_local_devclass(1) = '$'.
       IF ls_package_data-mainpack = 'X'.
-        zcx_abapgit_exception=>raise( |Main package { iv_package } cannot be used locally| ).
+        zcx_abapgit_exception=>raise( |Main package { iv_package } cannot be used in local package| ).
       ELSEIF ls_package_data-mainpack = 'S'.
-        zcx_abapgit_exception=>raise( |Structure package { iv_package } cannot be used locally| ).
+        zcx_abapgit_exception=>raise( |Structure package { iv_package } cannot be used in local package| ).
       ENDIF.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -482,6 +482,10 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       CHANGING
         cg_data = ls_package_data ).
 
+    IF mv_local_devclass(1) = '$' AND ls_package_data-mainpack IS NOT INITIAL.
+      zcx_abapgit_exception=>raise( |{ iv_package } is main or structure package and cannot be used in locally| ).
+    ENDIF.
+
     li_package = get_package( ).
 
     " Swap out repository package name with the local installation package name


### PR DESCRIPTION
Main or structure package and cannot be used in local packages (`$...`). 

abapGit will now raise an error, if one tries to pull main or structure packages into a local package.

Tests:
https://github.com/abapGit-tests/DEVC_main_package
https://github.com/abapGit-tests/DEVC_struct_package