### PR TITLE
DEVC: Fix dump if package has been delete

### DIFF
--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -359,7 +359,12 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = get_package( )->changed_by.
+    DATA li_package TYPE REF TO if_package.
+
+    li_package = get_package( ).
+    IF li_package IS BOUND.
+      rv_user = li_package->changed_by.
+    ENDIF.
   ENDMETHOD.
 
 


### PR DESCRIPTION
If a package is deleted in a different session while viewing a repository, refreshing the repo view will dump.

![image](https://user-images.githubusercontent.com/59966492/188683736-7ba5cdac-6e1e-4444-b735-8bb1a624e0bc.png)
