### PR TITLE
Commit table content if user wants to

### DIFF
--- a/src/data/zcl_abapgit_data_serializer.clas.abap
+++ b/src/data/zcl_abapgit_data_serializer.clas.abap
@@ -32,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_data_serializer IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_DATA_SERIALIZER IMPLEMENTATION.
 
 
   METHOD convert_itab_to_json.
@@ -48,6 +48,7 @@ CLASS zcl_abapgit_data_serializer IMPLEMENTATION.
     TRY.
         lo_ajson = zcl_abapgit_ajson=>create_empty( ).
         lo_ajson->keep_item_order( ).
+        lo_ajson->format_datetime( ).
         lo_ajson->set(
           iv_path = '/'
           iv_val = <lg_tab> ).

--- a/src/json/zcl_abapgit_ajson.clas.locals_imp.abap
+++ b/src/json/zcl_abapgit_ajson.clas.locals_imp.abap
@@ -1439,7 +1439,7 @@ CLASS lcl_abap_to_json IMPLEMENTATION.
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)
     " the structures will be repeated in real life
 
-    ls_next_prefix-path = is_prefix-path && ls_root-name && '/'.
+    ls_next_prefix-path = is_prefix-path && <root>-name && '/'.
 
     LOOP AT lt_comps ASSIGNING <c>.
 

--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -119,6 +119,9 @@ CLASS ZCL_ABAPGIT_FILE_DESERIALIZE IMPLEMENTATION.
       ENDLOOP.
     ENDIF.
 
+    "ignore table content
+    DELETE rt_results WHERE path = '/data/'.
+
     SORT rt_results
       BY obj_type ASCENDING
          obj_name ASCENDING

--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -120,7 +120,7 @@ CLASS ZCL_ABAPGIT_FILE_DESERIALIZE IMPLEMENTATION.
     ENDIF.
 
     "ignore table content
-    DELETE rt_results WHERE path = '/data/'.
+    DELETE rt_results WHERE path = zif_abapgit_data_config=>c_default_path.
 
     SORT rt_results
       BY obj_type ASCENDING

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -163,7 +163,7 @@ CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
 
     lv_length  = strlen( io_dot->get_starting_folder( ) ).
     IF lv_length > strlen( iv_path )
-    OR iv_path = '/data/'.
+    OR iv_path = zif_abapgit_data_config=>c_default_path.
 * treat as not existing locally
       RETURN.
     ENDIF.

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -50,7 +50,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -162,7 +162,8 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
           lt_unique_package_names TYPE HASHED TABLE OF devclass WITH UNIQUE KEY table_line.
 
     lv_length  = strlen( io_dot->get_starting_folder( ) ).
-    IF lv_length > strlen( iv_path ).
+    IF lv_length > strlen( iv_path )
+    OR iv_path = '/data/'.
 * treat as not existing locally
       RETURN.
     ENDIF.

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -162,8 +162,7 @@ CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
           lt_unique_package_names TYPE HASHED TABLE OF devclass WITH UNIQUE KEY table_line.
 
     lv_length  = strlen( io_dot->get_starting_folder( ) ).
-    IF lv_length > strlen( iv_path )
-    OR iv_path = zif_abapgit_data_config=>c_default_path.
+    IF lv_length > strlen( iv_path ).
 * treat as not existing locally
       RETURN.
     ENDIF.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -266,7 +266,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
           ls_result        TYPE zif_abapgit_data_deserializer=>ty_result,
           ls_overwrite     TYPE zif_abapgit_definitions=>ty_overwrite.
 
-    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+    FIELD-SYMBOLS <lt_tab> TYPE ANY TABLE.
 
     find_remote_dot_abapgit( ).
     find_remote_dot_apack( ).
@@ -308,7 +308,9 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       ii_config  = get_data_config( )
       it_files   = get_files_remote( ) ).
 
-    " Update database
+    " Update database if user wants to: shall be added
+    " to the deserialize function above together with parameter
+    " IS_CHECKS once the 'test' period is ended
     LOOP AT lt_result INTO ls_result.
       READ TABLE is_checks-overwrite INTO ls_overwrite
         WITH KEY object_type_and_name
@@ -320,21 +322,21 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       ENDIF.
 
       IF ls_result-deletes IS BOUND.
-        ASSIGN ls_result-deletes->* TO <tab>.
-        IF <tab> IS NOT INITIAL.
-          DELETE (ls_result-table) FROM TABLE <tab>.
+        ASSIGN ls_result-deletes->* TO <lt_tab>.
+        IF <lt_tab> IS NOT INITIAL.
+          DELETE (ls_result-table) FROM TABLE <lt_tab>.
         ENDIF.
       ENDIF.
       IF ls_result-inserts IS BOUND.
-        ASSIGN ls_result-inserts->* TO <tab>.
-        IF <tab> IS NOT INITIAL.
-          INSERT (ls_result-table) FROM TABLE <tab>.
+        ASSIGN ls_result-inserts->* TO <lt_tab>.
+        IF <lt_tab> IS NOT INITIAL.
+          INSERT (ls_result-table) FROM TABLE <lt_tab>.
         ENDIF.
       ENDIF.
       IF ls_result-updates IS BOUND.
-        ASSIGN ls_result-updates->* TO <tab>.
-        IF <tab> IS NOT INITIAL.
-          MODIFY (ls_result-table) FROM TABLE <tab>.
+        ASSIGN ls_result-updates->* TO <lt_tab>.
+        IF <lt_tab> IS NOT INITIAL.
+          MODIFY (ls_result-table) FROM TABLE <lt_tab>.
         ENDIF.
       ENDIF.
     ENDLOOP.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -304,6 +304,37 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       ii_config  = get_data_config( )
       it_files   = get_files_remote( ) ).
 
+    " Update database
+    DATA ls_result      TYPE zif_abapgit_data_deserializer=>ty_result.
+    DATA ls_overwrite   TYPE zif_abapgit_definitions=>ty_overwrite.
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
+
+    LOOP AT lt_result INTO ls_result.
+      READ TABLE is_checks-overwrite INTO ls_overwrite WITH KEY obj_type = 'TABU' obj_name = ls_result-table.
+      IF sy-subrc <> 0 OR ls_overwrite-decision <> 'Y'.
+        CONTINUE.
+      ENDIF.
+
+      IF ls_result-deletes IS BOUND.
+        ASSIGN ls_result-deletes->* TO <tab>.
+        IF <tab> IS NOT INITIAL.
+          DELETE (ls_result-table) FROM TABLE <tab>.
+        ENDIF.
+      ENDIF.
+      IF ls_result-inserts IS BOUND.
+        ASSIGN ls_result-inserts->* TO <tab>.
+        IF <tab> IS NOT INITIAL.
+          INSERT (ls_result-table) FROM TABLE <tab>.
+        ENDIF.
+      ENDIF.
+      IF ls_result-updates IS BOUND.
+        ASSIGN ls_result-updates->* TO <tab>.
+        IF <tab> IS NOT INITIAL.
+          MODIFY (ls_result-table) FROM TABLE <tab>.
+        ENDIF.
+      ENDIF.
+    ENDLOOP.
+
     CLEAR: mt_local.
 
     update_last_deserialize( ).

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -262,7 +262,11 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     DATA: lt_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
           lt_result        TYPE zif_abapgit_data_deserializer=>ty_results,
-          lx_error         TYPE REF TO zcx_abapgit_exception.
+          lx_error         TYPE REF TO zcx_abapgit_exception,
+          ls_result        TYPE zif_abapgit_data_deserializer=>ty_result,
+          ls_overwrite     TYPE zif_abapgit_definitions=>ty_overwrite.
+
+    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
 
     find_remote_dot_abapgit( ).
     find_remote_dot_apack( ).
@@ -305,13 +309,13 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       it_files   = get_files_remote( ) ).
 
     " Update database
-    DATA ls_result      TYPE zif_abapgit_data_deserializer=>ty_result.
-    DATA ls_overwrite   TYPE zif_abapgit_definitions=>ty_overwrite.
-    FIELD-SYMBOLS <tab> TYPE ANY TABLE.
-
     LOOP AT lt_result INTO ls_result.
-      READ TABLE is_checks-overwrite INTO ls_overwrite WITH KEY obj_type = 'TABU' obj_name = ls_result-table.
-      IF sy-subrc <> 0 OR ls_overwrite-decision <> 'Y'.
+      READ TABLE is_checks-overwrite INTO ls_overwrite
+        WITH KEY object_type_and_name
+      COMPONENTS obj_type = zif_abapgit_data_config=>c_data_type-tabu
+                 obj_name = ls_result-table.
+
+      IF sy-subrc <> 0 OR ls_overwrite-decision <> zif_abapgit_definitions=>c_yes.
         CONTINUE.
       ENDIF.
 


### PR DESCRIPTION
Hello,
To make it possible to import and commit database content if the user confirms that's what he wants to in the popup, I had to change a few things during /data/ files (de)serialization:

- Fixed error message "Object type TABU is not supported by this system". To avoid this error I filtered objects coming from /data/ folder in ZCL_ABAPGIT_FILE_DESERIALIZE->FILTER_FILES_TO_DESERIALIZE
- Fixed fields with date format that always appear as different between local and remote repository because they are not formatted exactly the same way during serialization and deserialization. See line lo_ajson->format_datetime( ) added to ZCL_ABAPGIT_DATA_SERIALIZER->CONVERT_ITAB_TO_JSON

Hope that helps!
Cheers,
Nick