### PR TITLE
DEVC: Clean-up OTR entries

### DIFF
--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -381,6 +381,9 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
     lv_package = ms_item-obj_name.
 
+    " Remove remaining OTR entries
+    zcl_abapgit_sotr_handler=>delete_sotr_package( iv_package ).
+
     remove_obsolete_tadir( lv_package ).
 
     IF is_empty( lv_package ) = abap_true.


### PR DESCRIPTION
Uninstalling objects like `ENHC` just removes their references to OTR entries (`sotr_use/u` tables). Therefore, when the package is uninstalled, the remaining OTR entries will be completely removed.