### PR TITLE
Data serialization: fix dump ITAB_DUPLICATE_KEY

### DIFF
--- a/src/data/zcl_abapgit_data_serializer.clas.abap
+++ b/src/data/zcl_abapgit_data_serializer.clas.abap
@@ -32,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_data_serializer IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_DATA_SERIALIZER IMPLEMENTATION.
 
 
   METHOD convert_itab_to_json.
@@ -48,6 +48,7 @@ CLASS zcl_abapgit_data_serializer IMPLEMENTATION.
     TRY.
         lo_ajson = zcl_abapgit_ajson=>create_empty( ).
         lo_ajson->keep_item_order( ).
+        lo_ajson->format_datetime( ).
         lo_ajson->set(
           iv_path = '/'
           iv_val = <lg_tab> ).

--- a/src/json/zcl_abapgit_ajson.clas.locals_imp.abap
+++ b/src/json/zcl_abapgit_ajson.clas.locals_imp.abap
@@ -1439,7 +1439,7 @@ CLASS lcl_abap_to_json IMPLEMENTATION.
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)
     " the structures will be repeated in real life
 
-    ls_next_prefix-path = is_prefix-path && ls_root-name && '/'.
+    ls_next_prefix-path = is_prefix-path && <root>-name && '/'.
 
     LOOP AT lt_comps ASSIGNING <c>.
 

--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -119,6 +119,9 @@ CLASS ZCL_ABAPGIT_FILE_DESERIALIZE IMPLEMENTATION.
       ENDLOOP.
     ENDIF.
 
+    "ignore table content
+    DELETE rt_results WHERE path = '/data/'.
+
     SORT rt_results
       BY obj_type ASCENDING
          obj_name ASCENDING

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -50,7 +50,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -162,7 +162,8 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
           lt_unique_package_names TYPE HASHED TABLE OF devclass WITH UNIQUE KEY table_line.
 
     lv_length  = strlen( io_dot->get_starting_folder( ) ).
-    IF lv_length > strlen( iv_path ).
+    IF lv_length > strlen( iv_path )
+    OR iv_path = '/data/'.
 * treat as not existing locally
       RETURN.
     ENDIF.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -304,6 +304,37 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       ii_config  = get_data_config( )
       it_files   = get_files_remote( ) ).
 
+    " Update database
+    DATA ls_result      TYPE zif_abapgit_data_deserializer=>ty_result.
+    DATA ls_overwrite   TYPE zif_abapgit_definitions=>ty_overwrite.
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+
+    LOOP AT lt_result INTO ls_result.
+      READ TABLE is_checks-overwrite INTO ls_overwrite WITH KEY obj_type = 'TABU' obj_name = ls_result-table.
+      IF sy-subrc <> 0 OR ls_overwrite-decision <> 'Y'.
+        CONTINUE.
+      ENDIF.
+
+      IF ls_result-deletes IS BOUND.
+        ASSIGN ls_result-deletes->* TO <tab>.
+        IF <tab> IS NOT INITIAL.
+          DELETE (ls_result-table) FROM TABLE <tab>.
+        ENDIF.
+      ENDIF.
+      IF ls_result-inserts IS BOUND.
+        ASSIGN ls_result-inserts->* TO <tab>.
+        IF <tab> IS NOT INITIAL.
+          INSERT (ls_result-table) FROM TABLE <tab>.
+        ENDIF.
+      ENDIF.
+      IF ls_result-updates IS BOUND.
+        ASSIGN ls_result-updates->* TO <tab>.
+        IF <tab> IS NOT INITIAL.
+          MODIFY (ls_result-table) FROM TABLE <tab>.
+        ENDIF.
+      ENDIF.
+    ENDLOOP.
+
     CLEAR: mt_local.
 
     update_last_deserialize( ).


### PR DESCRIPTION
Dear contributors,

Apologize if that may not be the perfect pull request (this is my first one ever).
Here is the problem: the system dumps when I try to create a new online repository where /data/ folder contains data from some customizing tables :
<img width="653" alt="2022-05-20_14h09_02" src="https://user-images.githubusercontent.com/82606868/169526852-18d7a88b-e015-4d72-9c0f-35a73f2197d5.png">

It looks like the issue occurs as soon as one of the tables has a DDIC definition comprizing of "cascading" include structures. Example: WCFC_GIL_COMPROP.
<img width="447" alt="2022-05-20_14h23_32" src="https://user-images.githubusercontent.com/82606868/169527475-705a5f3a-7b1c-481f-952f-2a430947f53f.png">

Changing one line of coding solved the problem in my system.
Cheers,
Nick.
