### PR TITLE
Add paramter iv_show_log to serialize package

### DIFF
--- a/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_package.abap
+++ b/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_package.abap
@@ -27,6 +27,7 @@ FUNCTION z_abapgit_serialize_package.
       ev_xstring = zcl_abapgit_zip=>export(
        is_local_settings = ls_local_settings
        iv_package        = iv_package
+       iv_show_log       = iv_show_log
        io_dot_abapgit    = lo_dot_abapgit ).
 
     CATCH zcx_abapgit_exception INTO lx_error.


### PR DESCRIPTION
Pass along paramter `iv_show_log`(should have been an "unused variable/parameter" check).