### PR TITLE
Skip Project piece list request

### DIFF
--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -132,7 +132,8 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
     SELECT SINGLE a~trkorr FROM e070 AS a JOIN e071 AS b ON a~trkorr = b~trkorr
       INTO rv_transport
       WHERE ( a~trstatus = 'D' OR a~trstatus = 'L' )
-      AND b~pgmid = iv_program_id AND b~object = iv_object_type AND b~obj_name = iv_object_name.
+        AND a~trfunction <> 'G'
+        AND b~pgmid = iv_program_id AND b~object = iv_object_type AND b~obj_name = iv_object_name.
 
   ENDMETHOD.
 


### PR DESCRIPTION
The repository view displays the objects locked by project-generated piece list transport request
<img width="219" alt="image" src="https://user-images.githubusercontent.com/56556686/196953119-c8d11351-f9e7-4dd4-a218-933bd3cea4fe.png">
