### PR TITLE
OTGR: Fix errors with parent/child

### DIFF
--- a/src/objects/zcl_abapgit_object_otgr.clas.abap
+++ b/src/objects/zcl_abapgit_object_otgr.clas.abap
@@ -31,18 +31,27 @@ CLASS zcl_abapgit_object_otgr IMPLEMENTATION.
 
 
   METHOD instantiate_and_lock_otgr.
-    DATA: lv_new  TYPE abap_bool,
-          lv_name TYPE cls_attribute_name.
+    DATA:
+      lv_new   TYPE abap_bool,
+      lv_name  TYPE cls_attribute_name,
+      lv_state TYPE cls_type_group-activation_state.
 
     SELECT SINGLE name FROM cls_type_group INTO lv_name WHERE name = ms_item-obj_name.
-    lv_new = boolc( sy-subrc <> 0 ).
+    IF sy-subrc = 0.
+      lv_new   = abap_false.
+      lv_state = cl_pak_wb_domains=>co_activation_state-invalid.
+    ELSE.
+      lv_new   = abap_true.
+      lv_state = cl_pak_wb_domains=>co_activation_state-active.
+    ENDIF.
     lv_name = ms_item-obj_name.
 
     TRY.
         CREATE OBJECT ro_otgr
           EXPORTING
-            im_name = lv_name
-            im_new  = lv_new.
+            im_name             = lv_name
+            im_new              = lv_new
+            im_activation_state = lv_state.
       CATCH cx_pak_invalid_data
           cx_pak_not_authorized
           cx_pak_invalid_state
@@ -233,6 +242,7 @@ CLASS zcl_abapgit_object_otgr IMPLEMENTATION.
 
   METHOD zif_abapgit_object~serialize.
     DATA: lv_text      TYPE string,
+          lv_name      TYPE ty_otgr-cls_type_group,
           ls_otgr      TYPE ty_otgr,
           lo_otgr      TYPE REF TO cl_cls_object_type_group,
           lx_pak_error TYPE REF TO cx_root,
@@ -269,7 +279,19 @@ CLASS zcl_abapgit_object_otgr IMPLEMENTATION.
     TRY.
         ls_otgr-cls_type_group-name = lo_otgr->if_cls_object_type_group~get_name( ).
         ls_otgr-cls_type_group-proxy_flag = lo_otgr->if_cls_object_type_group~get_proxy_filter( ).
-        lo_otgr->get_elements( IMPORTING ex_elements = ls_otgr-elements ).
+        lo_otgr->get_elements(
+          EXPORTING
+            im_explicit_elements_only = abap_true
+          IMPORTING
+            ex_elements               = ls_otgr-elements ).
+
+        " Remove children since they are created automatically (by the child group)
+        LOOP AT ls_otgr-elements ASSIGNING <ls_element>.
+          SELECT SINGLE name FROM cls_type_group INTO lv_name WHERE name = <ls_element>-type.
+          IF sy-subrc = 0.
+            DELETE ls_otgr-elements.
+          ENDIF.
+        ENDLOOP.
 
         IF <lt_parents> IS ASSIGNED.
           CALL METHOD lo_otgr->('IF_CLS_OBJECT_TYPE_GROUP~GET_PARENT_GROUPS')


### PR DESCRIPTION
- Fix "error while instantiating CL_CLS_OBJECT_TYPE_GROUP"
- Remove children since they are created automatically