### PR TITLE
Fix detection of SAP GUI for Windows

### DIFF
--- a/src/ui/zcl_abapgit_frontend_services.clas.abap
+++ b/src/ui/zcl_abapgit_frontend_services.clas.abap
@@ -324,32 +324,9 @@ CLASS zcl_abapgit_frontend_services IMPLEMENTATION.
 
   METHOD zif_abapgit_frontend_services~is_sapgui_for_windows.
 
-    DATA: lv_platform TYPE i.
-
-    cl_gui_frontend_services=>get_platform(
-      RECEIVING
-        platform             = lv_platform
-      EXCEPTIONS
-        error_no_gui         = 1
-        cntl_error           = 2
-        not_supported_by_gui = 3
-        OTHERS               = 4 ).
-    IF sy-subrc <> 0.
-      rv_result = abap_false.
-    ENDIF.
-
-    CASE lv_platform.
-      WHEN cl_gui_frontend_services=>platform_nt351 OR
-           cl_gui_frontend_services=>platform_nt40 OR
-           cl_gui_frontend_services=>platform_nt50 OR
-           cl_gui_frontend_services=>platform_windows95 OR
-           cl_gui_frontend_services=>platform_windows98 OR
-           cl_gui_frontend_services=>platform_windowsxp.
-        " Everything after Windows XP is reported as Windows XP
-        rv_result = abap_true.
-      WHEN OTHERS.
-        rv_result = abap_false.
-    ENDCASE.
+    CALL FUNCTION 'GUI_HAS_ACTIVEX'
+      IMPORTING
+        return = rv_result.
 
   ENDMETHOD.
 


### PR DESCRIPTION
`cl_gui_frontend_services=>get_platform` returns "Windows" also when running SAP GUI for Java on a Windows machine.

Correct way is to check for the available object model (ActiveX/OLE vs Java Beans vs HTML).

The issue is visible when using JavaGUI on Windows: the "Open IE Dev Tools" menu item is visible but not working:

![image](https://user-images.githubusercontent.com/59966492/205392932-827268e9-50a0-4328-85c2-550385943b08.png)

The fix will detect WinGUI properly and hide the "Open IE Dev Tools" menu item.