### PR TITLE
TABL: Fix deserialize if foreign key exists

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -59,6 +59,8 @@ CLASS zcl_abapgit_object_tabl DEFINITION
     TYPES:
       ty_dd03p_tt TYPE STANDARD TABLE OF dd03p .
     TYPES:
+      ty_dd08v_tt TYPE STANDARD TABLE OF dd08v.
+    TYPES:
       BEGIN OF ty_dd02_text,
         ddlanguage TYPE dd02t-ddlanguage,
         ddtext     TYPE dd02t-ddtext,
@@ -108,6 +110,9 @@ CLASS zcl_abapgit_object_tabl DEFINITION
         !iv_tabclass               TYPE dd02l-tabclass
       RETURNING
         VALUE(rv_is_db_table_type) TYPE dd02l-tabclass .
+    METHODS clear_foreign_keys
+      CHANGING
+        !ct_dd08v TYPE ty_dd08v_tt.
 ENDCLASS.
 
 
@@ -201,6 +206,30 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
            cs_dd03p-decimals,
            cs_dd03p-lowercase,
            cs_dd03p-signflag.
+
+  ENDMETHOD.
+
+
+  METHOD clear_foreign_keys.
+
+    DATA:
+      ls_item  TYPE zif_abapgit_definitions=>ty_item,
+      lv_index TYPE sy-tabix.
+
+    FIELD-SYMBOLS <ls_dd08v> TYPE dd08v.
+
+    " Remove foreign key definitions where the check table/view does not exist (yet)
+    LOOP AT ct_dd08v ASSIGNING <ls_dd08v>.
+      lv_index = sy-tabix.
+      ls_item-obj_name = <ls_dd08v>-checktable.
+      ls_item-obj_type = 'TABL'.
+      IF zcl_abapgit_objects=>exists( ls_item ) = abap_false.
+        ls_item-obj_type = 'VIEW'.
+        IF zcl_abapgit_objects=>exists( ls_item ) = abap_false.
+          DELETE ct_dd08v INDEX lv_index.
+        ENDIF.
+      ENDIF.
+    ENDLOOP.
 
   ENDMETHOD.
 
@@ -780,7 +809,8 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
       " DDIC Step: Remove references to search helps and foreign keys
       IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
-        CLEAR: lt_dd08v, lt_dd35v, lt_dd36m.
+        CLEAR: lt_dd35v, lt_dd36m.
+        clear_foreign_keys( CHANGING ct_dd08v = lt_dd08v ).
       ENDIF.
 
       IF iv_step = zif_abapgit_object=>gc_step_id-late


### PR DESCRIPTION
In case a foreign key definition already exists for a table and is referenced in another object - like a maintenance view - the activation would fail with the error "deleted foreign key is still used":

![image](https://user-images.githubusercontent.com/59966492/191986487-0aadda85-b2ad-4dcc-a3ed-66b854016b25.png)

The reason was that the first deserialize phase activated the table without any foreign keys (to prevent dependency issues, in case the check table doesn't exist). Now only non-existing foreign key definitions will be removed in the first phase avoiding the error.

Closes #5694