### PR TITLE
TABU: Add "jump" to SE16

### DIFF
--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -1,6 +1,6 @@
 CLASS zcl_abapgit_data_utils DEFINITION
   PUBLIC
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
 
@@ -10,12 +10,19 @@ CLASS zcl_abapgit_data_utils DEFINITION
       RETURNING
         VALUE(rr_data) TYPE REF TO data
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
     CLASS-METHODS build_filename
       IMPORTING
         !is_config         TYPE zif_abapgit_data_config=>ty_config
       RETURNING
-        VALUE(rv_filename) TYPE string .
+        VALUE(rv_filename) TYPE string.
+    CLASS-METHODS jump
+      IMPORTING
+        !is_item       TYPE zif_abapgit_definitions=>ty_item
+      RETURNING
+        VALUE(rv_exit) TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -89,6 +96,31 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
       CATCH cx_root.
         zcx_abapgit_exception=>raise( |Error creating internal table for data serialization| ).
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD jump.
+
+    IF is_item-obj_type = zif_abapgit_data_config=>c_data_type-tabu.
+      " Run SE16 with authorization check
+      CALL FUNCTION 'RS_TABLE_LIST_CREATE'
+        EXPORTING
+          table_name         = is_item-obj_name
+        EXCEPTIONS
+          table_is_structure = 1
+          table_not_exists   = 2
+          db_not_exists      = 3
+          no_permission      = 4
+          no_change_allowed  = 5
+          table_is_gtt       = 6
+          OTHERS             = 7.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |Table { is_item-obj_name } cannot be displayed| ).
+      ENDIF.
+
+      rv_exit = abap_true.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -102,24 +102,20 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
 
   METHOD jump.
 
-    IF is_item-obj_type = zif_abapgit_data_config=>c_data_type-tabu.
-      " Run SE16 with authorization check
-      CALL FUNCTION 'RS_TABLE_LIST_CREATE'
-        EXPORTING
-          table_name         = is_item-obj_name
-        EXCEPTIONS
-          table_is_structure = 1
-          table_not_exists   = 2
-          db_not_exists      = 3
-          no_permission      = 4
-          no_change_allowed  = 5
-          table_is_gtt       = 6
-          OTHERS             = 7.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |Table { is_item-obj_name } cannot be displayed| ).
-      ENDIF.
-
-      rv_exit = abap_true.
+    " Run SE16 with authorization check
+    CALL FUNCTION 'RS_TABLE_LIST_CREATE'
+      EXPORTING
+        table_name         = is_item-obj_name
+      EXCEPTIONS
+        table_is_structure = 1
+        table_not_exists   = 2
+        db_not_exists      = 3
+        no_permission      = 4
+        no_change_allowed  = 5
+        table_is_gtt       = 6
+        OTHERS             = 7.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Table { is_item-obj_name } cannot be displayed| ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -681,7 +681,9 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         TRY.
             " Hide HTML Viewer in dummy screen0 for direct CALL SCREEN to work
             li_html_viewer->set_visiblity( abap_false ).
-            IF zcl_abapgit_data_utils=>jump( ls_item ) IS INITIAL.
+            IF ls_item-obj_type = zif_abapgit_data_config=>c_data_type-tabu.
+              zcl_abapgit_data_utils=>jump( ls_item ).
+            ELSE.
               zcl_abapgit_objects=>jump( ls_item ).
             ENDIF.
             li_html_viewer->set_visiblity( abap_true ).

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -131,7 +131,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
+CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -681,7 +681,9 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         TRY.
             " Hide HTML Viewer in dummy screen0 for direct CALL SCREEN to work
             li_html_viewer->set_visiblity( abap_false ).
-            zcl_abapgit_objects=>jump( ls_item ).
+            IF zcl_abapgit_data_utils=>jump( ls_item ) IS INITIAL.
+              zcl_abapgit_objects=>jump( ls_item ).
+            ENDIF.
             li_html_viewer->set_visiblity( abap_true ).
           CATCH zcx_abapgit_exception INTO lx_ex.
             li_html_viewer->set_visiblity( abap_true ).


### PR DESCRIPTION
When using "Data Configuration" you can now jump from the repo view to the data browser (`se16`).

![image](https://user-images.githubusercontent.com/59966492/162213961-eeb54912-6b22-4bbb-8527-53b35d4ca526.png)

![image](https://user-images.githubusercontent.com/59966492/162214059-a895959b-ab32-4568-a8ad-82000156ab9c.png)
