### PR TITLE
Fix BOM in APACK xml

### DIFF
--- a/src/apack/zcl_abapgit_apack_helper.clas.abap
+++ b/src/apack/zcl_abapgit_apack_helper.clas.abap
@@ -359,7 +359,7 @@ CLASS zcl_abapgit_apack_helper IMPLEMENTATION.
       lo_manifest_writer = zcl_abapgit_apack_writer=>create_instance( ls_descriptor ).
       rs_file-path     = zif_abapgit_definitions=>c_root_dir.
       rs_file-filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
-      rs_file-data     = zcl_abapgit_convert=>string_to_xstring_utf8( lo_manifest_writer->serialize( ) ).
+      rs_file-data     = zcl_abapgit_convert=>string_to_xstring_utf8_bom( lo_manifest_writer->serialize( ) ).
       rs_file-sha1     = zcl_abapgit_hash=>sha1_blob( rs_file-data ).
     ENDIF.
 


### PR DESCRIPTION
Adds BOM to `.apack-manifest.xml` to match abapGit XML format