### PR TITLE
Repo overview: Add labels and links to command palette

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2441,7 +2441,7 @@ function enumerateUiActions() {
     });
 
   // command links
-  [].slice.call(document.querySelectorAll("a[class*='command']"))
+  [].slice.call(document.querySelectorAll("a.command"))
     .filter(function(anchor){
       return !!anchor.text;
     }).forEach(function(anchor){

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2429,6 +2429,30 @@ function enumerateUiActions() {
       });
     });
 
+  // labels
+  [].slice.call(document.querySelectorAll("a[href*='sapevent:label']"))
+    .forEach(function(anchor){
+      items.push({
+        action: function(){
+          anchor.click();
+        },
+        title: "Label: " + anchor.text
+      });
+    });
+
+  // command links
+  [].slice.call(document.querySelectorAll("a[class*='command']"))
+    .filter(function(anchor){
+      return !!anchor.text;
+    }).forEach(function(anchor){
+      items.push({
+        action: function(){
+          anchor.click();
+        },
+        title: anchor.text
+      });
+    });
+
   return items;
 }
 

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -517,11 +517,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     ri_html->add( '<span class="toolbar-light pad-sides">' ).
     ri_html->add( ri_html->a(
       iv_txt   = |<i id="icon-filter-favorite" class="icon icon-check { lv_icon_class }"></i> Only Favorites|
+      iv_class = 'command'
       iv_act   = |{ zif_abapgit_definitions=>c_action-toggle_favorites }| ) ).
     ri_html->add( ri_html->a(
-      iv_txt = '<i id="icon-filter-detail" class="icon icon-check"></i> Detail'
-      iv_act = |gHelper.toggleRepoListDetail()|
-      iv_typ = zif_abapgit_html=>c_action_type-onclick ) ).
+      iv_txt   = '<i id="icon-filter-detail" class="icon icon-check"></i> Detail'
+      iv_act   = |gHelper.toggleRepoListDetail()|
+      iv_class = 'command'
+      iv_typ   = zif_abapgit_html=>c_action_type-onclick ) ).
     ri_html->add( '</span>' ).
 
   ENDMETHOD.


### PR DESCRIPTION
Make labels and 'Only Favorites' + 'Detail' accessible via command palette (F1)
![grafik](https://user-images.githubusercontent.com/17437789/200284363-d645a051-04d2-4370-9818-a29fc10d7ec2.png)
![grafik](https://user-images.githubusercontent.com/17437789/200284481-a2f35456-a8cd-487e-81bc-d3c905a8d422.png)
![grafik](https://user-images.githubusercontent.com/17437789/200284571-48057236-07b3-4fc3-8eea-e1ff192fd681.png)

Note, this change introduces CSS class `command` to distinguish anchors which should be accessible via command palette from which which should not. @sbcgua what do you think about that?
`enumerateUiActions` is currently quite messy and contains some redundancies. I plan to do some work on that in the near future. Maybe `command` can help there too to clean things up.