### PR TITLE
Repo View: Fix cross-out for menu items

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -425,7 +425,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     lo_tb_branch = build_branch_dropdown( ).
 
-    lo_tb_tag = build_tag_dropdown( lv_wp_opt ).
+    lo_tb_tag = build_tag_dropdown( ).
 
     lo_tb_advanced = build_advanced_dropdown( iv_wp_opt = lv_wp_opt ).
 

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -142,8 +142,6 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
       RAISING
         zcx_abapgit_exception .
     METHODS build_tag_dropdown
-      IMPORTING
-        !iv_wp_opt             LIKE zif_abapgit_html=>c_html_opt-crossout
       RETURNING
         VALUE(ro_tag_dropdown) TYPE REF TO zcl_abapgit_html_toolbar
       RAISING
@@ -310,6 +308,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     ro_advanced_dropdown->add( iv_txt = 'Quality Assurance'
                                iv_typ = zif_abapgit_html=>c_action_type-separator ).
+
     ro_advanced_dropdown->add( iv_txt = 'Syntax Check'
                                iv_act = |{ zif_abapgit_definitions=>c_action-repo_syntax_check }?key={ mv_key }| ).
     ro_advanced_dropdown->add( iv_txt = 'Unit Test'
@@ -328,8 +327,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                                iv_opt = lv_crossout ).
 
     ro_advanced_dropdown->add( iv_txt = 'Beta - Data'
-                               iv_act = |{ c_actions-go_data }?key={ mv_key }|
-                               iv_opt = lv_crossout ).
+                               iv_act = |{ c_actions-go_data }?key={ mv_key }| ).
 
     IF is_repo_lang_logon_lang( ) = abap_false AND zcl_abapgit_services_abapgit=>get_abapgit_tcode( ) IS NOT INITIAL.
       ro_advanced_dropdown->add(
@@ -459,10 +457,10 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     ro_menu->add(
       iv_txt = zcl_abapgit_gui_buttons=>repo_list( )
       iv_act = zif_abapgit_definitions=>c_action-abapgit_home
-               )->add(
-                 iv_txt = zcl_abapgit_gui_buttons=>help( )
-                 iv_title = 'Help'
-                 io_sub = zcl_abapgit_gui_chunk_lib=>help_submenu( ) ).
+    )->add(
+      iv_txt = zcl_abapgit_gui_buttons=>help( )
+      iv_title = 'Help'
+      io_sub = zcl_abapgit_gui_chunk_lib=>help_submenu( ) ).
 
   ENDMETHOD.
 
@@ -584,8 +582,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     ENDIF.
 
     ro_tag_dropdown->add( iv_txt = 'Switch'
-                          iv_act = |{ zif_abapgit_definitions=>c_action-git_tag_switch }?key={ mv_key }|
-                          iv_opt = iv_wp_opt ).
+                          iv_act = |{ zif_abapgit_definitions=>c_action-git_tag_switch }?key={ mv_key }| ).
     ro_tag_dropdown->add( iv_txt = 'Create'
                           iv_act = |{ zif_abapgit_definitions=>c_action-git_tag_create }?key={ mv_key }| ).
     ro_tag_dropdown->add( iv_txt = 'Delete'


### PR DESCRIPTION
"Advanced > Beta - Data" and "Tag > Switch" were crossed-out unnecessarily