### PR TITLE
Avoid overwriting built-in functions

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -87,7 +87,14 @@
     "sy_modification": false,
     "call_transaction_authority_check": true,
     "function_module_recommendations": false,
-    "method_overwrites_builtin": false,
+    "method_overwrites_builtin": {
+      "exclude": [
+        "zcl_abapgit_ajson.clas.locals_imp.abap",
+        "zcl_abapgit_ajson.clas.testclasses.abap",
+        "zcl_abapgit_stage.clas.abap",
+        "zif_abapgit_log.intf.abap"
+      ]
+    },
     "omit_parameter_name": false,
     "omit_receiving": true,
     "unused_methods": true,

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -777,7 +777,7 @@ CLASS ltcl_calculate_status DEFINITION FOR TESTING RISK LEVEL HARMLESS
       complete_state,
       only_remote FOR TESTING RAISING zcx_abapgit_exception,
       only_local FOR TESTING RAISING zcx_abapgit_exception,
-      match FOR TESTING RAISING zcx_abapgit_exception,
+      match_file FOR TESTING RAISING zcx_abapgit_exception,
       diff FOR TESTING RAISING zcx_abapgit_exception,
       moved FOR TESTING RAISING zcx_abapgit_exception,
       local_outside_main FOR TESTING RAISING zcx_abapgit_exception,
@@ -857,7 +857,7 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD match.
+  METHOD match_file.
 
     mo_helper->add_local(
       iv_obj_type = 'DOMA'

--- a/src/objects/core/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_files.clas.abap
@@ -77,7 +77,7 @@ CLASS zcl_abapgit_objects_files DEFINITION
     METHODS get_accessed_files
       RETURNING
         VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
-    METHODS contains
+    METHODS contains_file
       IMPORTING
         !iv_extra         TYPE clike OPTIONAL
         !iv_ext           TYPE string
@@ -204,7 +204,7 @@ CLASS zcl_abapgit_objects_files IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD contains.
+  METHOD contains_file.
     DATA: lv_filename TYPE string.
 
     lv_filename = zcl_abapgit_filename_logic=>object_to_file(

--- a/src/objects/zcl_abapgit_object_sfpf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpf.clas.abap
@@ -230,7 +230,7 @@ CLASS zcl_abapgit_object_sfpf IMPLEMENTATION.
     TRY.
         li_form = cl_fp_helper=>convert_xstring_to_form( lv_xstr ).
 
-        IF zif_abapgit_object~mo_files->contains( c_layout_file_ext ) = abap_true.
+        IF zif_abapgit_object~mo_files->contains_file( c_layout_file_ext ) = abap_true.
           lv_layout = zif_abapgit_object~mo_files->read_raw( c_layout_file_ext ).
           li_form->get_layout( )->set_layout_data( lv_layout ).
         ENDIF.

--- a/src/ui/zcl_abapgit_html_toolbar.clas.abap
+++ b/src/ui/zcl_abapgit_html_toolbar.clas.abap
@@ -24,7 +24,7 @@ CLASS zcl_abapgit_html_toolbar DEFINITION
         !iv_li_class   TYPE string OPTIONAL
       RETURNING
         VALUE(ro_self) TYPE REF TO zcl_abapgit_html_toolbar .
-    METHODS count
+    METHODS count_items
       RETURNING
         VALUE(rv_count) TYPE i .
     METHODS render
@@ -116,7 +116,7 @@ CLASS zcl_abapgit_html_toolbar IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD count.
+  METHOD count_items.
     rv_count = lines( mt_items ).
   ENDMETHOD.
 


### PR DESCRIPTION
- Remove cases where built-in function were overwritten
- Enable `method_overwrites_builtin` rule
- Exceptions:
  - `zcl_abapgit_ajson.clas.locals_imp.abap`, `zcl_abapgit_ajson.clas.testclasses.abap` (https://github.com/sbcgua/ajson/pull/136)
  - `zcl_abapgit_stage.clas.abap` (method `count` used frequently)
  - `zif_abapgit_log.intf.abap` (method `count` used frequently)