### PR TITLE
AMSD: Fix "Step DDIC is only for DDIC objects"

### DIFF
--- a/src/objects/zcl_abapgit_object_amsd.clas.abap
+++ b/src/objects/zcl_abapgit_object_amsd.clas.abap
@@ -316,7 +316,7 @@ CLASS zcl_abapgit_object_amsd IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_deserialize_steps.
-    APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
   ENDMETHOD.
 
 


### PR DESCRIPTION
AMSD is not supported by mass activation. Assigns AMSD to "Step ABAP"