### PR TITLE
Downport, version unit tests

### DIFF
--- a/src/zcl_abapgit_version.clas.testclasses.abap
+++ b/src/zcl_abapgit_version.clas.testclasses.abap
@@ -119,7 +119,13 @@ CLASS ltcl_version_parse IMPLEMENTATION.
     DATA: lt_source TYPE string_table.
 
     IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true.
-      cl_abap_unit_assert=>skip( 'Test method not supported in standalone version' ).
+      TRY.
+          CALL METHOD cl_abap_unit_assert=>('SKIP')
+            EXPORTING
+              msg = 'Test method not supported in standalone version'.
+        CATCH cx_sy_dyn_call_illegal_method. " NW <= 752
+          RETURN.
+      ENDTRY.
     ENDIF.
 
     READ REPORT 'ZIF_ABAPGIT_VERSION===========IU' INTO lt_source STATE 'A'.


### PR DESCRIPTION
Fix syntax error in latest abapGit with NW 752 SP04
![grafik](https://user-images.githubusercontent.com/17437789/193752326-fe5cfd7d-9caf-4494-8e26-360f168a665a.png)

![grafik](https://user-images.githubusercontent.com/17437789/193752584-bcff1ef3-4322-4667-85b8-c2b2b78e6668.png)
