### PR TITLE
CLAS,ENHO: Fix inactive enhancements

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -315,5 +315,16 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
     ELSEIF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
+
+    CLEAR:
+      rs_interface_properties-uuid,
+      rs_interface_properties-author,
+      rs_interface_properties-createdon,
+      rs_interface_properties-changedby,
+      rs_interface_properties-changedon,
+      rs_interface_properties-chgdanyby,
+      rs_interface_properties-chgdanyon,
+      rs_interface_properties-r3release,
+      rs_interface_properties-version.
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -157,11 +157,27 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
 
 
   METHOD zif_abapgit_oo_object_fnc~create.
-    DATA: lt_vseoattrib TYPE seoo_attributes_r.
+
+    DATA:
+      lt_vseoattrib    TYPE seoo_attributes_r,
+      ls_interface_key TYPE seoclskey,
+      ls_properties    TYPE vseointerf.
+
     FIELD-SYMBOLS: <lv_clsname> TYPE seoclsname.
 
     ASSIGN COMPONENT 'CLSNAME' OF STRUCTURE cg_properties TO <lv_clsname>.
     ASSERT sy-subrc = 0.
+
+    " Get existing interface properties and check if the interface
+    " needs to be created/updated (or is the same)
+    IF iv_check = abap_true.
+      ls_interface_key-clsname = <lv_clsname>.
+      ls_properties = zif_abapgit_oo_object_fnc~get_interface_properties( ls_interface_key ).
+
+      IF ls_properties = cg_properties.
+        RETURN.
+      ENDIF.
+    ENDIF.
 
     lt_vseoattrib = convert_attrib_to_vseoattrib(
                       iv_clsname    = <lv_clsname>
@@ -171,7 +187,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
         CALL FUNCTION 'SEO_INTERFACE_CREATE_COMPLETE'
           EXPORTING
             devclass        = iv_package
-            overwrite       = iv_overwrite
+            overwrite       = abap_true
             version         = seoc_version_active
             suppress_dialog = abap_true " Parameter missing in 702
           CHANGING
@@ -189,7 +205,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
         CALL FUNCTION 'SEO_INTERFACE_CREATE_COMPLETE'
           EXPORTING
             devclass        = iv_package
-            overwrite       = iv_overwrite
+            overwrite       = abap_true
             version         = seoc_version_active
           CHANGING
             interface       = cg_properties
@@ -206,6 +222,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
@@ -21,8 +21,8 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
   METHODS:
     create
       IMPORTING
+        iv_check      TYPE abap_bool
         iv_package    TYPE devclass
-        iv_overwrite  TYPE abap_bool DEFAULT abap_true
         it_attributes TYPE zif_abapgit_definitions=>ty_obj_attribute_tt OPTIONAL
       CHANGING
         cg_properties TYPE any

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -181,6 +181,7 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
     mi_object_oriented_object_fct->create(
       EXPORTING
+        iv_check      = abap_true
         iv_package    = iv_package
         it_attributes = lt_attributes
       CHANGING
@@ -279,16 +280,16 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
 
   METHOD deserialize_pre_ddic.
-    DATA: ls_vseoclass  TYPE vseoclass,
-          lt_attributes TYPE zif_abapgit_definitions=>ty_obj_attribute_tt.
+
+    DATA: ls_vseoclass TYPE vseoclass.
 
     ii_xml->read( EXPORTING iv_name = 'VSEOCLASS'
                   CHANGING  cg_data = ls_vseoclass ).
 
     mi_object_oriented_object_fct->create(
       EXPORTING
+        iv_check      = abap_false
         iv_package    = iv_package
-        it_attributes = lt_attributes
       CHANGING
         cg_properties = ls_vseoclass ).
 
@@ -633,19 +634,6 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
     ENDTRY.
 
     zcl_abapgit_language=>restore_login_language( ).
-
-    CLEAR: ls_vseoclass-uuid,
-           ls_vseoclass-author,
-           ls_vseoclass-createdon,
-           ls_vseoclass-changedby,
-           ls_vseoclass-changedon,
-           ls_vseoclass-r3release,
-           ls_vseoclass-chgdanyby,
-           ls_vseoclass-chgdanyon,
-           ls_vseoclass-clsfinal,
-           ls_vseoclass-clsabstrct,
-           ls_vseoclass-exposure,
-           ls_vseoclass-version.
 
     IF mv_skip_testclass = abap_true.
       CLEAR ls_vseoclass-with_unit_tests.

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -382,16 +382,6 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
     ls_intf-vseointerf = mi_object_oriented_object_fct->get_interface_properties( ls_clskey ).
 
-    CLEAR: ls_intf-vseointerf-uuid,
-           ls_intf-vseointerf-author,
-           ls_intf-vseointerf-createdon,
-           ls_intf-vseointerf-changedby,
-           ls_intf-vseointerf-changedon,
-           ls_intf-vseointerf-chgdanyby,
-           ls_intf-vseointerf-chgdanyon,
-           ls_intf-vseointerf-r3release,
-           ls_intf-vseointerf-version.
-
     " Select all active translations of documentation
     " Skip main language - it was already serialized
     SELECT DISTINCT langu

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -185,7 +185,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
   METHOD deserialize_pre_ddic.
 
-    DATA: ls_intf   TYPE ty_intf.
+    DATA ls_intf TYPE ty_intf.
 
     IF zcl_abapgit_persist_factory=>get_settings( )->read( )->get_experimental_features( ) = abap_true.
       ls_intf = read_json( ).
@@ -196,6 +196,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
     mi_object_oriented_object_fct->create(
       EXPORTING
+        iv_check      = abap_false
         iv_package    = iv_package
       CHANGING
         cg_properties = ls_intf-vseointerf ).
@@ -527,6 +528,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
       ELSE.
         mi_object_oriented_object_fct->create(
           EXPORTING
+            iv_check      = abap_true
             iv_package    = iv_package
           CHANGING
             cg_properties = ls_intf-vseointerf ).


### PR DESCRIPTION
When pulling a change to an existing class, existing enhancements were inactivated and the enhancement code was deleted. 

This was caused by unnecessarily calling `CALL FUNCTION 'SEO_CLASS_CREATE_COMPLETE'` in `zcl_abapgit_oo_class->create`, twice.

The change avoids the second call if the class properties and attributes have *not* been changed. Interfaces are handled the same way. 

Tested with CI tests for classes and interfaces:

![image](https://user-images.githubusercontent.com/59966492/194184985-346ce3c4-fd31-44c0-9384-74544f0280ed.png)

![image](https://user-images.githubusercontent.com/59966492/194184992-53ad801f-fc7d-45ef-8ac9-d0a9859182b8.png)

Closes #5809

PS: Also improves performance when deserializing many classes *and* gets rid of the status bar flicker! Yay😃 