### PR TITLE
Fix initial focus for link hints

### DIFF
--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -251,7 +251,7 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     IF mo_settings->get_link_hints_enabled( ) = abap_true AND lv_link_hint_key IS NOT INITIAL.
 
       ii_html->add( |activateLinkHints("{ lv_link_hint_key }");| ).
-      ii_html->add( |setInitialFocusWithQuerySelector('a span', true);| ).
+      ii_html->add( |setInitialFocusWithQuerySelector('#header', false);| ).
       ii_html->add( |enableArrowListNavigation();| ).
 
     ENDIF.


### PR DESCRIPTION
When link hints are active initial focus is set to first link which is the abapGit logo. Pressing enter then navigates to repo overview. As this often happens accidentally this is a bit annoying. Setting initial focus to a element without an action is much better.
![grafik](https://user-images.githubusercontent.com/17437789/204131977-0ce8f5ad-bf2f-405d-93fb-4502528eaded.png)
