### PR TITLE
Diff: Properly show diffs for whitespace

### DIFF
--- a/src/utils/zcl_abapgit_diff.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_diff.clas.testclasses.abap
@@ -25,22 +25,24 @@ CLASS ltcl_diff DEFINITION FOR TESTING
       IMPORTING
         !iv_ignore_indentation TYPE abap_bool DEFAULT abap_false
         !iv_ignore_comments    TYPE abap_bool DEFAULT abap_false
-        !iv_ignore_case        TYPE abap_bool DEFAULT abap_false.
+        !iv_ignore_case        TYPE abap_bool DEFAULT abap_false
+      RAISING
+        zcx_abapgit_exception.
 
     METHODS:
-      diff01 FOR TESTING,
-      diff02 FOR TESTING,
-      diff03 FOR TESTING,
-      diff04 FOR TESTING,
-      diff05 FOR TESTING,
-      diff06 FOR TESTING,
-      diff07 FOR TESTING,
-      diff08 FOR TESTING,
-      diff09 FOR TESTING,
-      diff10 FOR TESTING,
-      diff11 FOR TESTING,
-      diff12 FOR TESTING,
-      diff13 FOR TESTING.
+      diff01 FOR TESTING RAISING zcx_abapgit_exception,
+      diff02 FOR TESTING RAISING zcx_abapgit_exception,
+      diff03 FOR TESTING RAISING zcx_abapgit_exception,
+      diff04 FOR TESTING RAISING zcx_abapgit_exception,
+      diff05 FOR TESTING RAISING zcx_abapgit_exception,
+      diff06 FOR TESTING RAISING zcx_abapgit_exception,
+      diff07 FOR TESTING RAISING zcx_abapgit_exception,
+      diff08 FOR TESTING RAISING zcx_abapgit_exception,
+      diff09 FOR TESTING RAISING zcx_abapgit_exception,
+      diff10 FOR TESTING RAISING zcx_abapgit_exception,
+      diff11 FOR TESTING RAISING zcx_abapgit_exception,
+      diff12 FOR TESTING RAISING zcx_abapgit_exception,
+      diff13 FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 


### PR DESCRIPTION
The SAP diff function ignores lines that contain only whitespace. Therefore such differences were not shown in abapGit. Some post-processing now identifies these diffs. It also shows a short message instead of an empty table in case there are no diffs.

Before:

![saplogon_883](https://user-images.githubusercontent.com/59966492/175062616-6fe688f3-0a55-4a74-b754-482b7f2ec38c.png)

After:

Showing that on side actually contains spaces

![image](https://user-images.githubusercontent.com/59966492/175062988-870ed66c-c4e4-45a9-ab13-23f610bfed8b.png)

If there's really no diff:

![saplogon_884](https://user-images.githubusercontent.com/59966492/175062612-f4f483d7-19ce-402c-bb19-274ab72ad9fb.png)
