### PR TITLE
ASFC,SPLO,SPPF: Fix missing transport entry

### DIFF
--- a/src/objects/zcl_abapgit_object_asfc.clas.abap
+++ b/src/objects/zcl_abapgit_object_asfc.clas.abap
@@ -38,12 +38,16 @@ CLASS zcl_abapgit_object_asfc IMPLEMENTATION.
 
   METHOD zif_abapgit_object~delete.
 
+    set_default_transport( iv_transport ).
+
     get_generic( )->delete( iv_package ).
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~deserialize.
+
+    set_default_transport( iv_transport ).
 
     get_generic( )->deserialize(
       iv_package = iv_package

--- a/src/objects/zcl_abapgit_object_splo.clas.abap
+++ b/src/objects/zcl_abapgit_object_splo.clas.abap
@@ -30,6 +30,10 @@ CLASS zcl_abapgit_object_splo IMPLEMENTATION.
     DELETE FROM tsp1d WHERE papart = ms_item-obj_name.    "#EC CI_SUBRC
     DELETE FROM tsp0p WHERE pdpaper = ms_item-obj_name.   "#EC CI_SUBRC
 
+    set_default_transport( iv_transport ).
+
+    corr_insert( iv_package ).
+
   ENDMETHOD.
 
 
@@ -50,6 +54,8 @@ CLASS zcl_abapgit_object_splo IMPLEMENTATION.
     MODIFY tsp1t FROM ls_tsp1t.                           "#EC CI_SUBRC
     MODIFY tsp1d FROM ls_tsp1d.                           "#EC CI_SUBRC
     MODIFY tsp0p FROM ls_tsp0p.                           "#EC CI_SUBRC
+
+    set_default_transport( iv_transport ).
 
     tadir_insert( iv_package ).
 

--- a/src/objects/zcl_abapgit_object_sppf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sppf.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SPPF IMPLEMENTATION.
+CLASS zcl_abapgit_object_sppf IMPLEMENTATION.
 
 
   METHOD get_generic.
@@ -38,12 +38,16 @@ CLASS ZCL_ABAPGIT_OBJECT_SPPF IMPLEMENTATION.
 
   METHOD zif_abapgit_object~delete.
 
+    set_default_transport( iv_transport ).
+
     get_generic( )->delete( iv_package ).
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~deserialize.
+
+    set_default_transport( iv_transport ).
 
     get_generic( )->deserialize(
       iv_package = iv_package

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -41,6 +41,9 @@ CLASS zcl_abapgit_objects_super DEFINITION
     METHODS set_default_package
       IMPORTING
         !iv_package TYPE devclass .
+    METHODS set_default_transport
+      IMPORTING
+        !iv_transport TYPE trkorr.
     METHODS serialize_longtexts
       IMPORTING
         !ii_xml           TYPE REF TO zif_abapgit_xml_output
@@ -366,7 +369,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD set_default_package.
 
-    " In certain cases we need to set the package package via ABAP memory
+    " In certain cases we need to set the package via ABAP memory
     " because we can't supply it via the APIs.
     "
     " Set default package, see function module RS_CORR_INSERT FORM get_current_devclass.
@@ -377,6 +380,18 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     " We don't need to reset the memory as it is done in above mentioned form routine.
 
     EXPORT current_devclass FROM iv_package TO MEMORY ID 'EUK'.
+
+  ENDMETHOD.
+
+
+  METHOD set_default_transport.
+
+    " In certain cases we need to set the transport via ABAP memory
+    " because we can't supply it via the APIs.
+    "
+    " See function module RS_CORR_INSERT
+
+    EXPORT tasknr FROM iv_transport TO MEMORY ID 'EUT'.
 
   ENDMETHOD.
 


### PR DESCRIPTION
In certain cases, the default transport set by abapGit does not work and there's no API to pass the transport for the object type. Therefore, we need to set the transport via ABAP memory (similar to setting the default package).