### PR TITLE
refactor call to TR_READ_NAMESPACE

### DIFF
--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -423,14 +423,7 @@ CLASS zcl_abapgit_file_status IMPLEMENTATION.
     ENDLOOP.
 
     LOOP AT lt_namespace INTO lv_namespace.
-      CALL FUNCTION 'TR_READ_NAMESPACE'
-        EXPORTING
-          iv_namespace           = lv_namespace
-        IMPORTING
-          es_trnspace            = ls_trnspace
-        EXCEPTIONS
-          namespace_not_existing = 1
-          OTHERS                 = 2.
+      SELECT SINGLE editflag FROM trnspace INTO ls_trnspace-editflag WHERE namespace = lv_namespace.
       IF sy-subrc <> 0.
         ii_log->add( iv_msg  = |Namespace { lv_namespace } does not exist. Create it in transaction SE03|
                      iv_type = 'W' ).


### PR DESCRIPTION
tabl TRNSPACE is already referenced, function module TR_READ_NAMESPACE does a simple table read

this will make it easier to run unit tests

plus will also run a bit faster, less calls, less data read