### PR TITLE
"New Online Repo": Derive package/name from URL

### DIFF
--- a/src/objects/core/zcl_abapgit_dependencies.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_dependencies.clas.testclasses.abap
@@ -83,6 +83,10 @@ CLASS ltcl_sap_package IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD zif_abapgit_sap_package~get_description.
+
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS ltcl_resolve_packages DEFINITION FOR TESTING

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -105,6 +105,10 @@ CLASS ltcl_run_checks IMPLEMENTATION.
     RETURN.
   ENDMETHOD.
 
+  METHOD zif_abapgit_sap_package~get_description.
+    RETURN.
+  ENDMETHOD.
+
   METHOD append_result.
 
     DATA ls_result LIKE LINE OF mt_results.

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.testclasses.abap
@@ -96,6 +96,10 @@ CLASS ltcl_folder_logic_package IMPLEMENTATION.
     RETURN.
   ENDMETHOD.
 
+  METHOD zif_abapgit_sap_package~get_description.
+    RETURN.
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS ltcl_folder_logic DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
@@ -162,6 +166,10 @@ CLASS ltcl_folder_logic IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_sap_package~create_local.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_sap_package~get_description.
     RETURN.
   ENDMETHOD.
 
@@ -362,6 +370,10 @@ CLASS ltcl_folder_logic_namespaces IMPLEMENTATION.
     RETURN.
   ENDMETHOD.
 
+  METHOD zif_abapgit_sap_package~get_description.
+    RETURN.
+  ENDMETHOD.
+
   METHOD setup.
 
     zcl_abapgit_injector=>set_sap_package( iv_package     = c_top
@@ -490,6 +502,10 @@ CLASS ltcl_folder_logic_no_parent IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_sap_package~create_local.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_sap_package~get_description.
     RETURN.
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -108,8 +108,6 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
 
   METHOD derive_package.
 
-    DATA lv_name TYPE string.
-
     " Derive package from URL (repo name)
     TRY.
         rv_package = to_upper( replace(
@@ -122,7 +120,7 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
 
     " Map to valid package name
     IF rv_package(1) NA 'YZ'.
-      rv_package = 'Z' && rv_package.
+      rv_package = '$' && rv_package.
     ENDIF.
     IF strlen( rv_package ) > 30.
       rv_package = rv_package(30).

--- a/src/ui/zcl_abapgit_services_basis.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.testclasses.abap
@@ -318,6 +318,9 @@ CLASS ltcl_sap_package_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD zif_abapgit_sap_package~get_description.
+
+  ENDMETHOD.
 
   METHOD was_create_called.
 

--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -261,6 +261,30 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_sap_package~get_description.
+
+    DATA: li_package TYPE REF TO if_package.
+
+    cl_package_factory=>load_package(
+      EXPORTING
+        i_package_name             = mv_package
+      IMPORTING
+        e_package                  = li_package
+      EXCEPTIONS
+        object_not_existing        = 1
+        unexpected_error           = 2
+        intern_err                 = 3
+        no_access                  = 4
+        object_locked_and_modified = 5
+        OTHERS                     = 6 ).
+
+    IF sy-subrc = 0.
+      rv_description = li_package->short_text.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_sap_package~get_transport_layer.
 
     " Get default transport layer

--- a/src/zif_abapgit_sap_package.intf.abap
+++ b/src/zif_abapgit_sap_package.intf.abap
@@ -49,4 +49,7 @@ INTERFACE zif_abapgit_sap_package
       VALUE(rv_transport_layer) TYPE devlayer
     RAISING
       zcx_abapgit_exception .
+  METHODS get_description
+    RETURNING
+      VALUE(rv_description) TYPE string.
 ENDINTERFACE.


### PR DESCRIPTION
Adds a button in the "New Online Repo" dialog to derive the SAP package from the URL. 

The repo name part of the URL will be used as the package name. If it does not start with Y/Z, it adds a `$` in front. 

If the SAP package already exists, then its short text will be used as the display name.

The speedy way to clone a repo is now:

1. Paste the URL
2. Click "Derive"
3. Click "Create Online"
4. Click "Pull"

![image](https://user-images.githubusercontent.com/59966492/190703375-0762c684-5556-4efd-8a1f-a8707a6ba5e8.png)

