### PR TITLE
WDYN: Fix dump if no components exist

### DIFF
--- a/src/objects/zcl_abapgit_object_wdyn.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdyn.clas.abap
@@ -948,23 +948,25 @@ CLASS zcl_abapgit_object_wdyn IMPLEMENTATION.
       COLLECT lv_object INTO lt_object.
     ENDLOOP.
 
-    IF io_xml->i18n_params( )-main_language_only = abap_true.
-      SELECT * FROM dokil INTO TABLE lt_dokil
-        FOR ALL ENTRIES IN lt_object
-        WHERE id = c_longtext_id_wc AND object = lt_object-table_line AND masterlang = abap_true
-        ORDER BY PRIMARY KEY.
-    ELSE.
-      SELECT * FROM dokil INTO TABLE lt_dokil
-        FOR ALL ENTRIES IN lt_object
-        WHERE id = c_longtext_id_wc AND object = lt_object-table_line
-        ORDER BY PRIMARY KEY.
-    ENDIF.
+    IF lt_object IS NOT INITIAL.
+      IF io_xml->i18n_params( )-main_language_only = abap_true.
+        SELECT * FROM dokil INTO TABLE lt_dokil
+          FOR ALL ENTRIES IN lt_object
+          WHERE id = c_longtext_id_wc AND object = lt_object-table_line AND masterlang = abap_true
+          ORDER BY PRIMARY KEY.
+      ELSE.
+        SELECT * FROM dokil INTO TABLE lt_dokil
+          FOR ALL ENTRIES IN lt_object
+          WHERE id = c_longtext_id_wc AND object = lt_object-table_line
+          ORDER BY PRIMARY KEY.
+      ENDIF.
 
-    serialize_longtexts(
-      ii_xml           = io_xml
-      it_dokil         = lt_dokil
-      iv_longtext_id   = c_longtext_id_wc
-      iv_longtext_name = c_longtext_name_wc ).
+      serialize_longtexts(
+        ii_xml           = io_xml
+        it_dokil         = lt_dokil
+        iv_longtext_id   = c_longtext_id_wc
+        iv_longtext_name = c_longtext_name_wc ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
If a Web Dynpro contains no components, all (!) longtexts in the system will be read (>650,000). No only is this a performance/memory issue but can also lead to the following dump (due to some inconsistent entries):

![image](https://user-images.githubusercontent.com/59966492/189000139-5602cca3-4ae3-4ed5-972c-36e089a596b3.png)

The solution is to avoid `select for all entries` with an empty table.


