### PR TITLE
Fix syntax error in systems with BW

### DIFF
--- a/src/objects/core/zcl_abapgit_gui_jumper.clas.abap
+++ b/src/objects/core/zcl_abapgit_gui_jumper.clas.abap
@@ -51,19 +51,27 @@ CLASS zcl_abapgit_gui_jumper IMPLEMENTATION.
 
     DATA:
       lv_exit  TYPE abap_bool,
-      lv_tlogo TYPE rstlogo,
-      lv_objnm TYPE rsawbnobjnm.
+      lv_tlogo TYPE c LENGTH 4, "rstlogo
+      lv_objnm TYPE c LENGTH 40. "rsawbnobjnm
 
     lv_tlogo = is_item-obj_type.
     lv_objnm = is_item-obj_name.
 
-    lv_exit = cl_rsawbn_awb=>is_supported_navigation(
-      i_tlogo = lv_tlogo
-      i_fcode = 'DISPLAY' ).
+    TRY.
+        CALL METHOD ('CL_RSAWBN_AWB')=>('IS_SUPPORTED_NAVIGATION')
+          EXPORTING
+            i_tlogo               = lv_tlogo
+            i_fcode               = 'DISPLAY'
+          IMPORTING
+            re_is_supported_fcode = lv_exit.
 
-    IF lv_exit = abap_false.
-      RETURN.
-    ENDIF.
+        IF lv_exit = abap_false.
+          RETURN.
+        ENDIF.
+      CATCH cx_root.
+        " Not a BW system
+        RETURN.
+    ENDTRY.
 
     TRY.
         CALL METHOD ('CL_RSAWBN_AWB')=>('NAVIGATE_FROM_APPLICATION')
@@ -73,13 +81,15 @@ CLASS zcl_abapgit_gui_jumper IMPLEMENTATION.
             i_new_mode             = iv_new_window
           IMPORTING
             e_exit_own_application = lv_exit.
+
       CATCH cx_root.
-        cl_rsawbn_awb=>navigate_from_application(
+        " Older release without i_new_mode
+        CALL METHOD ('CL_RSAWBN_AWB')=>('NAVIGATE_FROM_APPLICATION')
           EXPORTING
             i_tlogo                = lv_tlogo
             i_objnm                = lv_objnm
           IMPORTING
-            e_exit_own_application = lv_exit ).
+            e_exit_own_application = lv_exit.
     ENDTRY.
 
     rv_exit = lv_exit.


### PR DESCRIPTION
abapGit should support systems without `SAP_BW` component. Therefore, references to BW data types have to be replaced by generic types and BW classes have to be replaced by dynamic calls.

Follow-up to #5556

Closes #5565