### PR TITLE
Check logon language during uninstall

### DIFF
--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -286,6 +286,8 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
     DATA: li_package TYPE REF TO zif_abapgit_sap_package.
 
+    find_remote_dot_abapgit( ).
+
     check_write_protect( ).
     check_language( ).
 

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -286,6 +286,9 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
     DATA: li_package TYPE REF TO zif_abapgit_sap_package.
 
+    check_write_protect( ).
+    check_language( ).
+
     li_package = zcl_abapgit_factory=>get_sap_package( get_package( ) ).
     rs_checks-transport-required = li_package->are_changes_recorded_in_tr_req( ).
 


### PR DESCRIPTION
Uninstalling a repo should only be allowed in the original language of the repo (same as pulling).

Also adds write-protect check to sync behavior with deserializing repo.

Fixes #5730