### PR TITLE
Fixes to ci

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -73,7 +73,7 @@ jobs:
         GIT_USER_NAME: 'github-actions[bot]'
         GIT_USER_EMAIL: 'github-actions[bot]@users.noreply.github.com'
       run: ./ci/push-tag.sh ${{ needs.auto-tag.outputs.pushedTag }}
-      # Importantly, this calls the push-tags script from build repositayr, not the local one !
+      # Importantly, this calls the push-tags script from build repository, not the local one !
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -73,6 +73,7 @@ jobs:
         GIT_USER_NAME: 'github-actions[bot]'
         GIT_USER_EMAIL: 'github-actions[bot]@users.noreply.github.com'
       run: ./ci/push-tag.sh ${{ needs.auto-tag.outputs.pushedTag }}
+      # Importantly, this calls the push-tags script from build repositayr, not the local one !
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -70,7 +70,6 @@ jobs:
         path: build
     - uses: actions/checkout@v3
       with:
-        repository: abapGit/abapGit
         path: abapGit
     - name: mirror tag to the artifact
       env:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -67,13 +67,19 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: abapGit/build
+        path: build
+    - uses: actions/checkout@v3
+      with:
+        repository: abapGit/abapGit
+        path: abapGit
     - name: mirror tag to the artifact
       env:
         GITHUB_API_KEY: ${{ secrets.DEPLOY_ABAPGIT_BUILD }}
         GIT_USER_NAME: 'github-actions[bot]'
         GIT_USER_EMAIL: 'github-actions[bot]@users.noreply.github.com'
-      run: ./ci/push-tag.sh ${{ needs.auto-tag.outputs.pushedTag }}
-      # Importantly, this calls the push-tags script from build repository, not the local one !
+      run: |
+        cd build
+        ../abapGit/ci/push-tag.sh ${{ needs.auto-tag.outputs.pushedTag }}
 
   coverage:
     runs-on: ubuntu-latest

--- a/ci/deploy-release-tag.sh
+++ b/ci/deploy-release-tag.sh
@@ -49,4 +49,5 @@ PUSH_URL=$(echo "$REPO_URL" | sed -Ene "s#(https://)#\1$GITHUB_API_KEY@#p")
 
 git tag $TAG || exit 1
 git push $PUSH_URL $TAG || exit 1
-echo "::set-output name=pushedTag::$TAG"
+echo "pushedTag=$TAG" >> $GITHUB_OUTPUT
+# https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

--- a/ci/push-tag.sh
+++ b/ci/push-tag.sh
@@ -5,6 +5,8 @@ if [ -z $TAG ]; then
     echo "Failed: Tag was not specified"
     exit 1
 fi
+echo "Tag to set: $TAG"
+
 if [ -z $GIT_USER_EMAIL ] || [ -z $GIT_USER_NAME ]; then
     echo "Failed: Git user name and email must be defined via env"
     exit 1
@@ -13,8 +15,13 @@ git config user.email "$GIT_USER_EMAIL"
 git config user.name "$GIT_USER_NAME"
 
 REPO_URL=$(git remote -v | grep -m1 '^origin' | sed -Ene 's#.*(https://[^[:space:]]+).*#\1#p')
-PUSH_URL=$(echo "$REPO_URL" | sed -Ene "s#(https://)#\1$GITHUB_API_KEY@#p")
+echo "Repo URL: $REPO_URL"
+
+PUSH_URL=$(echo "$REPO_URL" | sed -Ene 's|(https://)|\1'"$GITHUB_API_KEY"'@|p')
 # e.g. https://$GITHUB_API_KEY@github.com/larshp/abapGit.git
 
 git tag $TAG || exit 1
+echo "New tag list:"
+git tag
+
 git push $PUSH_URL $TAG || exit 1


### PR DESCRIPTION
Mainly addressing this: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
And some minor improvements (better logging) to the push-tags script

But also I'd like to report on the `auto-tag-artifact` job issues progress. So it still does not work. And it is very difficult to debug without an almost complete replication of the repos structure. So ! It seems that the issue was with the DEPLOY_TOKEN, which (i assume) contained some special symbols. Though this is strange because the build deployment works with the same command ... but the existing command works with a simple "XXXX" as a token ... so really unclear. And I don't want to print token in the console to debug it for the security reasons ...
Anyway, I made some improvements that,  hopefully will work next time for the next tag