### PR TITLE
Fix object deletions not working

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -150,6 +150,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
 
       APPEND INITIAL LINE TO lt_changes ASSIGNING <ls_changes>.
       MOVE-CORRESPONDING <ls_result> TO <ls_changes>.
+      <ls_changes>-devclass = <ls_result>-package.
 
       IF <ls_result>-packmove = abap_true.
         <ls_changes>-action = zif_abapgit_objects=>c_deserialize_action-packmove.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -141,6 +141,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       ls_tadir-pgmid    = 'R3TR'.
       ls_tadir-object   = <ls_overwrite>-obj_type.
       ls_tadir-obj_name = <ls_overwrite>-obj_name.
+      ls_tadir-devclass = <ls_overwrite>-devclass.
       INSERT ls_tadir INTO TABLE lt_tadir.
 
     ENDLOOP.


### PR DESCRIPTION
Package is now required for CLAS deletion for RS_CORR_INSERT but was not correctly determined for object deletions because of different field names when using MOVE-CORRESPONDING and another missing assignment.

Fixes #5593

Would be nice if someone could double check this change.