### PR TITLE
Fix syntax highlighting for xml and html

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_xml.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.abap
@@ -24,7 +24,7 @@ CLASS zcl_abapgit_syntax_xml DEFINITION
         "for XML tags, we will use a submatch
         " main pattern includes quoted strings so we can ignore < and > in attr values
         xml_tag  TYPE string VALUE '(?:"[^"]*")|(?:''[^'']*'')|([<>])', "#EC NOTEXT
-        attr     TYPE string VALUE '(?:^|\s)[-a-z:_0-9]+\s*(?==)', "#EC NOTEXT
+        attr     TYPE string VALUE '(?:^|\s)[-a-z:_0-9]+\s*(?==\s*["|''])', "#EC NOTEXT
         attr_val TYPE string VALUE '("[^"]*")|(''[^'']*'')', "#EC NOTEXT
         " comments <!-- ... -->
         comment  TYPE string VALUE '[\<]!--.*--[\>]|[\<]!--|--[\>]', "#EC NOTEXT
@@ -41,7 +41,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SYNTAX_XML IMPLEMENTATION.
+CLASS zcl_abapgit_syntax_xml IMPLEMENTATION.
 
 
   METHOD constructor.

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
@@ -13,7 +13,8 @@ CLASS ltcl_abapgit_syntax_xml DEFINITION FINAL FOR TESTING
       complete_xml_tag_with_closing FOR TESTING RAISING cx_static_check,
       empty_attributes FOR TESTING RAISING cx_static_check,
       open_tags FOR TESTING RAISING cx_static_check,
-      attributes_only FOR TESTING RAISING cx_static_check.
+      attributes_only FOR TESTING RAISING cx_static_check,
+      attribute_value_equal_signs FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -99,6 +100,20 @@ CLASS ltcl_abapgit_syntax_xml IMPLEMENTATION.
 
 
   ENDMETHOD.
+
+  METHOD attribute_value_equal_signs.
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = |<span class="xml_tag">&lt;meta</span>|
+         && |<span class="attr"> name</span>=|
+         && |<span class="attr_val">"viewport"</span>|
+         && |<span class="attr"> content</span>=|
+         && |<span class="attr_val">"width=device, initial=1.0, maximum=1.0"</span>|
+         && |<span class="xml_tag">&gt;</span>|
+      act = mo_cut->process_line( |<meta name="viewport" content="width=device, initial=1.0, maximum=1.0">| ) ).
+
+  ENDMETHOD.
+
 
 ENDCLASS.
 


### PR DESCRIPTION
The parsing was not correct if an xml/html attribute value contained more than one `=` sign.

Before:

![image](https://user-images.githubusercontent.com/59966492/199854358-8f68c3e7-028b-4e2b-9a5f-64101c6aad74.png)

After:

![image](https://user-images.githubusercontent.com/59966492/199854345-97873cdf-78b5-4128-817a-a221c29f7d96.png)
