### PR TITLE
Avoid duplicate key error

### DIFF
--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -471,7 +471,13 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    lt_tpool_main = lt_tpool.
+    " Copy single records to be able to catch duplicate key error
+    LOOP AT lt_tpool ASSIGNING <ls_tpool>.
+      INSERT <ls_tpool> INTO TABLE lt_tpool_main.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |Inconsistent textpool in { ms_item-obj_type } { ms_item-obj_name }| ).
+      ENDIF.
+    ENDLOOP.
 
     LOOP AT it_langu_additional INTO lv_langu.
 


### PR DESCRIPTION
Follow-up #5652

Inconsistent textpool in classes now raises an error

![image](https://user-images.githubusercontent.com/59966492/175915528-fba0929e-a083-450c-9e39-70c29b1db635.png)
