### PR TITLE
Avoid logon when comparing with remote

### DIFF
--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -191,7 +191,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD bind_listener.
@@ -429,11 +429,10 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    get_files_remote( ).
-
     CREATE OBJECT ri_config TYPE zcl_abapgit_data_config.
     mi_data_config = ri_config.
 
+    " Assume remote data has been loaded already
     READ TABLE mt_remote ASSIGNING <ls_remote>
       WITH KEY file_path
       COMPONENTS path = zif_abapgit_data_config=>c_default_path.


### PR DESCRIPTION
"Data Config" is persisted on remote side only. Comparison feature reads the local part only and therefore does not support comparing of "data config". Therefore `get_files_remote` is not necessary.

Closes #5189, #5443