### PR TITLE
ENHO: Unlock objects in cases of errors

### DIFF
--- a/src/objects/enh/zcl_abapgit_object_enho_badi.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_badi.clas.abap
@@ -64,6 +64,10 @@ CLASS zcl_abapgit_object_enho_badi IMPLEMENTATION.
         lo_badi->if_enh_object~save( run_dark = abap_true ).
         lo_badi->if_enh_object~unlock( ).
       CATCH cx_enh_root INTO lx_enh_root.
+        TRY.
+            lo_badi->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).
     ENDTRY.
 

--- a/src/objects/enh/zcl_abapgit_object_enho_class.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_class.clas.abap
@@ -188,6 +188,10 @@ CLASS zcl_abapgit_object_enho_class IMPLEMENTATION.
         lo_enh_class->if_enh_object~save( run_dark = abap_true ).
         lo_enh_class->if_enh_object~unlock( ).
       CATCH cx_enh_root INTO lx_enh_root.
+        TRY.
+            lo_enh_class->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).
     ENDTRY.
 

--- a/src/objects/enh/zcl_abapgit_object_enho_fugr.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_fugr.clas.abap
@@ -75,6 +75,10 @@ CLASS zcl_abapgit_object_enho_fugr IMPLEMENTATION.
         lo_fugrdata->if_enh_object~save( run_dark = abap_true ).
         lo_fugrdata->if_enh_object~unlock( ).
       CATCH cx_enh_root INTO lx_enh_root.
+        TRY.
+            lo_fugrdata->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).
     ENDTRY.
 

--- a/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
@@ -222,6 +222,10 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
         lo_hook_impl->if_enh_object~save( run_dark = abap_true ).
         lo_hook_impl->if_enh_object~unlock( ).
       CATCH cx_enh_root INTO lx_enh_root.
+        TRY.
+            lo_hook_impl->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).
     ENDTRY.
 

--- a/src/objects/enh/zcl_abapgit_object_enho_intf.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_intf.clas.abap
@@ -65,6 +65,10 @@ CLASS zcl_abapgit_object_enho_intf IMPLEMENTATION.
         lo_enh_intf->if_enh_object~save( run_dark = abap_true ).
         lo_enh_intf->if_enh_object~unlock( ).
       CATCH cx_enh_root INTO lx_enh_root.
+        TRY.
+            lo_enh_intf->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise_with_text( lx_enh_root ).
     ENDTRY.
 

--- a/src/objects/enh/zcl_abapgit_object_enho_wdyc.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_wdyc.clas.abap
@@ -67,6 +67,10 @@ CLASS zcl_abapgit_object_enho_wdyc IMPLEMENTATION.
         lo_wdyconf->if_enh_object~save( run_dark = abap_true ).
         lo_wdyconf->if_enh_object~unlock( ).
       CATCH cx_enh_root cx_static_check.
+        TRY.
+            lo_wdyconf->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise( 'error deserializing ENHO wdyconf' ).
     ENDTRY.
   ENDMETHOD.

--- a/src/objects/enh/zcl_abapgit_object_enho_wdyn.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_wdyn.clas.abap
@@ -83,6 +83,10 @@ CLASS zcl_abapgit_object_enho_wdyn IMPLEMENTATION.
         lo_wdyn->if_enh_object~unlock( ).
 
       CATCH cx_root.
+        TRY.
+            lo_wdyn->if_enh_object~unlock( ).
+          CATCH cx_sy_ref_is_initial cx_enh_mod_not_allowed ##NO_HANDLER.
+        ENDTRY.
         zcx_abapgit_exception=>raise( |error deserializing ENHO wdyn { ms_item-obj_name }| ).
     ENDTRY.
 


### PR DESCRIPTION
If an error occurs during deserializing enhancements, the enhancement objects remain locked:

![image](https://user-images.githubusercontent.com/59966492/194185630-edf6d6ed-7e3a-4f92-97ab-420af0033c0a.png)

![image](https://user-images.githubusercontent.com/59966492/194185638-91bf41ae-9cbe-4a94-a40a-bb25699e587a.png)

The fix unlocks the objects in such cases.