### PR TITLE
DOCV: Fix dump for namespaced documents

### DIFF
--- a/src/objects/zcl_abapgit_object_docv.clas.abap
+++ b/src/objects/zcl_abapgit_object_docv.clas.abap
@@ -49,10 +49,10 @@ CLASS zcl_abapgit_object_docv IMPLEMENTATION.
     super->constructor( is_item     = is_item
                         iv_language = iv_language ).
 
-    IF ms_item-obj_name(2) = 'UO' OR ms_item-obj_name(2) = 'UP'.
+    IF ms_item-obj_name(2) <> 'DT'. " IN, MO, UO, UP
       mv_id         = ms_item-obj_name(2).
       mv_doc_object = ms_item-obj_name+2.
-    ELSE. " DT, IN, MO
+    ELSE. " DT
       CALL FUNCTION 'RS_NAME_SPLIT_NAMESPACE'
         EXPORTING
           name_with_namespace    = ms_item-obj_name

--- a/src/objects/zcl_abapgit_object_docv.clas.abap
+++ b/src/objects/zcl_abapgit_object_docv.clas.abap
@@ -11,7 +11,9 @@ CLASS zcl_abapgit_object_docv DEFINITION
     METHODS constructor
       IMPORTING
         !is_item     TYPE zif_abapgit_definitions=>ty_item
-        !iv_language TYPE spras.
+        !iv_language TYPE spras
+      RAISING
+        zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -44,18 +46,29 @@ CLASS zcl_abapgit_object_docv IMPLEMENTATION.
     DATA: lv_prefix    TYPE namespace,
           lv_bare_name TYPE progname.
 
-    super->constructor( is_item = is_item
+    super->constructor( is_item     = is_item
                         iv_language = iv_language ).
 
-    CALL FUNCTION 'RS_NAME_SPLIT_NAMESPACE'
-      EXPORTING
-        name_with_namespace    = ms_item-obj_name
-      IMPORTING
-        namespace              = lv_prefix
-        name_without_namespace = lv_bare_name.
+    IF ms_item-obj_name(2) = 'UO' OR ms_item-obj_name(2) = 'UP'.
+      mv_id         = ms_item-obj_name(2).
+      mv_doc_object = ms_item-obj_name+2.
+    ELSE. " DT, IN, MO
+      CALL FUNCTION 'RS_NAME_SPLIT_NAMESPACE'
+        EXPORTING
+          name_with_namespace    = ms_item-obj_name
+        IMPORTING
+          namespace              = lv_prefix
+          name_without_namespace = lv_bare_name
+        EXCEPTIONS
+          delimiter_error        = 1
+          OTHERS                 = 2.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |Error determining namespace for { ms_item-obj_type } { ms_item-obj_name }| ).
+      ENDIF.
 
-    mv_id         = lv_bare_name(2).
-    mv_doc_object = |{ lv_prefix }{ lv_bare_name+2(*) }|.
+      mv_id         = lv_bare_name(2).
+      mv_doc_object = |{ lv_prefix }{ lv_bare_name+2 }|.
+    ENDIF.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Fix handing of documents in classes `UO` and `UP` which use a different namespace logic than `DT`, `IN`, `MO`. 

Regression #5756

Closes #5854