### PR TITLE
ENHC: Fix diffs due to OTR

### DIFF
--- a/src/objects/zcl_abapgit_object_enhc.clas.abap
+++ b/src/objects/zcl_abapgit_object_enhc.clas.abap
@@ -136,10 +136,6 @@ CLASS zcl_abapgit_object_enhc IMPLEMENTATION.
         li_enh_composite->if_enh_object~activate( ).
         li_enh_composite->if_enh_object~unlock( ).
 
-        zcl_abapgit_sotr_handler=>create_sotr(
-          iv_package = iv_package
-          io_xml     = io_xml ).
-
       CATCH cx_enh_root INTO lx_enh_root.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).
     ENDTRY.
@@ -228,12 +224,6 @@ CLASS zcl_abapgit_object_enhc IMPLEMENTATION.
                      ig_data = lt_enh_childs ).
         io_xml->add( iv_name = 'LONGTEXT_ID'
                      ig_data = lv_longtext_id ).
-
-        zcl_abapgit_sotr_handler=>read_sotr(
-          iv_pgmid    = 'R3TR'
-          iv_object   = ms_item-obj_type
-          iv_obj_name = ms_item-obj_name
-          io_xml      = io_xml ).
 
       CATCH cx_enh_root INTO lx_enh_root.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).


### PR DESCRIPTION
`cl_enh_composite` already handles OTR shorttext and there's no need to use `zcl_abapgit_sotr_handler` (which leads to duplicate entries in `sotr_use` for the same object).

Update test case:
https://github.com/abapGit-tests/ENHC