### PR TITLE
AFF: Fix existence check

### DIFF
--- a/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
@@ -294,7 +294,9 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
             result = rv_bool.
 
       CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise_with_text( lx_error ).
+        " return false instead of raising exception, because abapGit assumes
+        " that raising exception = existing object
+        rv_bool = abap_false.
     ENDTRY.
 
   ENDMETHOD.
@@ -354,7 +356,6 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
           lv_json_as_xstring   TYPE xstring,
           lx_exception         TYPE REF TO cx_root,
           lv_name              TYPE c LENGTH 120,
-          lv_is_deletion       TYPE abap_bool VALUE abap_false,
           lv_dummy             TYPE string.
 
     FIELD-SYMBOLS: <ls_intf_aff_obj>      TYPE any,


### PR DESCRIPTION
Fixes existence check for AFF objects causing failing unit tests on NW >= 756 SP00
[5798](https://github.com/abapGit/abapGit/issues/5798)
![grafik](https://user-images.githubusercontent.com/17437789/193843606-50357126-b69b-4565-aab8-8e4246ae66ce.png)

As abapGit assumes raised exceptions during existence check as existing objects
https://github.com/abapGit/abapGit/blob/1be856d23a571adcf0b6bb4166b998c170fe2fb7/src/objects/zcl_abapgit_objects.clas.abap#L862-L865
