### PR TITLE
TOBJ: Deletion of logical transport objects

### DIFF
--- a/src/objects/zcl_abapgit_object_tobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_tobj.clas.abap
@@ -98,6 +98,10 @@ CLASS zcl_abapgit_object_tobj IMPLEMENTATION.
     ls_objh-objectname = ms_item-obj_name(lv_type_pos).
     ls_objh-objecttype = ms_item-obj_name+lv_type_pos.
 
+    IF ls_objh-objecttype = 'L'.
+      zcx_abapgit_exception=>raise( |Use transaction SOBJ to delete transport objects { ls_objh-objectname }| ).
+    ENDIF.
+
     CALL FUNCTION 'OBJ_GENERATE'
       EXPORTING
         iv_objectname         = ls_objh-objectname
@@ -111,7 +115,7 @@ CLASS zcl_abapgit_object_tobj IMPLEMENTATION.
         object_enqueue_failed = 5
         OTHERS                = 6.
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from OBJ_GENERATE' ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
     delete_extra( ls_objh-objectname ).


### PR DESCRIPTION
Logical transport objects can be serialized and deserialized. However, deletion leads to "error from OBJ_GENERATE".

![image](https://user-images.githubusercontent.com/59966492/202297042-1355c572-b03b-4999-a81a-76c5cd1520ed.png)

The improved message will point to transaction SOBJ to delete the transport object manually.