### PR TITLE
Repo Settings: Fix dump in 702

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_sett_info.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_info.clas.abap
@@ -171,6 +171,8 @@ CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
 
   METHOD format_timestamp.
 
+    DATA lv_temp TYPE c LENGTH 30.
+
     IF iv_timestamp IS INITIAL.
       rv_timestamp = 'n/a'.
       RETURN.
@@ -180,7 +182,9 @@ CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
       EXPORTING
         input  = iv_timestamp
       IMPORTING
-        output = rv_timestamp.
+        output = lv_temp.
+
+    rv_timestamp = lv_temp.
 
   ENDMETHOD.
 


### PR DESCRIPTION
`write ... to <string>` is not supported in 702

![image](https://user-images.githubusercontent.com/59966492/205134345-0f49ae1e-412a-4d5a-a241-3c555b9301a8.png)

![image](https://user-images.githubusercontent.com/59966492/205134363-0f896921-b6d3-4654-a537-69e4c8161fab.png)
