### PR TITLE
Fix regression in non-Unicode systems

### DIFF
--- a/src/repo/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/repo/zcl_abapgit_dot_abapgit.clas.abap
@@ -280,7 +280,10 @@ CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
 
     "unicode systems always add the byte order mark to the xml, while non-unicode does not
     "this code will always add the byte order mark if it is not in the xml
-    lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
+    TRY.
+        lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
+      CATCH zcx_abapgit_exception ##NO_HANDLER.
+    ENDTRY.
     IF lv_xml(1) <> lv_mark.
       CONCATENATE lv_mark lv_xml INTO lv_xml.
     ENDIF.

--- a/src/repo/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/repo/zcl_abapgit_dot_abapgit.clas.abap
@@ -283,7 +283,7 @@ CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
     TRY.
         lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
       CATCH zcx_abapgit_exception ##NO_HANDLER.
-* In non-unicode systems, the byte order mark throws an error        
+* In non-unicode systems, the byte order mark throws an error
     ENDTRY.
     IF lv_xml(1) <> lv_mark.
       CONCATENATE lv_mark lv_xml INTO lv_xml.

--- a/src/repo/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/repo/zcl_abapgit_dot_abapgit.clas.abap
@@ -283,6 +283,7 @@ CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
     TRY.
         lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
       CATCH zcx_abapgit_exception ##NO_HANDLER.
+* In non-unicode systems, the byte order mark throws an error        
     ENDTRY.
     IF lv_xml(1) <> lv_mark.
       CONCATENATE lv_mark lv_xml INTO lv_xml.


### PR DESCRIPTION
Fixes error "Character set conversion for one or more characters is not possible" in non-Unicode systems

Regression of #5638

Closes #5721