### PR TITLE
Fix tag popup 

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -1086,7 +1086,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
           lv_answer    TYPE c LENGTH 1,
           lv_default   TYPE i,
           lv_tag       TYPE string,
-          lv_text      TYPE string,
           lt_selection TYPE TABLE OF spopli.
 
     FIELD-SYMBOLS: <ls_sel> LIKE LINE OF lt_selection,
@@ -1148,9 +1147,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     ls_branch = lo_branches->find_by_name( <ls_tag>-name ).
     MOVE-CORRESPONDING ls_branch TO rs_tag.
-
-    lv_text = |Tag switched to { zcl_abapgit_git_tag=>remove_tag_prefix( rs_tag-name ) } |.
-    MESSAGE lv_text TYPE 'S'.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -247,7 +247,8 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
   METHOD switch_tag.
 
     DATA: lo_repo TYPE REF TO zcl_abapgit_repo_online,
-          ls_tag  TYPE zif_abapgit_definitions=>ty_git_tag.
+          ls_tag  TYPE zif_abapgit_definitions=>ty_git_tag,
+          lv_text TYPE string.
 
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
 
@@ -256,9 +257,15 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
     ENDIF.
 
+    REPLACE '^{}' IN ls_tag-name WITH ''.
+
     lo_repo->select_branch( ls_tag-name ).
 
     COMMIT WORK AND WAIT.
+
+    lv_text = |Tag switched to { zcl_abapgit_git_tag=>remove_tag_prefix( ls_tag-name ) } |.
+
+    MESSAGE lv_text TYPE 'S'.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
Tag popup is used for delete and switch therefore the message must be moved to the switch method.

Also reference tags were not handled properly when switching (showing `^{}` as part of tag name) .