### PR TITLE
Repo overview page, Polishing

### DIFF
--- a/src/ui/zabapgit_css_theme_dark.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_dark.w3mi.data.css
@@ -20,6 +20,9 @@
   --theme-greyscale-light: #CCCCCC;
   --theme-greyscale-lighter: #E5E5E5;
   --theme-list-hover-background-color: black;
+
+  --theme-table-background-color: #333333;
+  --theme-table-head-background-color: #202020;
 }
 
 /* GLOBALS */

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -7,6 +7,7 @@
   --theme-container-background-color: #f2f2f2;
   --theme-container-border-color: lightgrey;
   --theme-table-background-color: white;
+  --theme-table-head-background-color: #edf2f9;
   --theme-table-border-color: #ddd;
   --theme-table-cell-border-color: #eee;
 
@@ -366,7 +367,7 @@ div.debug_container {
 /* Repo overview */
 
 .repo-overview { background-color: var(--theme-container-background-color); }
-.repo-overview table { 
+.repo-overview table {
   background-color: var(--theme-table-background-color);
   border-color: var(--theme-table-border-color);
 }
@@ -374,7 +375,7 @@ div.debug_container {
   color: var(--theme-link-color);
 }
 .repo-overview thead tr {
-  background-color: #edf2f9;
+  background-color: var(--theme-table-head-background-color);
 }
 .repo-overview thead tr,
 .repo-overview tfoot tr {

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -467,9 +467,11 @@ function StageHelper(params) {
   this.formAction      = params.formAction;
   this.patchAction     = params.patchAction;
   this.user            = params.user;
+  this.ids             = params.ids;
   this.selectedCount   = 0;
   this.filteredCount   = 0;
   this.lastFilterValue = "";
+  this.focusFilterKey  = params.focusFilterKey;
 
   // DOM nodes
   this.dom = {
@@ -507,7 +509,6 @@ function StageHelper(params) {
   this.setHooks();
   if (this.user) this.injectFilterMe();
   Hotkeys.addHotkeyToHelpSheet("^Enter", "Commit");
-  this.dom.objectSearch.focus();
 }
 
 StageHelper.prototype.findCounters = function() {
@@ -546,6 +547,17 @@ StageHelper.prototype.setHooks = function() {
   this.dom.objectSearch.onkeypress   = this.onFilter.bind(this);
   window.onbeforeunload              = this.onPageUnload.bind(this);
   window.onload                      = this.onPageLoad.bind(this);
+
+  var self = this;
+  document.addEventListener("keypress", function(event) {
+    if (document.activeElement.id !== self.ids.objectSearch
+      && self.focusFilterKey && event.key === self.focusFilterKey) {
+
+      self.dom.objectSearch.focus();
+      event.preventDefault();
+    }
+  });
+
 };
 
 // Detect column index

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -245,7 +245,10 @@ function getIndocStyleSheet() {
   return style.sheet;
 }
 
-function RepoOverViewHelper() {
+function RepoOverViewHelper(opts) {
+  if (opts && opts.focusFilterKey) {
+    this.focusFilterKey = opts.focusFilterKey;
+  }
   this.setHooks();
   this.pageId = "RepoOverViewHelperState"; // constant is OK for this case
   this.isDetailsDisplayed = false;
@@ -281,6 +284,13 @@ RepoOverViewHelper.prototype.registerKeyboardShortcuts = function() {
     if (document.activeElement.id === "filter") {
       return;
     }
+    if (self.focusFilterKey && event.key === self.focusFilterKey) {
+      var filterInput = document.getElementById("filter");
+      if (filterInput) filterInput.focus();
+      event.preventDefault();
+      return;
+    }
+
     var keycode = event.keyCode;
     var rows = Array.prototype.slice.call(self.getVisibleRows());
     var selected = document.querySelector(".repo-overview tr.selected");

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -503,8 +503,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     ri_html->add( zcl_abapgit_gui_chunk_lib=>render_text_input(
       iv_name      = |filter|
       iv_label     = |Filter:|
-      iv_value     = mv_filter
-      iv_autofocus = abap_true ) ).
+      iv_value     = mv_filter ) ).
     ri_html->add( |<input type="submit" class="hidden-submit">| ).
     ri_html->add( |</form>| ).
 
@@ -574,8 +573,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->set_title( cl_abap_typedescr=>describe_by_object_ref( me )->get_relative_name( ) ).
-    ri_html->add( 'setInitialFocus("filter");' ).
-    ri_html->add( 'var gHelper = new RepoOverViewHelper();' ).
+    ri_html->add( 'var gHelper = new RepoOverViewHelper({ focusFilterKey: "f" });' ).
 
   ENDMETHOD.
 
@@ -900,6 +898,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     ls_hotkey_action-description = |Open Repository|.
     ls_hotkey_action-action = `###`.
     ls_hotkey_action-hotkey = |Enter|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-description = |Focus filter|.
+    ls_hotkey_action-action = `####`.
+    ls_hotkey_action-hotkey = |f|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -553,6 +553,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
 
   ENDMETHOD.
 
+
   METHOD render_repo_list.
 
     ii_html->add( |<table>| ).
@@ -776,6 +777,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
 
 
   METHOD set_order_by.
+    IF mv_order_by <> iv_order_by.
+      set_order_direction( abap_false ). " Reset ordering
+    ENDIF.
     mv_order_by = iv_order_by.
   ENDMETHOD.
 
@@ -809,7 +813,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-change_order_by.
 
         set_order_by( ii_event->query( )->get( 'ORDERBY' ) ).
-        set_order_direction( abap_false ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
       WHEN zif_abapgit_definitions=>c_action-toggle_favorites.

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -124,7 +124,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
 
   METHOD build_menu.
@@ -659,6 +659,7 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ri_html->add( |  user:            "{ to_lower( sy-uname ) }",| ).
     ri_html->add( '  formAction:      "stage_commit",' ).
     ri_html->add( |  patchAction:     "{ zif_abapgit_definitions=>c_action-go_patch }",| ).
+    ri_html->add( '  focusFilterKey:  "f",' ).
 
     ri_html->add( '  ids: {' ).
     ri_html->add( '    stageTab:          "stageTab",' ).
@@ -863,6 +864,12 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ls_hotkey_action-description  = |Refresh|.
     ls_hotkey_action-action       = c_action-stage_refresh.
     ls_hotkey_action-hotkey       = |r|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    " registered/handled in js
+    ls_hotkey_action-description = |Focus filter|.
+    ls_hotkey_action-action = `#`.
+    ls_hotkey_action-hotkey = |f|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/utils/zcl_abapgit_repo_labels.clas.abap
+++ b/src/utils/zcl_abapgit_repo_labels.clas.abap
@@ -116,7 +116,7 @@ CLASS ZCL_ABAPGIT_REPO_LABELS IMPLEMENTATION.
 
     rv_labels = concat_lines_of(
       table = lt_normalized
-      sep = `,` ).
+      sep = `, ` ).
 
   ENDMETHOD.
 
@@ -149,7 +149,7 @@ CLASS ZCL_ABAPGIT_REPO_LABELS IMPLEMENTATION.
 
     rv_config = concat_lines_of(
       table = lt_pairs
-      sep = `,` ).
+      sep = `, ` ).
 
   ENDMETHOD.
 
@@ -188,10 +188,16 @@ CLASS ZCL_ABAPGIT_REPO_LABELS IMPLEMENTATION.
   METHOD split_colors.
 
     DATA lt_pairs TYPE string_table.
+    DATA lv_clean_config LIKE iv_config.
     DATA ls_c LIKE LINE OF rt_label_colors.
     FIELD-SYMBOLS <lv_pair> LIKE LINE OF lt_pairs.
 
-    SPLIT iv_config AT ',' INTO TABLE lt_pairs.
+    lv_clean_config = replace(
+      val = iv_config
+      sub = cl_abap_char_utilities=>newline
+      with = ` ` ). " text area ends with LF
+
+    SPLIT lv_clean_config AT ',' INTO TABLE lt_pairs.
     LOOP AT lt_pairs ASSIGNING <lv_pair>.
       CONDENSE <lv_pair>.
       IF <lv_pair> IS NOT INITIAL.

--- a/src/utils/zcl_abapgit_repo_labels.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_repo_labels.clas.testclasses.abap
@@ -52,11 +52,11 @@ CLASS ltcl_tags IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_repo_labels=>normalize( `a,ab, a_b ,,a-b,a.b,Ab, a b ` )
-      exp = 'Ab,a,a b,a-b,a.b,a_b,ab' ).
+      exp = 'Ab, a, a b, a-b, a.b, a_b, ab' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_repo_labels=>normalize( 'a,ab#,a_b' )
-      exp = 'a,a_b' ).
+      exp = 'a, a_b' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_repo_labels=>normalize( '' )
@@ -68,7 +68,7 @@ CLASS ltcl_tags IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( " duplicates and sorting
       act = zcl_abapgit_repo_labels=>normalize( 'ba,ab,ab' )
-      exp = 'ab,ba' ).
+      exp = 'ab, ba' ).
 
   ENDMETHOD.
 
@@ -133,6 +133,14 @@ CLASS ltcl_tags IMPLEMENTATION.
       act = zcl_abapgit_repo_labels=>split_colors( 'a:red, b : #123456 ,,' )
       exp = lt_exp ).
 
+    CLEAR lt_exp. " Case for textarea - it adds LF at the end
+    APPEND INITIAL LINE TO lt_exp ASSIGNING <ls_c>.
+    <ls_c>-label = 'a'.
+    <ls_c>-color = 'red'.
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_repo_labels=>split_colors( `a:red ` && cl_abap_char_utilities=>newline )
+      exp = lt_exp ).
+
   ENDMETHOD.
 
   METHOD split_colors_into_map.
@@ -157,7 +165,7 @@ CLASS ltcl_tags IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_repo_labels=>normalize_colors( 'a:red , b : #123456' )
-      exp = 'a:red,b:#123456' ).
+      exp = 'a:red, b:#123456' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = zcl_abapgit_repo_labels=>normalize_colors( 'a:red,b:,:blue' )
@@ -173,7 +181,7 @@ CLASS ltcl_tags IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals( " duplicates and sorting
       act = zcl_abapgit_repo_labels=>normalize_colors( 'b:blue,a:red,a:red,a:blue' )
-      exp = 'a:red,b:blue' ).
+      exp = 'a:red, b:blue' ).
 
 
   ENDMETHOD.

--- a/src/zcl_abapgit_settings.clas.abap
+++ b/src/zcl_abapgit_settings.clas.abap
@@ -379,7 +379,8 @@ CLASS zcl_abapgit_settings IMPLEMENTATION.
 
 
   METHOD set_default_link_hint_key.
-    set_link_hint_key( |f| ).
+    " Since #5859 'f' is used for "focus filter", we use 't' as the new default
+    set_link_hint_key( |t| ).
   ENDMETHOD.
 
 


### PR DESCRIPTION
final tuning for #5781

1) Rework reset sorting order (follows #5840, #5839)
2) Better overflow in settings

normalized label separator is `comma+space`. Looks nicer + fixes overflow

before
![2022-11-06_16h01_32](https://user-images.githubusercontent.com/15635498/200182424-5f6681cd-71fe-487d-9cad-326cc2bbbe6e.png)

after
![2022-11-06_17h01_08](https://user-images.githubusercontent.com/15635498/200182431-37732ec5-95bb-4f62-9ae3-08ed264cc329.png)

3) Remove filter autofocus (fixes #5846)
4) And, just by the way, same for Stage page, couldn't pass by, it was also annoying
5) Fix dark there for overview (fixes #5848, @NeumannJoerg please check)

All fixes commit-by-commit for easier review