### PR TITLE
Propagate codepage conversion errors

### DIFF
--- a/src/git/zcl_abapgit_git_pack.clas.abap
+++ b/src/git/zcl_abapgit_git_pack.clas.abap
@@ -71,12 +71,16 @@ CLASS zcl_abapgit_git_pack DEFINITION
       IMPORTING
         !it_nodes      TYPE ty_nodes_tt
       RETURNING
-        VALUE(rv_data) TYPE xstring .
+        VALUE(rv_data) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS encode_commit
       IMPORTING
         !is_commit     TYPE ty_commit
       RETURNING
-        VALUE(rv_data) TYPE xstring .
+        VALUE(rv_data) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS encode_tag
       IMPORTING
         !is_tag        TYPE ty_tag
@@ -148,7 +152,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GIT_PACK IMPLEMENTATION.
+CLASS zcl_abapgit_git_pack IMPLEMENTATION.
 
 
   METHOD decode.

--- a/src/objects/core/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_files.clas.abap
@@ -12,7 +12,9 @@ CLASS zcl_abapgit_objects_files DEFINITION
       IMPORTING
         !iv_extra  TYPE clike OPTIONAL
         !iv_ext    TYPE string
-        !iv_string TYPE string.
+        !iv_string TYPE string
+      RAISING
+        zcx_abapgit_exception .
     METHODS read_string
       IMPORTING
         !iv_extra        TYPE clike OPTIONAL
@@ -26,7 +28,9 @@ CLASS zcl_abapgit_objects_files DEFINITION
         !iv_extra     TYPE clike OPTIONAL
         !ii_xml       TYPE REF TO zif_abapgit_xml_output
         !iv_normalize TYPE abap_bool DEFAULT abap_true
-        !is_metadata  TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL.
+        !is_metadata  TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL
+      RAISING
+        zcx_abapgit_exception .
     METHODS read_xml
       IMPORTING
         !iv_extra     TYPE clike OPTIONAL
@@ -45,7 +49,9 @@ CLASS zcl_abapgit_objects_files DEFINITION
     METHODS add_abap
       IMPORTING
         !iv_extra TYPE clike OPTIONAL
-        !it_abap  TYPE STANDARD TABLE.
+        !it_abap  TYPE STANDARD TABLE
+      RAISING
+        zcx_abapgit_exception .
     METHODS add
       IMPORTING
         !is_file TYPE zif_abapgit_definitions=>ty_file .

--- a/src/objects/core/zcl_abapgit_objects_files.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_objects_files.clas.testclasses.abap
@@ -4,17 +4,23 @@ CLASS ltcl_objects_files DEFINITION FOR TESTING
   PRIVATE SECTION.
     DATA: mo_cut TYPE REF TO zcl_abapgit_objects_files.
 
-    METHODS setup.
+    METHODS setup
+      RAISING
+        zcx_abapgit_exception .
 
     METHODS get_program_data
       IMPORTING
         iv_line_break    TYPE clike
       RETURNING
-        VALUE(rv_result) TYPE xstring.
+        VALUE(rv_result) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
 
     METHODS get_xml_data
       RETURNING
-        VALUE(rv_result) TYPE xstring.
+        VALUE(rv_result) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
 
     METHODS get_expected_abap_source
       RETURNING

--- a/src/objects/zcl_abapgit_object_wapa.clas.abap
+++ b/src/objects/zcl_abapgit_object_wapa.clas.abap
@@ -22,7 +22,8 @@ CLASS zcl_abapgit_object_wapa DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         RAISING   zcx_abapgit_exception,
       to_page_content
         IMPORTING iv_content        TYPE xstring
-        RETURNING VALUE(rt_content) TYPE o2pageline_table,
+        RETURNING VALUE(rt_content) TYPE o2pageline_table
+        RAISING   zcx_abapgit_exception,
       read_page
         IMPORTING is_page         TYPE o2pagattr
                   iv_no_files_add TYPE abap_bool OPTIONAL

--- a/src/repo/zcl_abapgit_repo.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo.clas.testclasses.abap
@@ -13,7 +13,8 @@ CLASS ltcl_find_remote_dot_abapgit DEFINITION FINAL FOR TESTING
       when_find_remote_dot_abapgit,
       then_dot_abapgit_is_bound,
       then_no_exception_is_raised,
-      given_dot_abapgit_file,
+      given_dot_abapgit_file
+        RAISING zcx_abapgit_exception,
       given_no_dot_abapgit_file,
       then_dot_abapgit_is_not_bound,
       given_repo_has_files

--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -289,7 +289,10 @@ CLASS zcl_abapgit_syntax_highlighter IMPLEMENTATION.
         WITH '<span class="red">&odash;</span>'.
 
       IF strlen( rv_line ) BETWEEN 1 AND 2.
-        lv_bom = zcl_abapgit_convert=>string_to_xstring( rv_line ).
+        TRY.
+            lv_bom = zcl_abapgit_convert=>string_to_xstring( rv_line ).
+          CATCH zcx_abapgit_exception ##NO_HANDLER.
+        ENDTRY.
         IF lv_bom(2) = cl_abap_char_utilities=>byte_order_mark_big.
           rv_line = '<span class="red">&squf;</span>'. " UTF-16 big-endian (FE FF)
         ENDIF.

--- a/src/ui/core/zcl_abapgit_gui_asset_manager.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_asset_manager.clas.abap
@@ -18,7 +18,9 @@ CLASS zcl_abapgit_gui_asset_manager DEFINITION PUBLIC FINAL CREATE PUBLIC .
         !iv_cachable  TYPE abap_bool DEFAULT abap_true
         !iv_mime_name TYPE wwwdatatab-objid OPTIONAL
         !iv_base64    TYPE string OPTIONAL
-        !iv_inline    TYPE string OPTIONAL .
+        !iv_inline    TYPE string OPTIONAL
+      RAISING
+        zcx_abapgit_exception.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -45,7 +47,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
+CLASS zcl_abapgit_gui_asset_manager IMPLEMENTATION.
 
 
   METHOD get_mime_asset.

--- a/src/ui/core/zcl_abapgit_gui_css_processor.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_css_processor.clas.testclasses.abap
@@ -3,7 +3,8 @@ CLASS ltcl_test_base DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT A
   PROTECTED SECTION.
     METHODS:
       add_file IMPORTING iv_url     TYPE string
-                         iv_content TYPE string OPTIONAL.
+                         iv_content TYPE string OPTIONAL
+               RAISING zcx_abapgit_exception.
     DATA:
       mo_asset_manager TYPE REF TO zcl_abapgit_gui_asset_manager,
       mo_cut           TYPE REF TO zcl_abapgit_gui_css_processor.
@@ -36,9 +37,9 @@ ENDCLASS.
 CLASS ltcl_single_file DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT INHERITING FROM ltcl_test_base.
   PUBLIC SECTION.
     METHODS:
-      test_file_exists FOR TESTING,
+      test_file_exists FOR TESTING RAISING zcx_abapgit_exception,
       test_file_does_not_exist FOR TESTING,
-      test_empty_file FOR TESTING,
+      test_empty_file FOR TESTING RAISING zcx_abapgit_exception,
       test_no_variables FOR TESTING RAISING zcx_abapgit_exception,
       test_simple_variables FOR TESTING RAISING zcx_abapgit_exception,
       test_complex_variables FOR TESTING RAISING zcx_abapgit_exception,

--- a/src/ui/core/zcl_abapgit_gui_html_processor.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_html_processor.clas.testclasses.abap
@@ -58,7 +58,7 @@ CLASS ltcl_html_processor_test DEFINITION
       RETURNING
         VALUE(rv_html) TYPE string.
 
-    METHODS setup.
+    METHODS setup RAISING zcx_abapgit_exception.
     METHODS process_typical FOR TESTING RAISING zcx_abapgit_exception.
     METHODS process_with_preserve FOR TESTING RAISING zcx_abapgit_exception.
     METHODS process_no_css FOR TESTING RAISING zcx_abapgit_exception.

--- a/src/ui/zcl_abapgit_gui_page_sett_info.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_info.clas.abap
@@ -380,7 +380,10 @@ CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
     rs_info-size = xstrlen( is_file-data ).
 
     IF is_file-filename CP '*.abap'.
-      lv_code = zcl_abapgit_convert=>xstring_to_string_utf8( is_file-data ).
+      TRY.
+          lv_code = zcl_abapgit_convert=>xstring_to_string_utf8( is_file-data ).
+        CATCH zcx_abapgit_exception ##NO_HANDLER.
+      ENDTRY.
 
       SPLIT lv_code AT zif_abapgit_definitions=>c_newline INTO TABLE lt_code.
 

--- a/src/ui/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/zcl_abapgit_html_action_utils.clas.abap
@@ -119,7 +119,11 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
 
     CONSTANTS lc_nbsp TYPE xstring VALUE 'C2A0'. " &nbsp;
 
-    gv_non_breaking_space = zcl_abapgit_convert=>xstring_to_string_utf8( lc_nbsp ).
+    TRY.
+        gv_non_breaking_space = zcl_abapgit_convert=>xstring_to_string_utf8( lc_nbsp ).
+      CATCH zcx_abapgit_exception.
+        ASSERT 0 = 1.
+    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_convert.clas.abap
+++ b/src/utils/zcl_abapgit_convert.clas.abap
@@ -18,17 +18,23 @@ CLASS zcl_abapgit_convert DEFINITION
       IMPORTING
         !iv_string        TYPE string
       RETURNING
-        VALUE(rv_xstring) TYPE xstring .
+        VALUE(rv_xstring) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS xstring_to_string_utf8
       IMPORTING
         !iv_data         TYPE xsequence
       RETURNING
-        VALUE(rv_string) TYPE string .
+        VALUE(rv_string) TYPE string
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS string_to_xstring_utf8_bom
       IMPORTING
         !iv_string        TYPE string
       RETURNING
-        VALUE(rv_xstring) TYPE xstring .
+        VALUE(rv_xstring) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS xstring_to_int
       IMPORTING
         !iv_xstring TYPE xstring
@@ -55,7 +61,9 @@ CLASS zcl_abapgit_convert DEFINITION
       IMPORTING
         !iv_str        TYPE string
       RETURNING
-        VALUE(rv_xstr) TYPE xstring .
+        VALUE(rv_xstr) TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS string_to_tab
       IMPORTING
         !iv_str  TYPE string
@@ -82,7 +90,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
+CLASS zcl_abapgit_convert IMPLEMENTATION.
 
 
   METHOD base64_to_xstring.
@@ -195,6 +203,8 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
 
   METHOD string_to_xstring_utf8.
 
+    DATA lx_error TYPE REF TO cx_root.
+
     TRY.
         IF go_convert_out IS INITIAL.
           go_convert_out = cl_abap_conv_out_ce=>create( encoding = 'UTF-8' ).
@@ -207,7 +217,8 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
       CATCH cx_parameter_invalid_range
             cx_sy_codepage_converter_init
             cx_sy_conversion_codepage
-            cx_parameter_invalid_type.                  "#EC NO_HANDLER
+            cx_parameter_invalid_type INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.
 
   ENDMETHOD.
@@ -271,6 +282,8 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
 
   METHOD xstring_to_string_utf8.
 
+    DATA lx_error TYPE REF TO cx_root.
+
     TRY.
         IF go_convert_in IS INITIAL.
           go_convert_in = cl_abap_conv_in_ce=>create( encoding = 'UTF-8' ).
@@ -286,7 +299,8 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
       CATCH cx_parameter_invalid_range
             cx_sy_codepage_converter_init
             cx_sy_conversion_codepage
-            cx_parameter_invalid_type.                  "#EC NO_HANDLER
+            cx_parameter_invalid_type INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.
 
   ENDMETHOD.

--- a/src/utils/zcl_abapgit_convert.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_convert.clas.testclasses.abap
@@ -9,12 +9,13 @@ CLASS ltcl_convert DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FIN
     METHODS convert_int FOR TESTING RAISING zcx_abapgit_exception.
     METHODS split_string FOR TESTING.
     METHODS convert_bitbyte FOR TESTING RAISING zcx_abapgit_exception.
-    METHODS string_to_xstring_utf8 FOR TESTING.
-    METHODS xstring_to_string_utf8 FOR TESTING.
+    METHODS string_to_xstring_utf8 FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS xstring_to_string_utf8 FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS xstring_to_string_not_utf8 FOR TESTING RAISING zcx_abapgit_exception.
     METHODS base64_to_xstring FOR TESTING.
     METHODS conversion_exit_isola_output FOR TESTING.
     METHODS string_to_tab FOR TESTING.
-    METHODS string_to_xstring FOR TESTING.
+    METHODS string_to_xstring FOR TESTING RAISING zcx_abapgit_exception.
     METHODS xstring_to_bintab FOR TESTING.
 
 ENDCLASS.
@@ -129,6 +130,19 @@ CLASS ltcl_convert IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lv_result
       exp = 'abc' ).
+
+  ENDMETHOD.
+
+  METHOD xstring_to_string_not_utf8.
+
+    DATA lv_result TYPE string.
+
+    " 0xF8-0xFF are not valid in UTF-8
+    TRY.
+        lv_result = zcl_abapgit_convert=>xstring_to_string_utf8( 'F8FF00' ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception ##NO_HANDLER.
+    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -12,7 +12,9 @@ CLASS zcl_abapgit_diff DEFINITION
         !iv_old                TYPE xstring
         !iv_ignore_indentation TYPE abap_bool DEFAULT abap_false
         !iv_ignore_comments    TYPE abap_bool DEFAULT abap_false
-        !iv_ignore_case        TYPE abap_bool DEFAULT abap_false.
+        !iv_ignore_case        TYPE abap_bool DEFAULT abap_false
+      RAISING
+        zcx_abapgit_exception.
     METHODS get
       RETURNING
         VALUE(rt_diff) TYPE zif_abapgit_definitions=>ty_diffs_tt.
@@ -65,7 +67,9 @@ CLASS zcl_abapgit_diff DEFINITION
         !iv_old TYPE xstring
       EXPORTING
         !et_new TYPE rswsourcet
-        !et_old TYPE rswsourcet.
+        !et_old TYPE rswsourcet
+      RAISING
+        zcx_abapgit_exception.
     METHODS map_beacons.
     METHODS shortlist.
     METHODS create_regex_set

--- a/src/utils/zcl_abapgit_diff.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_diff.clas.testclasses.abap
@@ -25,22 +25,24 @@ CLASS ltcl_diff DEFINITION FOR TESTING
       IMPORTING
         !iv_ignore_indentation TYPE abap_bool DEFAULT abap_false
         !iv_ignore_comments    TYPE abap_bool DEFAULT abap_false
-        !iv_ignore_case        TYPE abap_bool DEFAULT abap_false.
+        !iv_ignore_case        TYPE abap_bool DEFAULT abap_false
+      RAISING
+        zcx_abapgit_exception.
 
     METHODS:
-      diff01 FOR TESTING,
-      diff02 FOR TESTING,
-      diff03 FOR TESTING,
-      diff04 FOR TESTING,
-      diff05 FOR TESTING,
-      diff06 FOR TESTING,
-      diff07 FOR TESTING,
-      diff08 FOR TESTING,
-      diff09 FOR TESTING,
-      diff10 FOR TESTING,
-      diff11 FOR TESTING,
-      diff12 FOR TESTING,
-      diff13 FOR TESTING.
+      diff01 FOR TESTING RAISING zcx_abapgit_exception,
+      diff02 FOR TESTING RAISING zcx_abapgit_exception,
+      diff03 FOR TESTING RAISING zcx_abapgit_exception,
+      diff04 FOR TESTING RAISING zcx_abapgit_exception,
+      diff05 FOR TESTING RAISING zcx_abapgit_exception,
+      diff06 FOR TESTING RAISING zcx_abapgit_exception,
+      diff07 FOR TESTING RAISING zcx_abapgit_exception,
+      diff08 FOR TESTING RAISING zcx_abapgit_exception,
+      diff09 FOR TESTING RAISING zcx_abapgit_exception,
+      diff10 FOR TESTING RAISING zcx_abapgit_exception,
+      diff11 FOR TESTING RAISING zcx_abapgit_exception,
+      diff12 FOR TESTING RAISING zcx_abapgit_exception,
+      diff13 FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -9,14 +9,14 @@ CLASS zcl_abapgit_utils DEFINITION
       IMPORTING
         !iv_data            TYPE xstring
       RETURNING
-        VALUE(rv_is_binary) TYPE abap_bool .
+        VALUE(rv_is_binary) TYPE abap_bool.
     CLASS-METHODS extract_author_data
       IMPORTING
         !iv_author TYPE string
       EXPORTING
-        !ev_author  TYPE zif_abapgit_definitions=>ty_commit-author
-        !ev_email   TYPE zif_abapgit_definitions=>ty_commit-email
-        !ev_time    TYPE zif_abapgit_definitions=>ty_commit-time
+        !ev_author TYPE zif_abapgit_definitions=>ty_commit-author
+        !ev_email  TYPE zif_abapgit_definitions=>ty_commit-email
+        !ev_time   TYPE zif_abapgit_definitions=>ty_commit-time
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS is_valid_email
@@ -79,7 +79,13 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
 
     lv_data = iv_data(lv_xlen).
 
-    lv_string_data = zcl_abapgit_convert=>xstring_to_string_utf8( lv_data ).
+    TRY.
+        lv_string_data = zcl_abapgit_convert=>xstring_to_string_utf8( lv_data ).
+      CATCH zcx_abapgit_exception.
+        " Contains data that does not convert to UTF-8 so consider it binary
+        rv_is_binary = abap_true.
+        RETURN.
+    ENDTRY.
 
     REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>newline IN lv_string_data WITH space.
     REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>cr_lf IN lv_string_data WITH space.

--- a/src/utils/zcl_abapgit_utils.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_utils.clas.testclasses.abap
@@ -120,12 +120,16 @@ CLASS ltcl_is_binary DEFINITION FINAL FOR TESTING
 
       given_file
         IMPORTING
-          iv_file TYPE string,
+          iv_file TYPE string
+        RAISING zcx_abapgit_exception,
       given_image,
-      given_cds_metadata,
-      given_cds_view_with_umlaut,
+      given_cds_metadata
+        RAISING zcx_abapgit_exception,
+      given_cds_view_with_umlaut
+        RAISING zcx_abapgit_exception,
 
-      when_is_binary_determined,
+      when_is_binary_determined
+        RAISING zcx_abapgit_exception,
 
       then_is_not_binary,
       then_is_binary.

--- a/src/xml/zcl_abapgit_xml.clas.abap
+++ b/src/xml/zcl_abapgit_xml.clas.abap
@@ -164,7 +164,11 @@ CLASS zcl_abapgit_xml IMPLEMENTATION.
 
     "unicode systems always add the byte order mark to the xml, while non-unicode does not
     "this code will always add the byte order mark if it is not in the xml
-    lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
+    TRY.
+        lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
+      CATCH zcx_abapgit_exception ##NO_HANDLER.
+        ASSERT 0 = 1.
+    ENDTRY.
     IF rv_xml(1) <> lv_mark.
       CONCATENATE lv_mark rv_xml INTO rv_xml.
     ENDIF.

--- a/src/zcl_abapgit_news.clas.abap
+++ b/src/zcl_abapgit_news.clas.abap
@@ -44,7 +44,9 @@ CLASS zcl_abapgit_news DEFINITION
       IMPORTING
         !iv_rawdata          TYPE xstring
         !iv_lastseen_version TYPE string
-        !iv_current_version  TYPE string .
+        !iv_current_version  TYPE string
+      RAISING
+        zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
 

--- a/src/zlib/zcl_abapgit_zlib.clas.testclasses.abap
+++ b/src/zlib/zcl_abapgit_zlib.clas.testclasses.abap
@@ -6,7 +6,7 @@ CLASS ltcl_zlib DEFINITION FOR TESTING
   PRIVATE SECTION.
     METHODS:
       fixed FOR TESTING RAISING cx_dynamic_check,
-      dynamic FOR TESTING RAISING cx_dynamic_check,
+      dynamic FOR TESTING RAISING cx_dynamic_check zcx_abapgit_exception,
       not_compressed FOR TESTING RAISING cx_dynamic_check.
 
 ENDCLASS.

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -127,6 +127,8 @@
       {"object": "ZCL_ABAPGIT_ZLIB",       "class": "ltcl_zlib", "method": "fixed"},
       {"object": "ZCL_ABAPGIT_UTILS", "class": "ltcl_is_binary", "method": "image_is_binary",          "note": "REGEX '[^[:print:]]'"},
 
+      {"object": "ZCL_ABAPGIT_CONVERT", "class": "ltcl_convert", "method": "xstring_to_string_not_utf8", "note": "Decode of invalid UTF8 does not fail"},
+
       {"object": "ZCL_ABAPGIT_AJSON", "class": "ltcl_serializer_test", "method": "stringify_condensed", "note": "field sorting is wrong, probably sorted internal tables needed"},
       {"object": "ZCL_ABAPGIT_AJSON", "class": "ltcl_serializer_test", "method": "stringify_indented"},
       {"object": "ZCL_ABAPGIT_AJSON", "class": "ltcl_serializer_test", "method": "array_index",     "note": "uses secondary index array_index?"},


### PR DESCRIPTION
Instead of ignoring errors during codepage conversion in `zcl_abapgit_convert=>string_to_xstring_utf8` and `xstring_to_string_utf8`, the errors are now passed on to the user.

The change also showed that `zcl_abapgit_utils=>is_binary` was not working properly. The method was adjusted accordingly.

Ref #5590
