### PR TITLE
Repo view: Show icon for different source system

### DIFF
--- a/src/objects/core/zabapgit_parallel.fugr.xml
+++ b/src/objects/core/zabapgit_parallel.fugr.xml
@@ -97,6 +97,10 @@
        <TYP>TADIR-DEVCLASS</TYP>
       </RSIMP>
       <RSIMP>
+       <PARAMETER>IV_SRCSYSTEM</PARAMETER>
+       <TYP>TADIR-SRCSYSTEM</TYP>
+      </RSIMP>
+      <RSIMP>
        <PARAMETER>IV_LANGUAGE</PARAMETER>
        <TYP>SY-LANGU</TYP>
       </RSIMP>
@@ -143,6 +147,11 @@
        <PARAMETER>IV_DEVCLASS</PARAMETER>
        <KIND>P</KIND>
        <STEXT>Package</STEXT>
+      </RSFDO>
+      <RSFDO>
+       <PARAMETER>IV_SRCSYSTEM</PARAMETER>
+       <KIND>P</KIND>
+       <STEXT>Original System of Object</STEXT>
       </RSFDO>
       <RSFDO>
        <PARAMETER>IV_LANGUAGE</PARAMETER>

--- a/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
+++ b/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
@@ -5,6 +5,7 @@ FUNCTION z_abapgit_serialize_parallel.
 *"     VALUE(IV_OBJ_TYPE) TYPE  TADIR-OBJECT
 *"     VALUE(IV_OBJ_NAME) TYPE  TADIR-OBJ_NAME
 *"     VALUE(IV_DEVCLASS) TYPE  TADIR-DEVCLASS
+*"     VALUE(IV_SRCSYSTEM) TYPE  TADIR-SRCSYSTEM
 *"     VALUE(IV_LANGUAGE) TYPE  SY-LANGU
 *"     VALUE(IV_PATH) TYPE  STRING
 *"     VALUE(IV_MAIN_LANGUAGE_ONLY) TYPE  CHAR1
@@ -22,9 +23,10 @@ FUNCTION z_abapgit_serialize_parallel.
         ls_files TYPE zcl_abapgit_objects=>ty_serialization.
 
   TRY.
-      ls_item-obj_type = iv_obj_type.
-      ls_item-obj_name = iv_obj_name.
-      ls_item-devclass = iv_devclass.
+      ls_item-obj_type  = iv_obj_type.
+      ls_item-obj_name  = iv_obj_name.
+      ls_item-devclass  = iv_devclass.
+      ls_item-srcsystem = iv_srcsystem.
 
       ls_files = zcl_abapgit_objects=>serialize(
         is_item               = ls_item

--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -134,7 +134,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
+CLASS zcl_abapgit_file_status IMPLEMENTATION.
 
 
   METHOD build_existing.
@@ -142,9 +142,10 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
     DATA: ls_file_sig LIKE LINE OF it_state.
 
     " Item
-    rs_result-obj_type = is_local-item-obj_type.
-    rs_result-obj_name = is_local-item-obj_name.
-    rs_result-package  = is_local-item-devclass.
+    rs_result-obj_type  = is_local-item-obj_type.
+    rs_result-obj_name  = is_local-item-obj_name.
+    rs_result-package   = is_local-item-devclass.
+    rs_result-srcsystem = is_local-item-srcsystem.
 
     " File
     rs_result-path     = is_local-file-path.
@@ -188,9 +189,10 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
   METHOD build_new_local.
 
     " Item
-    rs_result-obj_type = is_local-item-obj_type.
-    rs_result-obj_name = is_local-item-obj_name.
-    rs_result-package  = is_local-item-devclass.
+    rs_result-obj_type  = is_local-item-obj_type.
+    rs_result-obj_name  = is_local-item-obj_name.
+    rs_result-package   = is_local-item-devclass.
+    rs_result-srcsystem = is_local-item-srcsystem.
 
     " File
     rs_result-path     = is_local-file-path.
@@ -231,9 +233,10 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
     IF sy-subrc = 0.
 
       " Completely new (xml, abap) and new file in an existing object
-      rs_result-obj_type = ls_item-obj_type.
-      rs_result-obj_name = ls_item-obj_name.
-      rs_result-package  = ls_item-devclass.
+      rs_result-obj_type  = ls_item-obj_type.
+      rs_result-obj_name  = ls_item-obj_name.
+      rs_result-package   = ls_item-devclass.
+      rs_result-srcsystem = sy-sysid.
 
       READ TABLE it_state INTO ls_file_sig
         WITH KEY path = is_remote-path filename = is_remote-filename

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -497,9 +497,10 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
           ls_file_item TYPE zif_abapgit_objects=>ty_serialization.
 
 
-    ls_file_item-item-obj_type = is_tadir-object.
-    ls_file_item-item-obj_name = is_tadir-obj_name.
-    ls_file_item-item-devclass = is_tadir-devclass.
+    ls_file_item-item-obj_type  = is_tadir-object.
+    ls_file_item-item-obj_name  = is_tadir-obj_name.
+    ls_file_item-item-devclass  = is_tadir-devclass.
+    ls_file_item-item-srcsystem = is_tadir-srcsystem.
 
     TRY.
         ls_file_item = zcl_abapgit_objects=>serialize(

--- a/src/repo/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/repo/zcl_abapgit_repo_content_list.clas.abap
@@ -53,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
+CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
 
   METHOD build_folders.
@@ -123,15 +123,16 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
     LOOP AT lt_tadir ASSIGNING <ls_tadir>.
       APPEND INITIAL LINE TO rt_repo_items ASSIGNING <ls_repo_item>.
-      <ls_repo_item>-obj_type = <ls_tadir>-object.
-      <ls_repo_item>-obj_name = <ls_tadir>-obj_name.
-      <ls_repo_item>-path     = <ls_tadir>-path.
+      <ls_repo_item>-obj_type  = <ls_tadir>-object.
+      <ls_repo_item>-obj_name  = <ls_tadir>-obj_name.
+      <ls_repo_item>-path      = <ls_tadir>-path.
+      <ls_repo_item>-srcsystem = <ls_tadir>-srcsystem.
       MOVE-CORRESPONDING <ls_repo_item> TO ls_item.
       <ls_repo_item>-inactive = boolc( zcl_abapgit_objects=>is_active( ls_item ) = abap_false ).
       IF <ls_repo_item>-inactive = abap_true.
         <ls_repo_item>-sortkey = c_sortkey-inactive.
       ELSE.
-        <ls_repo_item>-sortkey  = c_sortkey-default.      " Default sort key
+        <ls_repo_item>-sortkey = c_sortkey-default.      " Default sort key
       ENDIF.
 
       IF <ls_repo_item>-obj_type IS NOT INITIAL.
@@ -149,7 +150,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
   METHOD build_repo_items_with_remote.
 
     DATA:
-      lo_state  TYPE REF TO zcl_abapgit_item_state,
+      lo_state      TYPE REF TO zcl_abapgit_item_state,
       ls_file       TYPE zif_abapgit_definitions=>ty_repo_file,
       lt_status     TYPE zif_abapgit_definitions=>ty_results_tt,
       ls_item       TYPE zif_abapgit_definitions=>ty_item,
@@ -165,12 +166,13 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
     LOOP AT lt_status ASSIGNING <ls_status>.
       AT NEW obj_name. "obj_type + obj_name
         APPEND INITIAL LINE TO rt_repo_items ASSIGNING <ls_repo_item>.
-        <ls_repo_item>-obj_type = <ls_status>-obj_type.
-        <ls_repo_item>-obj_name = <ls_status>-obj_name.
-        <ls_repo_item>-inactive = <ls_status>-inactive.
-        <ls_repo_item>-sortkey  = c_sortkey-default. " Default sort key
-        <ls_repo_item>-changes  = 0.
-        <ls_repo_item>-path     = <ls_status>-path.
+        <ls_repo_item>-obj_type  = <ls_status>-obj_type.
+        <ls_repo_item>-obj_name  = <ls_status>-obj_name.
+        <ls_repo_item>-inactive  = <ls_status>-inactive.
+        <ls_repo_item>-sortkey   = c_sortkey-default. " Default sort key
+        <ls_repo_item>-changes   = 0.
+        <ls_repo_item>-path      = <ls_status>-path.
+        <ls_repo_item>-srcsystem = <ls_status>-srcsystem.
         CREATE OBJECT lo_state.
       ENDAT.
 

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -121,6 +121,11 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
         !is_item                     TYPE zif_abapgit_definitions=>ty_repo_item
       RETURNING
         VALUE(rv_inactive_html_code) TYPE string .
+    METHODS build_srcsystem_code
+      IMPORTING
+        !is_item                     TYPE zif_abapgit_definitions=>ty_repo_item
+      RETURNING
+        VALUE(rv_srcsystem_html_code) TYPE string .
     METHODS open_in_main_language
       RAISING
         zcx_abapgit_exception .
@@ -189,7 +194,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -545,6 +550,18 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
     rv_html = li_html->a(
       iv_txt = |{ is_item-obj_name }|
       iv_act = |{ zif_abapgit_definitions=>c_action-jump }?{ lv_encode }| ).
+
+  ENDMETHOD.
+
+
+  METHOD build_srcsystem_code.
+
+    IF is_item-srcsystem IS NOT INITIAL AND is_item-srcsystem <> sy-sysid.
+      rv_srcsystem_html_code = zcl_abapgit_html=>icon(
+        iv_name  = 'server-solid/grey'
+        iv_hint  = |Original system: { is_item-srcsystem }|
+        iv_class = 'cursor-pointer' ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -1020,7 +1037,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
       ELSE.
         lv_link = build_obj_jump_link( is_item ).
         ri_html->add( |<td class="type">{ is_item-obj_type }</td>| ).
-        ri_html->add( |<td class="object">{ lv_link } { build_inactive_object_code( is_item ) }</td>| ).
+        ri_html->add( |<td class="object">{ lv_link } { build_inactive_object_code( is_item )
+                      } { build_srcsystem_code( is_item ) }</td>| ).
       ENDIF.
     ENDIF.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -73,9 +73,10 @@ INTERFACE zif_abapgit_definitions
     END OF ty_comment .
   TYPES:
     BEGIN OF ty_item_signature,
-      obj_type TYPE tadir-object,
-      obj_name TYPE tadir-obj_name,
-      devclass TYPE devclass,
+      obj_type  TYPE tadir-object,
+      obj_name  TYPE tadir-obj_name,
+      devclass  TYPE devclass,
+      srcsystem TYPE tadir-srcsystem,
     END OF ty_item_signature .
   TYPES:
     BEGIN OF ty_item.
@@ -176,29 +177,31 @@ INTERFACE zif_abapgit_definitions
       WITH NON-UNIQUE SORTED KEY type COMPONENTS type sha1 .
   TYPES:
     BEGIN OF ty_tadir,
-      pgmid    TYPE tadir-pgmid,
-      object   TYPE tadir-object,
-      obj_name TYPE tadir-obj_name,
-      devclass TYPE tadir-devclass,
-      korrnum  TYPE tadir-korrnum, " todo, I think this field can be removed after #2464 -Hvam
-      delflag  TYPE tadir-delflag,
-      genflag  TYPE tadir-genflag,
-      path     TYPE string,
+      pgmid     TYPE tadir-pgmid,
+      object    TYPE tadir-object,
+      obj_name  TYPE tadir-obj_name,
+      devclass  TYPE tadir-devclass,
+      korrnum   TYPE tadir-korrnum, " used by ZCL_ABAPGIT_DEPENDENCIES->RESOLVE
+      delflag   TYPE tadir-delflag,
+      genflag   TYPE tadir-genflag,
+      path      TYPE string,
+      srcsystem TYPE tadir-srcsystem,
     END OF ty_tadir .
   TYPES:
     ty_tadir_tt TYPE STANDARD TABLE OF ty_tadir WITH DEFAULT KEY .
   TYPES:
     BEGIN OF ty_result,
-      obj_type TYPE tadir-object,
-      obj_name TYPE tadir-obj_name,
-      inactive TYPE abap_bool,
-      path     TYPE string,
-      filename TYPE string,
-      package  TYPE devclass,
-      match    TYPE abap_bool,
-      lstate   TYPE ty_item_state,
-      rstate   TYPE ty_item_state,
-      packmove TYPE abap_bool,
+      obj_type  TYPE tadir-object,
+      obj_name  TYPE tadir-obj_name,
+      inactive  TYPE abap_bool,
+      path      TYPE string,
+      filename  TYPE string,
+      package   TYPE devclass,
+      match     TYPE abap_bool,
+      lstate    TYPE ty_item_state,
+      rstate    TYPE ty_item_state,
+      packmove  TYPE abap_bool,
+      srcsystem TYPE tadir-srcsystem,
     END OF ty_result .
   TYPES:
     ty_results_tt TYPE STANDARD TABLE OF ty_result WITH DEFAULT KEY .
@@ -315,6 +318,7 @@ INTERFACE zif_abapgit_definitions
       files      TYPE ty_repo_file_tt,
       changed_by TYPE syuname,
       packmove   TYPE abap_bool,
+      srcsystem  TYPE tadir-srcsystem,
     END OF ty_repo_item .
   TYPES:
     ty_repo_item_tt TYPE STANDARD TABLE OF ty_repo_item WITH DEFAULT KEY .


### PR DESCRIPTION
In case an objects originates from a different system (`<> sy-sysid`), an icon will be shown after the object. On hover, you can see the id of the original system. 

Closes https://github.com/abapGit/abapGit/issues/3865

![image](https://user-images.githubusercontent.com/59966492/166149005-72111449-3fa6-459b-96f5-f10c133a75e6.png)
