### PR TITLE
Reset sort order to ascending in repo overview

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -730,6 +730,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-change_order_by.
 
         set_order_by( ii_event->query( )->get( 'ORDERBY' ) ).
+        set_order_direction( abap_false ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
       WHEN zif_abapgit_definitions=>c_action-toggle_favorites.


### PR DESCRIPTION
Reset mv_order_by_descending to abap_false for action change-order-by in event handler
Solves issue #5839 