### PR TITLE
Remove cases of modifying `syst` fields

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -84,7 +84,12 @@
     "intf_referencing_clas": false,
     "method_implemented_twice": true,
     "parser_702_chaining": true,
-    "sy_modification": false,
+    "sy_modification": {
+      "exclude": [
+        "zcl_abapgit_ajson.clas.locals_imp.abap",
+        "zcl_abapgit_objects_program.clas.abap"
+      ]
+    },
     "call_transaction_authority_check": true,
     "function_module_recommendations": false,
     "method_overwrites_builtin": false,

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -123,6 +123,7 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
   METHOD call_se93.
 
     DATA: lt_message TYPE STANDARD TABLE OF bdcmsgcoll.
+    DATA lv_msg TYPE string.
 
     FIELD-SYMBOLS: <ls_message> TYPE bdcmsgcoll.
 
@@ -146,7 +147,7 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
         TYPE <ls_message>-msgtyp
         NUMBER <ls_message>-msgnr
         WITH <ls_message>-msgv1 <ls_message>-msgv2 <ls_message>-msgv3 <ls_message>-msgv4
-        INTO sy-msgli.
+        INTO lv_msg.
       zcx_abapgit_exception=>raise_t100( ).
     ENDLOOP.
 
@@ -452,6 +453,7 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
   METHOD shift_param.
 
     DATA: ls_param  LIKE LINE OF ct_rsparam,
+          lv_fdpos  TYPE sy-fdpos,
           lv_length TYPE i.
 
     FIELD-SYMBOLS <lg_f> TYPE any.
@@ -469,8 +471,8 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
         IF ls_param-field(1) = space.
           SHIFT ls_param-field.
         ENDIF.
-        sy-fdpos = sy-fdpos + 1.
-        SHIFT cs_tstcp-param BY sy-fdpos PLACES.
+        lv_fdpos = sy-fdpos + 1.
+        SHIFT cs_tstcp-param BY lv_fdpos PLACES.
         IF cs_tstcp-param CA ';'.
           IF sy-fdpos <> 0.
             ASSIGN cs_tstcp-param(sy-fdpos) TO <lg_f>.
@@ -479,8 +481,8 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
               SHIFT ls_param-value.
             ENDIF.
           ENDIF.
-          sy-fdpos = sy-fdpos + 1.
-          SHIFT cs_tstcp-param BY sy-fdpos PLACES.
+          lv_fdpos = sy-fdpos + 1.
+          SHIFT cs_tstcp-param BY lv_fdpos PLACES.
           APPEND ls_param TO ct_rsparam.
         ELSE.
           lv_length = strlen( cs_tstcp-param ).
@@ -504,6 +506,7 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
 * see subroutine split_parameters in include LSEUKF01
 
     DATA: lv_off       TYPE i,
+          lv_fdpos     TYPE sy-fdpos,
           lv_param_beg TYPE i.
 
 
@@ -535,11 +538,11 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
       ENDIF.
       IF cs_tstcp-param CA ' '.
       ENDIF.
-      sy-fdpos = sy-fdpos - lv_off.
-      IF sy-fdpos > 0.
+      lv_fdpos = sy-fdpos - lv_off.
+      IF lv_fdpos > 0.
         cs_rsstcd-call_tcode = cs_tstcp-param+lv_off(sy-fdpos).
-        sy-fdpos = sy-fdpos + 1 + lv_off.
-        cs_rsstcd-variant = cs_tstcp-param+sy-fdpos.
+        lv_fdpos = lv_fdpos + 1 + lv_off.
+        cs_rsstcd-variant = cs_tstcp-param+lv_fdpos.
       ENDIF.
     ELSEIF cs_tstcp-param(1) = '/'.
       cs_rsstcd-st_tcode = c_true.
@@ -552,9 +555,9 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
       IF cs_tstcp-param CA ' '.
       ENDIF.
       lv_param_beg = sy-fdpos + 1.
-      sy-fdpos = sy-fdpos - 2.
-      IF sy-fdpos > 0.
-        cs_rsstcd-call_tcode = cs_tstcp-param+2(sy-fdpos).
+      lv_fdpos = sy-fdpos - 2.
+      IF lv_fdpos > 0.
+        cs_rsstcd-call_tcode = cs_tstcp-param+2(lv_fdpos).
       ENDIF.
       SHIFT cs_tstcp-param BY lv_param_beg PLACES.
     ELSE.

--- a/src/ui/zcl_abapgit_services_basis.clas.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.abap
@@ -82,9 +82,7 @@ CLASS zcl_abapgit_services_basis IMPLEMENTATION.
     ENDIF.
 
     IF zcl_abapgit_factory=>get_sap_package( iv_devclass )->exists( ) = abap_true.
-      " Package &1 already exists
-      MESSAGE e042(pak) INTO sy-msgli WITH iv_devclass.
-      zcx_abapgit_exception=>raise_t100( ).
+      zcx_abapgit_exception=>raise( |Package { iv_devclass } already exists| ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -488,7 +488,7 @@ CLASS ZCX_ABAPGIT_EXCEPTION IMPLEMENTATION.
     ENDDO.
 
     " Set syst using generic error message
-    MESSAGE e001(00) WITH ls_msg-msgv1 ls_msg-msgv2 ls_msg-msgv3 ls_msg-msgv4 INTO sy-lisel.
+    MESSAGE e001(00) WITH ls_msg-msgv1 ls_msg-msgv2 ls_msg-msgv3 ls_msg-msgv4 INTO lv_rest.
 
     rs_msg = ls_msg.
 


### PR DESCRIPTION
- Remove cases where `syst` fields were modified
- Activate corresponding abaplint rule
- Exceptions:
  - `zcl_abapgit_ajson` (https://github.com/sbcgua/ajson/pull/135)
  - `zcl_abapgit_objects_program`   https://github.com/abapGit/abapGit/blob/d2ba4af8055c9156a971c340125af4096663b9f7/src/objects/zcl_abapgit_objects_program.clas.abap#L301