### PR TITLE
Show installation flavour in footer

### DIFF
--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -102,7 +102,14 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
   METHOD footer.
 
+    DATA lv_version_detail TYPE string.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true.
+      lv_version_detail = ` (Standalone Version)`.
+    ELSE.
+      lv_version_detail = ` (Developer Version)`.
+    ENDIF.
 
     ri_html->add( '<div id="footer">' ).
     ri_html->add( '<table class="w100"><tr>' ).
@@ -115,7 +122,7 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     ri_html->add( ri_html->icon( iv_name = 'abapgit'
                                  iv_hint = |{ iv_time } sec| ) ).
     ri_html->add( '</div>' ).
-    ri_html->add( |<div class="version">{ zif_abapgit_version=>c_abap_version }</div>| ).
+    ri_html->add( |<div class="version">{ zif_abapgit_version=>c_abap_version }{ lv_version_detail }</div>| ).
     ri_html->add( '</td>' ).
 
     ri_html->add( '<td id="debug-output" class="w40"></td>' ).


### PR DESCRIPTION
This idea suddenly came to mind. You can also find this out less prominently under utilities -> debug info.

![image](https://user-images.githubusercontent.com/5270359/171165055-33a67e0b-224d-47db-b559-bbbb71ecc099.png)

Might be nice to also display the merge timestamp (currently only a comment in lif_abapmerge_marker so not accessible) or the commit hash for the developer version.