### PR TITLE
Force usage of local object handler classes

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -431,6 +431,11 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     REPLACE FIRST OCCURRENCE OF 'LCL' IN lv_class_name WITH 'ZCL_ABAPGIT'.
 
+    IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true.
+      " Prevent accidental usage of object handlers in the developer version
+      lv_class_name = |\\PROGRAM={ sy-repid }\\CLASS={ lv_class_name }|.
+    ENDIF.
+
     TRY.
         CREATE OBJECT ri_obj TYPE (lv_class_name)
           EXPORTING


### PR DESCRIPTION
in standalone version in supported object type determination.

Without this if the installed developer version has an object handler and the standalone version doesn't it gets called as its type is not shadowed. If there's any syntax error in the developer version (like it crashing because the definitions interface is updated at runtime) then the standalone version doesn't work either.

This approach should work better than using RTTS and in my opinion any such dynamic `CREATE OBJECT` should include the absolute type name when running in standalone to prevent accidental cross usage.

CC @mbtools 