### PR TITLE
IOBJ/ODSO: Fix errors if objects exist already

### DIFF
--- a/src/objects/zcl_abapgit_object_iobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_iobj.clas.abap
@@ -55,14 +55,20 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
 
     CALL FUNCTION 'RSD_IOBJ_GET'
       EXPORTING
-        i_iobjnm  = lv_objna
-        i_objvers = 'A'
+        i_iobjnm         = lv_objna
+        i_objvers        = 'A'
       IMPORTING
-        e_s_viobj = <lg_viobj>.
-
-    ASSIGN COMPONENT 'TSTPNM' OF STRUCTURE <lg_viobj> TO <lg_tstpnm>.
-
-    rv_user = <lg_tstpnm>.
+        e_s_viobj        = <lg_viobj>
+      EXCEPTIONS
+        iobj_not_found   = 1
+        illegal_input    = 2
+        bct_comp_invalid = 3
+        not_authorized   = 4
+        OTHERS           = 5.
+    IF sy-subrc = 0.
+      ASSIGN COMPONENT 'TSTPNM' OF STRUCTURE <lg_viobj> TO <lg_tstpnm>.
+      rv_user = <lg_tstpnm>.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -208,30 +214,48 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
 
     TRY.
 
-        CALL FUNCTION 'BAPI_IOBJ_CREATE'
-          EXPORTING
-            details                  = <lg_details>
-          IMPORTING
-            return                   = ls_return
-          TABLES
-            compounds                = <lt_compounds>
-            attributes               = <lt_attributes>
-            navigationattributes     = <lt_navigationattributes>
-            atrnavinfoprovider       = <lt_atrnavinfoprovider>
-            hierarchycharacteristics = <lt_hierarchycharacteristics>
-            elimination              = <lt_elimination>
-            hanafieldsmapping        = <lt_hanafieldsmapping>
-            xxlattributes            = <lt_xxlattributes>.
-
-        IF ls_return-type = 'E'.
-          zcx_abapgit_exception=>raise( |Error when creating iobj: { ls_return-message }| ).
-        ENDIF.
-
         ASSIGN
           COMPONENT 'INFOOBJECT'
           OF STRUCTURE <lg_details>
           TO <lg_infoobject>.
         ASSERT sy-subrc = 0.
+
+        IF zif_abapgit_object~exists( ) = abap_false.
+          CALL FUNCTION 'BAPI_IOBJ_CREATE'
+            EXPORTING
+              details                  = <lg_details>
+            IMPORTING
+              return                   = ls_return
+            TABLES
+              compounds                = <lt_compounds>
+              attributes               = <lt_attributes>
+              navigationattributes     = <lt_navigationattributes>
+              atrnavinfoprovider       = <lt_atrnavinfoprovider>
+              hierarchycharacteristics = <lt_hierarchycharacteristics>
+              elimination              = <lt_elimination>
+              hanafieldsmapping        = <lt_hanafieldsmapping>
+              xxlattributes            = <lt_xxlattributes>.
+        ELSE.
+          CALL FUNCTION 'BAPI_IOBJ_CHANGE'
+            EXPORTING
+              infoobject               = <lg_infoobject>
+              details                  = <lg_details>
+            IMPORTING
+              return                   = ls_return
+            TABLES
+              compounds                = <lt_compounds>
+              attributes               = <lt_attributes>
+              navigationattributes     = <lt_navigationattributes>
+              atrnavinfoprovider       = <lt_atrnavinfoprovider>
+              hierarchycharacteristics = <lt_hierarchycharacteristics>
+              elimination              = <lt_elimination>
+              hanafieldsmapping        = <lt_hanafieldsmapping>
+              xxlattributes            = <lt_xxlattributes>.
+        ENDIF.
+
+        IF ls_return-type = 'E'.
+          zcx_abapgit_exception=>raise( |Error when creating iobj: { ls_return-message }| ).
+        ENDIF.
 
         APPEND <lg_infoobject> TO <lt_infoobjects>.
 


### PR DESCRIPTION
Implementation worked only for new objects (argh, that should not have been approved)

For example:

![image](https://user-images.githubusercontent.com/59966492/167695624-bf9c54a8-06e6-4cda-99f5-b17786d9b936.png)
