### PR TITLE
Fix failing unit test for SAP_BASIS SP00

### DIFF
--- a/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
@@ -103,7 +103,9 @@ CLASS ltcl_lower_release IMPLEMENTATION.
 
     ls_requirement-component   = ls_component-component.
     ls_requirement-min_release = ls_component-release - 1.
-    ls_requirement-min_patch   = nmax( val1 = ls_component-extrelease - 1 val2 = 0 ).
+    ls_requirement-min_patch   = nmax(
+                                   val1 = ls_component-extrelease - 1
+                                   val2 = 0 ).
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
@@ -221,7 +223,9 @@ CLASS ltcl_same_release IMPLEMENTATION.
 
     ls_requirement-component   = ls_component-component.
     ls_requirement-min_release = ls_component-release.
-    ls_requirement-min_patch   = nmax( val1 = ls_component-extrelease - 1 val2 = 0 ).
+    ls_requirement-min_patch   = nmax(
+                                   val1 = ls_component-extrelease - 1
+                                   val2 = 0 ).
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(

--- a/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.testclasses.abap
@@ -103,7 +103,7 @@ CLASS ltcl_lower_release IMPLEMENTATION.
 
     ls_requirement-component   = ls_component-component.
     ls_requirement-min_release = ls_component-release - 1.
-    ls_requirement-min_patch   = ls_component-extrelease - 1.
+    ls_requirement-min_patch   = nmax( val1 = ls_component-extrelease - 1 val2 = 0 ).
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(
@@ -221,7 +221,7 @@ CLASS ltcl_same_release IMPLEMENTATION.
 
     ls_requirement-component   = ls_component-component.
     ls_requirement-min_release = ls_component-release.
-    ls_requirement-min_patch   = ls_component-extrelease - 1.
+    ls_requirement-min_patch   = nmax( val1 = ls_component-extrelease - 1 val2 = 0 ).
     APPEND ls_requirement TO lt_requirements.
 
     cl_abap_unit_assert=>assert_equals(


### PR DESCRIPTION
before this fix ls_requirement-min_patch gets negative for SP00 and therefore failing
![grafik](https://user-images.githubusercontent.com/17437789/193832059-f0431b23-ff5b-41c8-8c4e-f20ba179fbc6.png)
#5798
