### PR TITLE
downport assert_true()

### DIFF
--- a/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
@@ -306,7 +306,7 @@ CLASS ltcl_serialize IMPLEMENTATION.
     lv_is_equal = zcl_abapgit_ajson_utilities=>new( )->is_equal(
       iv_json_a = lv_actual
       iv_json_b = lv_expected ).
-    cl_abap_unit_assert=>assert_true( lv_is_equal ).
+    cl_abap_unit_assert=>assert_equals( act = lv_is_equal exp = abap_true ).
   ENDMETHOD.
 
 
@@ -343,6 +343,6 @@ CLASS ltcl_serialize IMPLEMENTATION.
     lv_is_equal = zcl_abapgit_ajson_utilities=>new( )->is_equal(
       iv_json_a = lv_actual
       iv_json_b = lv_expected ).
-    cl_abap_unit_assert=>assert_true( lv_is_equal ).
+    cl_abap_unit_assert=>assert_equals( act = lv_is_equal exp = abap_true ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
@@ -306,7 +306,9 @@ CLASS ltcl_serialize IMPLEMENTATION.
     lv_is_equal = zcl_abapgit_ajson_utilities=>new( )->is_equal(
       iv_json_a = lv_actual
       iv_json_b = lv_expected ).
-    cl_abap_unit_assert=>assert_equals( act = lv_is_equal exp = abap_true ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_is_equal
+      exp = abap_true ).
   ENDMETHOD.
 
 
@@ -343,6 +345,8 @@ CLASS ltcl_serialize IMPLEMENTATION.
     lv_is_equal = zcl_abapgit_ajson_utilities=>new( )->is_equal(
       iv_json_a = lv_actual
       iv_json_b = lv_expected ).
-    cl_abap_unit_assert=>assert_equals( act = lv_is_equal exp = abap_true ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_is_equal
+      exp = abap_true ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_utils.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_utils.clas.testclasses.abap
@@ -275,14 +275,18 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   METHOD then_is_not_binary.
 
-    cl_abap_unit_assert=>assert_equals( act = mv_act_is_binary exp = abap_false ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mv_act_is_binary
+      exp = abap_false ).
 
   ENDMETHOD.
 
 
   METHOD then_is_binary.
 
-    cl_abap_unit_assert=>assert_equals( act = mv_act_is_binary exp = abap_true ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mv_act_is_binary
+      exp = abap_true ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_utils.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_utils.clas.testclasses.abap
@@ -275,14 +275,14 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   METHOD then_is_not_binary.
 
-    cl_abap_unit_assert=>assert_false( mv_act_is_binary ).
+    cl_abap_unit_assert=>assert_equals( act = mv_act_is_binary exp = abap_false ).
 
   ENDMETHOD.
 
 
   METHOD then_is_binary.
 
-    cl_abap_unit_assert=>assert_true( mv_act_is_binary ).
+    cl_abap_unit_assert=>assert_equals( act = mv_act_is_binary exp = abap_true ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
`cl_abap_unit_assert=>assert_true( )` is not available on 7.02. Replaced with `cl_abap_unit_assert=>assert_equals( )`.