### PR TITLE
CLAS,INTF: Catch runtime error during update

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -313,6 +313,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
   METHOD update_meta.
 
     DATA: lo_update     TYPE REF TO cl_oo_class_section_source,
+          lx_error      TYPE REF TO cx_oo_clif_scan_error,
           ls_clskey     TYPE seoclskey,
           lv_scan_error TYPE abap_bool.
 
@@ -371,7 +372,11 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
     ENDIF.
 
 * this will update the SEO* database tables
-    lo_update->revert_scan_result( ).
+    TRY.
+        lo_update->revert_scan_result( ).
+      CATCH cx_oo_clif_scan_error INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
+    ENDTRY.
 
     IF iv_exposure = seoc_exposure_public.
       generate_classpool( iv_name ).

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -82,6 +82,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
   METHOD update_meta.
 
     DATA: lo_update     TYPE REF TO cl_oo_interface_section_source,
+          lx_error      TYPE REF TO cx_oo_clif_scan_error,
           ls_clskey     TYPE seoclskey,
           lv_scan_error TYPE abap_bool.
 
@@ -131,7 +132,11 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
     ENDIF.
 
 * this will update the SEO* database tables
-    lo_update->revert_scan_result( ).
+    TRY.
+        lo_update->revert_scan_result( ).
+      CATCH cx_oo_clif_scan_error INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
+    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Prevent dump when deserializing classes and interfaces in case a sub-component was changed in a way that standard SAP code does not handle. The error message is now passed on to the user.

References: 
- https://github.com/abapGit/abapGit/issues/5836
- message `OO_SOURCE_BASED 019`
- SAP Note [2166231](https://launchpad.support.sap.com/#/notes/2166231)
