### PR TITLE
Remove unused branch popup

### DIFF
--- a/src/ui/zcl_abapgit_html_form_utils.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_form_utils.clas.testclasses.abap
@@ -38,9 +38,6 @@ CLASS ltcl_popups_mock IMPLEMENTATION.
   METHOD zif_abapgit_popups~branch_list_popup.
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~branch_popup_callback.
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~choose_pr_popup.
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -578,69 +578,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_popups~branch_popup_callback.
-
-    DATA: lv_url          TYPE string,
-          ls_package_data TYPE scompkdtln,
-          ls_branch       TYPE zif_abapgit_definitions=>ty_git_branch,
-          lv_create       TYPE abap_bool,
-          lv_text         TYPE string.
-
-    FIELD-SYMBOLS: <ls_furl>     LIKE LINE OF ct_fields,
-                   <ls_fbranch>  LIKE LINE OF ct_fields,
-                   <ls_fpackage> LIKE LINE OF ct_fields.
-
-    CLEAR cs_error.
-
-    IF iv_code = 'COD1'.
-      cv_show_popup = abap_true.
-
-      READ TABLE ct_fields ASSIGNING <ls_furl> WITH KEY tabname = 'ABAPTXT255'.
-      IF sy-subrc <> 0 OR <ls_furl>-value IS INITIAL.
-        MESSAGE 'Fill URL' TYPE 'S' DISPLAY LIKE 'E'.
-        RETURN.
-      ENDIF.
-      lv_url = <ls_furl>-value.
-
-      ls_branch = zif_abapgit_popups~branch_list_popup( lv_url ).
-      IF ls_branch IS INITIAL.
-        RETURN.
-      ENDIF.
-
-      READ TABLE ct_fields ASSIGNING <ls_fbranch> WITH KEY tabname = 'TEXTL'.
-      ASSERT sy-subrc = 0.
-      <ls_fbranch>-value = ls_branch-name.
-
-    ELSEIF iv_code = 'COD2'.
-      cv_show_popup = abap_true.
-
-      READ TABLE ct_fields ASSIGNING <ls_fpackage> WITH KEY fieldname = 'DEVCLASS'.
-      ASSERT sy-subrc = 0.
-      ls_package_data-devclass = <ls_fpackage>-value.
-
-      IF zcl_abapgit_factory=>get_sap_package( ls_package_data-devclass )->exists( ) = abap_true.
-        lv_text = |Package { ls_package_data-devclass } already exists|.
-        MESSAGE lv_text TYPE 'I' DISPLAY LIKE 'E'.
-        RETURN.
-      ENDIF.
-
-      zif_abapgit_popups~popup_to_create_package(
-        IMPORTING
-          es_package_data = ls_package_data
-          ev_create       = lv_create ).
-      IF lv_create = abap_false.
-        RETURN.
-      ENDIF.
-
-      zcl_abapgit_factory=>get_sap_package( ls_package_data-devclass )->create( ls_package_data ).
-      COMMIT WORK.
-
-      <ls_fpackage>-value = ls_package_data-devclass.
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_popups~choose_pr_popup.
 
     DATA lv_answer    TYPE c LENGTH 1.

--- a/src/ui/zcl_abapgit_services_basis.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.testclasses.abap
@@ -334,15 +334,12 @@ CLASS ltcl_popups_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~branch_popup_callback.
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~choose_pr_popup.
 
   ENDMETHOD.
 
   METHOD zif_abapgit_popups~commit_list_popup.
+
   ENDMETHOD.
 
   METHOD zif_abapgit_popups~create_branch_popup.

--- a/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
@@ -32,11 +32,8 @@ CLASS ltcl_abapgit_popups_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_popups~branch_popup_callback.
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_popups~commit_list_popup.
+
   ENDMETHOD.
 
   METHOD zif_abapgit_popups~create_branch_popup.

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -103,15 +103,6 @@ INTERFACE zif_abapgit_popups
       VALUE(et_list)         TYPE STANDARD TABLE
     RAISING
       zcx_abapgit_exception .
-  METHODS branch_popup_callback
-    IMPORTING
-      !iv_code       TYPE clike
-    CHANGING
-      !ct_fields     TYPE ty_sval_tt
-      !cs_error      TYPE svale
-      !cv_show_popup TYPE char01
-    RAISING
-      zcx_abapgit_exception .
   METHODS popup_transport_request
     IMPORTING
       !is_transport_type        TYPE zif_abapgit_definitions=>ty_transport_type

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -36,32 +36,6 @@ FORM open_gui RAISING zcx_abapgit_exception.
 
 ENDFORM.
 
-FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_popups=>ty_sval_tt
-                  USING    pv_code TYPE clike
-                  CHANGING cs_error TYPE svale
-                           cv_show_popup TYPE c
-                  RAISING zcx_abapgit_exception ##CALLED ##NEEDED.
-* called dynamically from function module POPUP_GET_VALUES_USER_BUTTONS
-
-  DATA: lx_error  TYPE REF TO zcx_abapgit_exception,
-        li_popups TYPE REF TO zif_abapgit_popups.
-
-  TRY.
-      li_popups = zcl_abapgit_ui_factory=>get_popups( ).
-      li_popups->branch_popup_callback(
-        EXPORTING
-          iv_code       = pv_code
-        CHANGING
-          ct_fields     = tt_fields[]
-          cs_error      = cs_error
-          cv_show_popup = cv_show_popup ).
-
-    CATCH zcx_abapgit_exception INTO lx_error.
-      MESSAGE lx_error TYPE 'S' DISPLAY LIKE 'E'.
-  ENDTRY.
-
-ENDFORM.                    "branch_popup
-
 FORM output.
 
   DATA: lx_error TYPE REF TO zcx_abapgit_exception,


### PR DESCRIPTION
`branch_popup_callback` and `POPUP_GET_VALUES_USER_BUTTONS` are not used anymore and leftovers from previous refactoring.