### PR TITLE
fix: exclude Translation Object Detective language for MSAG objects

### DIFF
--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -165,7 +165,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
                           WITH NON-UNIQUE DEFAULT KEY,
           lt_dokil             TYPE zif_abapgit_definitions=>ty_dokil_tt,
           ls_dokil             LIKE LINE OF lt_dokil,
-          language_filter      TYPE zif_abapgit_environment=>ty_system_language_filter.
+          lt_language_filter   TYPE zif_abapgit_environment=>ty_system_language_filter.
 
     FIELD-SYMBOLS: <ls_t100>  TYPE t100.
 
@@ -189,13 +189,13 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         AND masterlang = abap_true
         ORDER BY PRIMARY KEY.
     ELSE.
-      language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+      lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
       SELECT * FROM dokil
         INTO TABLE lt_dokil
         FOR ALL ENTRIES IN lt_doku_object_names
         WHERE id = 'NA'
         AND object = lt_doku_object_names-table_line
-        AND langu IN language_filter
+        AND langu IN lt_language_filter
         ORDER BY PRIMARY KEY.
     ENDIF.
 
@@ -212,11 +212,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
 
   METHOD serialize_texts.
 
-    DATA: lv_msg_id       TYPE rglif-message_id,
-          lt_t100_texts   TYPE ty_t100_texts,
-          lt_t100t        TYPE TABLE OF t100t,
-          lt_i18n_langs   TYPE TABLE OF langu,
-          language_filter TYPE zif_abapgit_environment=>ty_system_language_filter.
+    DATA: lv_msg_id          TYPE rglif-message_id,
+          lt_t100_texts      TYPE ty_t100_texts,
+          lt_t100t           TYPE TABLE OF t100t,
+          lt_i18n_langs      TYPE TABLE OF langu,
+          lt_language_filter TYPE zif_abapgit_environment=>ty_system_language_filter.
 
     lv_msg_id = ms_item-obj_name.
 
@@ -226,11 +226,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
 
     " Collect additional languages
     " Skip main lang - it has been already serialized and also technical languages
-    language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+    lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
     SELECT DISTINCT sprsl AS langu INTO TABLE lt_i18n_langs
       FROM t100t
       WHERE arbgb = lv_msg_id
-      AND sprsl IN language_filter
+      AND sprsl IN lt_language_filter
       AND sprsl <> mv_language.          "#EC CI_BYPASS "#EC CI_GENBUFF
 
     SORT lt_i18n_langs ASCENDING.

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -164,7 +164,8 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
           lt_doku_object_names TYPE STANDARD TABLE OF dokhl-object
                           WITH NON-UNIQUE DEFAULT KEY,
           lt_dokil             TYPE zif_abapgit_definitions=>ty_dokil_tt,
-          ls_dokil             LIKE LINE OF lt_dokil.
+          ls_dokil             LIKE LINE OF lt_dokil,
+          language_filter      TYPE zif_abapgit_environment=>ty_system_language_filter.
 
     FIELD-SYMBOLS: <ls_t100>  TYPE t100.
 
@@ -188,7 +189,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         AND masterlang = abap_true
         ORDER BY PRIMARY KEY.
     ELSE.
-      DATA(language_filter) = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+      language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
       SELECT * FROM dokil
         INTO TABLE lt_dokil
         FOR ALL ENTRIES IN lt_doku_object_names
@@ -211,10 +212,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
 
   METHOD serialize_texts.
 
-    DATA: lv_msg_id     TYPE rglif-message_id,
-          lt_t100_texts TYPE ty_t100_texts,
-          lt_t100t      TYPE TABLE OF t100t,
-          lt_i18n_langs TYPE TABLE OF langu.
+    DATA: lv_msg_id       TYPE rglif-message_id,
+          lt_t100_texts   TYPE ty_t100_texts,
+          lt_t100t        TYPE TABLE OF t100t,
+          lt_i18n_langs   TYPE TABLE OF langu,
+          language_filter TYPE zif_abapgit_environment=>ty_system_language_filter.
 
     lv_msg_id = ms_item-obj_name.
 
@@ -223,8 +225,8 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
     ENDIF.
 
     " Collect additional languages
-    " Skip main lang - it has been already serialized
-    DATA(language_filter) = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+    " Skip main lang - it has been already serialized and also technical languages
+    language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
     SELECT DISTINCT sprsl AS langu INTO TABLE lt_i18n_langs
       FROM t100t
       WHERE arbgb = lv_msg_id

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -193,6 +193,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         FOR ALL ENTRIES IN lt_doku_object_names
         WHERE id = 'NA'
         AND object = lt_doku_object_names-table_line
+        AND langu <> c_translation_detective_lang
         ORDER BY PRIMARY KEY.
     ENDIF.
 
@@ -225,6 +226,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
     SELECT DISTINCT sprsl AS langu INTO TABLE lt_i18n_langs
       FROM t100t
       WHERE arbgb = lv_msg_id
+      AND sprsl <> c_translation_detective_lang
       AND sprsl <> mv_language.          "#EC CI_BYPASS "#EC CI_GENBUFF
 
     SORT lt_i18n_langs ASCENDING.

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -193,7 +193,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         FOR ALL ENTRIES IN lt_doku_object_names
         WHERE id = 'NA'
         AND object = lt_doku_object_names-table_line
-        AND langu <> c_translation_detective_lang
+        AND langu <> mv_translation_detective_lang
         ORDER BY PRIMARY KEY.
     ENDIF.
 
@@ -226,7 +226,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
     SELECT DISTINCT sprsl AS langu INTO TABLE lt_i18n_langs
       FROM t100t
       WHERE arbgb = lv_msg_id
-      AND sprsl <> c_translation_detective_lang
+      AND sprsl <> mv_translation_detective_lang
       AND sprsl <> mv_language.          "#EC CI_BYPASS "#EC CI_GENBUFF
 
     SORT lt_i18n_langs ASCENDING.

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -188,13 +188,13 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         AND masterlang = abap_true
         ORDER BY PRIMARY KEY.
     ELSE.
+      DATA(language_filter) = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
       SELECT * FROM dokil
         INTO TABLE lt_dokil
         FOR ALL ENTRIES IN lt_doku_object_names
         WHERE id = 'NA'
         AND object = lt_doku_object_names-table_line
-        AND langu <> mv_translation_detective_lang
-        AND langu <> mv_pseudo_translation_language
+        AND langu IN language_filter
         ORDER BY PRIMARY KEY.
     ENDIF.
 
@@ -224,11 +224,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
 
     " Collect additional languages
     " Skip main lang - it has been already serialized
+    DATA(language_filter) = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
     SELECT DISTINCT sprsl AS langu INTO TABLE lt_i18n_langs
       FROM t100t
       WHERE arbgb = lv_msg_id
-      AND sprsl <> mv_translation_detective_lang
-      AND sprsl <> mv_pseudo_translation_language
+      AND sprsl IN language_filter
       AND sprsl <> mv_language.          "#EC CI_BYPASS "#EC CI_GENBUFF
 
     SORT lt_i18n_langs ASCENDING.

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -160,11 +160,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
 
   METHOD serialize_longtexts_msag.
 
-    DATA: lv_doku_object_name           TYPE dokhl-object,
-          lt_doku_object_names          TYPE STANDARD TABLE OF dokhl-object
+    DATA: lv_doku_object_name  TYPE dokhl-object,
+          lt_doku_object_names TYPE STANDARD TABLE OF dokhl-object
                           WITH NON-UNIQUE DEFAULT KEY,
-          lt_dokil            TYPE zif_abapgit_definitions=>ty_dokil_tt,
-          ls_dokil            LIKE LINE OF lt_dokil.
+          lt_dokil             TYPE zif_abapgit_definitions=>ty_dokil_tt,
+          ls_dokil             LIKE LINE OF lt_dokil.
 
     FIELD-SYMBOLS: <ls_t100>  TYPE t100.
 
@@ -194,6 +194,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         WHERE id = 'NA'
         AND object = lt_doku_object_names-table_line
         AND langu <> mv_translation_detective_lang
+        AND langu <> mv_pseudo_translation_language
         ORDER BY PRIMARY KEY.
     ENDIF.
 
@@ -227,6 +228,7 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
       FROM t100t
       WHERE arbgb = lv_msg_id
       AND sprsl <> mv_translation_detective_lang
+      AND sprsl <> mv_pseudo_translation_language
       AND sprsl <> mv_language.          "#EC CI_BYPASS "#EC CI_GENBUFF
 
     SORT lt_i18n_langs ASCENDING.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -6,7 +6,6 @@ CLASS zcl_abapgit_objects_super DEFINITION
   PUBLIC SECTION.
 
     CONSTANTS c_user_unknown TYPE syuname VALUE 'UNKNOWN'.
-    CONSTANTS c_translation_detective_lang TYPE spras VALUE '늑'.
 
     METHODS constructor
       IMPORTING
@@ -16,6 +15,7 @@ CLASS zcl_abapgit_objects_super DEFINITION
 
     DATA ms_item TYPE zif_abapgit_definitions=>ty_item .
     DATA mv_language TYPE spras .
+    DATA mv_translation_detective_lang TYPE spras.
 
     METHODS get_metadata
       RETURNING
@@ -100,6 +100,11 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
 
   METHOD constructor.
+    CALL FUNCTION 'CONVERSION_EXIT_ISOLA_INPUT'
+      EXPORTING
+        input  = '1Q'
+      IMPORTING
+        output = mv_translation_detective_lang.
     ms_item = is_item.
     ASSERT NOT ms_item IS INITIAL.
     mv_language = iv_language.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -6,6 +6,7 @@ CLASS zcl_abapgit_objects_super DEFINITION
   PUBLIC SECTION.
 
     CONSTANTS c_user_unknown TYPE syuname VALUE 'UNKNOWN'.
+    CONSTANTS c_translation_detective_lang TYPE spras VALUE '늑'.
 
     METHODS constructor
       IMPORTING

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -16,6 +16,7 @@ CLASS zcl_abapgit_objects_super DEFINITION
     DATA ms_item TYPE zif_abapgit_definitions=>ty_item .
     DATA mv_language TYPE spras .
     DATA mv_translation_detective_lang TYPE spras.
+    DATA mv_pseudo_translation_language TYPE spras.
 
     METHODS get_metadata
       RETURNING
@@ -100,11 +101,33 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
 
   METHOD constructor.
+    " Translation Object Detective
+    " https://help.sap.com/docs/ABAP_PLATFORM_NEW/ceb25152cb0d4adba664cebea2bf4670/88a3d3cbccf64601975acabaccdfde45.html
     CALL FUNCTION 'CONVERSION_EXIT_ISOLA_INPUT'
       EXPORTING
-        input  = '1Q'
+        input            = '1Q'
       IMPORTING
-        output = mv_translation_detective_lang.
+        output           = mv_translation_detective_lang
+      EXCEPTIONS
+        unknown_language = 1
+        OTHERS           = 2.
+    IF sy-subrc = 1.
+      " The language for Translation Object Detective was not setup
+    ENDIF.
+    " 1943470 - Using technical language key 2Q to create pseudo-translations of ABAP developments
+    " https://launchpad.support.sap.com/#/notes/1943470
+    CALL FUNCTION 'CONVERSION_EXIT_ISOLA_INPUT'
+      EXPORTING
+        input            = '2Q'
+      IMPORTING
+        output           = mv_pseudo_translation_language
+      EXCEPTIONS
+        unknown_language = 1
+        OTHERS           = 2.
+    IF sy-subrc = 1.
+      " The language for Pseudo Translation was not setup
+    ENDIF.
+
     ms_item = is_item.
     ASSERT NOT ms_item IS INITIAL.
     mv_language = iv_language.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -15,8 +15,6 @@ CLASS zcl_abapgit_objects_super DEFINITION
 
     DATA ms_item TYPE zif_abapgit_definitions=>ty_item .
     DATA mv_language TYPE spras .
-    DATA mv_translation_detective_lang TYPE spras.
-    DATA mv_pseudo_translation_language TYPE spras.
 
     METHODS get_metadata
       RETURNING
@@ -101,33 +99,6 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
 
   METHOD constructor.
-    " Translation Object Detective
-    " https://help.sap.com/docs/ABAP_PLATFORM_NEW/ceb25152cb0d4adba664cebea2bf4670/88a3d3cbccf64601975acabaccdfde45.html
-    CALL FUNCTION 'CONVERSION_EXIT_ISOLA_INPUT'
-      EXPORTING
-        input            = '1Q'
-      IMPORTING
-        output           = mv_translation_detective_lang
-      EXCEPTIONS
-        unknown_language = 1
-        OTHERS           = 2.
-    IF sy-subrc = 1.
-      " The language for Translation Object Detective was not setup
-    ENDIF.
-    " 1943470 - Using technical language key 2Q to create pseudo-translations of ABAP developments
-    " https://launchpad.support.sap.com/#/notes/1943470
-    CALL FUNCTION 'CONVERSION_EXIT_ISOLA_INPUT'
-      EXPORTING
-        input            = '2Q'
-      IMPORTING
-        output           = mv_pseudo_translation_language
-      EXCEPTIONS
-        unknown_language = 1
-        OTHERS           = 2.
-    IF sy-subrc = 1.
-      " The language for Pseudo Translation was not setup
-    ENDIF.
-
     ms_item = is_item.
     ASSERT NOT ms_item IS INITIAL.
     mv_language = iv_language.

--- a/src/zcl_abapgit_environment.clas.abap
+++ b/src/zcl_abapgit_environment.clas.abap
@@ -157,8 +157,8 @@ CLASS zcl_abapgit_environment IMPLEMENTATION.
 
   METHOD zif_abapgit_environment~get_system_language_filter.
     DATA lv_translation_detective_lang TYPE spras.
-    DATA mv_pseudo_translation_language TYPE spras.
-    FIELD-SYMBOLS <fs_system_language_filter> LIKE LINE OF rt_system_language_filter.
+    DATA lv_pseudo_translation_language TYPE spras.
+    FIELD-SYMBOLS <ls_system_language_filter> LIKE LINE OF rt_system_language_filter.
 
     " Translation Object Detective
     " https://help.sap.com/docs/ABAP_PLATFORM_NEW/ceb25152cb0d4adba664cebea2bf4670/88a3d3cbccf64601975acabaccdfde45.html
@@ -174,10 +174,10 @@ CLASS zcl_abapgit_environment IMPLEMENTATION.
       " The language for Translation Object Detective was not setup
     ENDIF.
     IF NOT lv_translation_detective_lang IS INITIAL.
-      APPEND INITIAL LINE TO rt_system_language_filter ASSIGNING <fs_system_language_filter>.
-      <fs_system_language_filter>-sign = 'E'.
-      <fs_system_language_filter>-option = 'EQ'.
-      <fs_system_language_filter>-low = lv_translation_detective_lang.
+      APPEND INITIAL LINE TO rt_system_language_filter ASSIGNING <ls_system_language_filter>.
+      <ls_system_language_filter>-sign = 'E'.
+      <ls_system_language_filter>-option = 'EQ'.
+      <ls_system_language_filter>-low = lv_translation_detective_lang.
     ENDIF.
     " 1943470 - Using technical language key 2Q to create pseudo-translations of ABAP developments
     " https://launchpad.support.sap.com/#/notes/1943470
@@ -185,18 +185,18 @@ CLASS zcl_abapgit_environment IMPLEMENTATION.
       EXPORTING
         input            = '2Q'
       IMPORTING
-        output           = mv_pseudo_translation_language
+        output           = lv_pseudo_translation_language
       EXCEPTIONS
         unknown_language = 1
         OTHERS           = 2.
     IF sy-subrc = 1.
       " The language for Pseudo Translation was not setup
     ENDIF.
-    IF NOT mv_pseudo_translation_language IS INITIAL.
-      APPEND INITIAL LINE TO rt_system_language_filter ASSIGNING <fs_system_language_filter>.
-      <fs_system_language_filter>-sign = 'E'.
-      <fs_system_language_filter>-option = 'EQ'.
-      <fs_system_language_filter>-low = mv_pseudo_translation_language.
+    IF NOT lv_pseudo_translation_language IS INITIAL.
+      APPEND INITIAL LINE TO rt_system_language_filter ASSIGNING <ls_system_language_filter>.
+      <ls_system_language_filter>-sign = 'E'.
+      <ls_system_language_filter>-option = 'EQ'.
+      <ls_system_language_filter>-low = lv_pseudo_translation_language.
     ENDIF.
   ENDMETHOD.
 

--- a/src/zcl_abapgit_environment.clas.abap
+++ b/src/zcl_abapgit_environment.clas.abap
@@ -158,6 +158,8 @@ CLASS zcl_abapgit_environment IMPLEMENTATION.
   METHOD zif_abapgit_environment~get_system_language_filter.
     DATA lv_translation_detective_lang TYPE spras.
     DATA mv_pseudo_translation_language TYPE spras.
+    FIELD-SYMBOLS <fs_system_language_filter> LIKE LINE OF rt_system_language_filter.
+
     " Translation Object Detective
     " https://help.sap.com/docs/ABAP_PLATFORM_NEW/ceb25152cb0d4adba664cebea2bf4670/88a3d3cbccf64601975acabaccdfde45.html
     CALL FUNCTION 'CONVERSION_EXIT_ISOLA_INPUT'
@@ -172,7 +174,7 @@ CLASS zcl_abapgit_environment IMPLEMENTATION.
       " The language for Translation Object Detective was not setup
     ENDIF.
     IF NOT lv_translation_detective_lang IS INITIAL.
-      APPEND INITIAL LINE TO rt_system_language_filter ASSIGNING FIELD-SYMBOL(<fs_system_language_filter>).
+      APPEND INITIAL LINE TO rt_system_language_filter ASSIGNING <fs_system_language_filter>.
       <fs_system_language_filter>-sign = 'E'.
       <fs_system_language_filter>-option = 'EQ'.
       <fs_system_language_filter>-low = lv_translation_detective_lang.

--- a/src/zif_abapgit_environment.intf.abap
+++ b/src/zif_abapgit_environment.intf.abap
@@ -4,7 +4,8 @@ INTERFACE zif_abapgit_environment
     BEGIN OF ty_release_sp,
       release TYPE c LENGTH 10,
       sp      TYPE c LENGTH 10,
-    END OF ty_release_sp.
+    END OF ty_release_sp,
+    ty_system_language_filter TYPE RANGE OF spras.
 
   METHODS is_sap_cloud_platform
     RETURNING
@@ -27,4 +28,7 @@ INTERFACE zif_abapgit_environment
   METHODS get_basis_release
     RETURNING
       VALUE(rs_result) TYPE ty_release_sp.
+  METHODS get_system_language_filter
+    RETURNING
+      VALUE(rt_system_language_filter) TYPE ty_system_language_filter.
 ENDINTERFACE.


### PR DESCRIPTION
Excludes Translation Object Detective language from serialization
Provides a solution for object type MSAG in issue #5595