### PR TITLE
Diff/Patch: Improve beacons

### DIFF
--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -302,6 +302,7 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
           lv_regex LIKE LINE OF lt_regex.
 
     APPEND '^\s*(CLASS|FORM|MODULE|REPORT|METHOD|INTERFACE|FUNCTION)\s[^=]' TO lt_regex.
+    APPEND '^\s*(PUBLIC|PROTECTED|PRIVATE)\sSECTION(\s|\.)' TO lt_regex.
     APPEND '^\s*(CLASS|INTERFACE|FUNCTION|TYPE)-POOL\s' TO lt_regex.
     APPEND '^\s*(START|END)-OF-SELECTION(\s|\.)' TO lt_regex.
     APPEND '^\s*INITIALIZATION(\s|\.)' TO lt_regex.
@@ -382,12 +383,14 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
                                     del = ` ` ).
 
           IF lv_submatch = 'CLASS'.
-            lv_beacon_2lev = replace( val  = lv_beacon_str
-                                      sub  = ' IMPLEMENTATION'
-                                      with = ''
-                                      occ  = 0 ).
+            lv_beacon_2lev = replace( val   = lv_beacon_str
+                                      regex = '\s+(DEFINITION|IMPLEMENTATION)'
+                                      with  = ''
+                                      occ   = 0 ).
           ELSEIF lv_submatch = 'METHOD'.
             lv_beacon_str = lv_beacon_2lev && ` => ` && lv_beacon_str.
+          ELSEIF lv_submatch = 'PUBLIC' OR lv_submatch = 'PROTECTED' OR lv_submatch = 'PRIVATE'.
+            lv_beacon_str = lv_beacon_2lev && ` ` && lv_beacon_str.
           ENDIF.
 
           APPEND lv_beacon_str TO mt_beacons.

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -301,7 +301,7 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
           lt_regex TYPE zif_abapgit_definitions=>ty_string_tt,
           lv_regex LIKE LINE OF lt_regex.
 
-    APPEND '^\s*(CLASS|FORM|MODULE|REPORT|METHOD|INTERFACE|FUNCTION)\s' TO lt_regex.
+    APPEND '^\s*(CLASS|FORM|MODULE|REPORT|METHOD|INTERFACE|FUNCTION)\s[^=]' TO lt_regex.
     APPEND '^\s*(CLASS|INTERFACE|FUNCTION|TYPE)-POOL\s' TO lt_regex.
     APPEND '^\s*(START|END)-OF-SELECTION(\s|\.)' TO lt_regex.
     APPEND '^\s*INITIALIZATION(\s|\.)' TO lt_regex.
@@ -382,7 +382,10 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
                                     del = ` ` ).
 
           IF lv_submatch = 'CLASS'.
-            lv_beacon_2lev = lv_beacon_str.
+            lv_beacon_2lev = replace( val  = lv_beacon_str
+                                      sub  = ' IMPLEMENTATION'
+                                      with = ''
+                                      occ  = 0 ).
           ELSEIF lv_submatch = 'METHOD'.
             lv_beacon_str = lv_beacon_2lev && ` => ` && lv_beacon_str.
           ENDIF.

--- a/src/utils/zcl_abapgit_diff.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_diff.clas.testclasses.abap
@@ -594,6 +594,7 @@ CLASS ltcl_diff IMPLEMENTATION.
 
     add_beacon( `REPORT ztest_beacon` ).
     add_beacon( `CLASS lcl_test DEFINITION` ).
+    add_beacon( `CLASS lcl_test PUBLIC SECTION` ).
     add_beacon( `CLASS lcl_test IMPLEMENTATION` ).
     add_beacon( `CLASS lcl_test => METHOD test` ).
     add_beacon( `START-OF-SELECTION` ).

--- a/src/utils/zcl_abapgit_diff.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_diff.clas.testclasses.abap
@@ -1,4 +1,3 @@
-
 CLASS ltcl_diff DEFINITION FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS.
@@ -6,11 +5,13 @@ CLASS ltcl_diff DEFINITION FOR TESTING
   PRIVATE SECTION.
     DATA: mt_new      TYPE TABLE OF string,
           mt_old      TYPE TABLE OF string,
+          mt_beacons  TYPE zif_abapgit_definitions=>ty_string_tt,
           mt_expected TYPE zif_abapgit_definitions=>ty_diffs_tt.
 
     METHODS:
       add_new IMPORTING iv_new TYPE string,
       add_old IMPORTING iv_old TYPE string,
+      add_beacon   IMPORTING iv_beacon TYPE string,
       add_expected IMPORTING iv_new_num TYPE zif_abapgit_definitions=>ty_diff-new_num
                              iv_new     TYPE zif_abapgit_definitions=>ty_diff-new
                              iv_result  TYPE zif_abapgit_definitions=>ty_diff-result
@@ -26,6 +27,7 @@ CLASS ltcl_diff DEFINITION FOR TESTING
         !iv_ignore_indentation TYPE abap_bool DEFAULT abap_false
         !iv_ignore_comments    TYPE abap_bool DEFAULT abap_false
         !iv_ignore_case        TYPE abap_bool DEFAULT abap_false
+        !iv_check_beacons      TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception.
 
@@ -43,25 +45,23 @@ CLASS ltcl_diff DEFINITION FOR TESTING
       diff11 FOR TESTING RAISING zcx_abapgit_exception,
       diff12 FOR TESTING RAISING zcx_abapgit_exception,
       diff13 FOR TESTING RAISING zcx_abapgit_exception,
-      diff14 FOR TESTING RAISING zcx_abapgit_exception.
+      diff14 FOR TESTING RAISING zcx_abapgit_exception,
+      map_beacons FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
-
 
 CLASS ltcl_diff IMPLEMENTATION.
 
   METHOD add_new.
-    DATA lv_new LIKE LINE OF mt_new.
-
-    lv_new = iv_new.
-    APPEND lv_new TO mt_new.
+    APPEND iv_new TO mt_new.
   ENDMETHOD.
 
   METHOD add_old.
-    DATA lv_old LIKE LINE OF mt_old.
+    APPEND iv_old TO mt_old.
+  ENDMETHOD.
 
-    lv_old = iv_old.
-    APPEND lv_old TO mt_old.
+  METHOD add_beacon.
+    APPEND iv_beacon TO mt_beacons.
   ENDMETHOD.
 
   METHOD add_expected.
@@ -79,6 +79,7 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD setup.
     CLEAR mt_new.
     CLEAR mt_old.
+    CLEAR mt_beacons.
     CLEAR mt_expected.
   ENDMETHOD.
 
@@ -108,6 +109,12 @@ CLASS ltcl_diff IMPLEMENTATION.
         iv_ignore_comments    = iv_ignore_comments
         iv_ignore_case        = iv_ignore_case.
 
+    IF iv_check_beacons = abap_true.
+      cl_abap_unit_assert=>assert_equals(
+        act = lo_diff->get_beacons( )
+        exp = mt_beacons ).
+      RETURN.
+    ENDIF.
 
     lt_diff = lo_diff->get( ).
 
@@ -123,7 +130,7 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff01.
 
     "insert
-    add_new( iv_new = 'A' ).
+    add_new( 'A' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -137,8 +144,8 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff02.
 
     " identical
-    add_new( iv_new = 'A' ).
-    add_old( iv_old = 'A' ).
+    add_new( 'A' ).
+    add_old( 'A' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -152,7 +159,7 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff03.
 
     " delete
-    add_old( iv_old = 'A' ).
+    add_old( 'A' ).
 
     add_expected( iv_new_num = ''
                   iv_new     = ''
@@ -166,9 +173,9 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff04.
 
     " update
-    add_new( iv_new = 'A+' ).
+    add_new( 'A+' ).
 
-    add_old( iv_old = 'A' ).
+    add_old( 'A' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A+'
@@ -182,11 +189,11 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff05.
 
     " identical
-    add_new( iv_new = 'A' ).
-    add_new( iv_new = 'B' ).
+    add_new( 'A' ).
+    add_new( 'B' ).
 
-    add_old( iv_old = 'A' ).
-    add_old( iv_old = 'B' ).
+    add_old( 'A' ).
+    add_old( 'B' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -205,16 +212,16 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff06.
 
     " mixed
-    add_new( iv_new = 'A' ).
-    add_new( iv_new = 'B' ).
-    add_new( iv_new = 'inserted' ).
-    add_new( iv_new = 'C' ).
-    add_new( iv_new = 'D update' ).
+    add_new( 'A' ).
+    add_new( 'B' ).
+    add_new( 'inserted' ).
+    add_new( 'C' ).
+    add_new( 'D update' ).
 
-    add_old( iv_old = 'A' ).
-    add_old( iv_old = 'B' ).
-    add_old( iv_old = 'C' ).
-    add_old( iv_old = 'D' ).
+    add_old( 'A' ).
+    add_old( 'B' ).
+    add_old( 'C' ).
+    add_old( 'D' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -249,15 +256,15 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff07.
 
     " ignore indentation
-    add_new( iv_new = 'A' ).
-    add_new( iv_new = ' B' ). " changed indent
-    add_new( iv_new = 'C' ).
-    add_new( iv_new = '    D' ). " changed indent
+    add_new( 'A' ).
+    add_new( ' B' ). " changed indent
+    add_new( 'C' ).
+    add_new( '    D' ). " changed indent
 
-    add_old( iv_old = 'A' ).
-    add_old( iv_old = 'B' ).
-    add_old( iv_old = 'C' ).
-    add_old( iv_old = 'D' ).
+    add_old( 'A' ).
+    add_old( 'B' ).
+    add_old( 'C' ).
+    add_old( 'D' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -287,15 +294,15 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff08.
 
     " ignore comments
-    add_new( iv_new = 'A' ).
-    add_new( iv_new = '* X' ). " changed comment
-    add_new( iv_new = 'C' ).
-    add_new( iv_new = 'D " new' ). " changed comment
+    add_new( 'A' ).
+    add_new( '* X' ). " changed comment
+    add_new( 'C' ).
+    add_new( 'D " new' ). " changed comment
 
-    add_old( iv_old = 'A' ).
-    add_old( iv_old = '* B' ).
-    add_old( iv_old = 'C' ).
-    add_old( iv_old = 'D " old' ).
+    add_old( 'A' ).
+    add_old( '* B' ).
+    add_old( 'C' ).
+    add_old( 'D " old' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -325,15 +332,15 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff09.
 
     " ignore case
-    add_new( iv_new = 'A' ).
-    add_new( iv_new = 'b' ). " changed case
-    add_new( iv_new = 'c' ).
-    add_new( iv_new = 'D' ). " changed case
+    add_new( 'A' ).
+    add_new( 'b' ). " changed case
+    add_new( 'c' ).
+    add_new( 'D' ). " changed case
 
-    add_old( iv_old = 'A' ).
-    add_old( iv_old = 'B' ).
-    add_old( iv_old = 'c' ).
-    add_old( iv_old = 'd' ).
+    add_old( 'A' ).
+    add_old( 'B' ).
+    add_old( 'c' ).
+    add_old( 'd' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -363,9 +370,9 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff10.
 
     " ignore case should NOT ignore changed literals
-    add_new( iv_new = `WRITE 'TEST'` ).
+    add_new( `WRITE 'TEST'` ).
 
-    add_old( iv_old = `WRITE 'test'` ).
+    add_old( `WRITE 'test'` ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = `WRITE 'TEST'`
@@ -380,11 +387,11 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff11.
 
     " ignore case should ignore changed keywords, variables, types
-    add_new( iv_new = `write 'test'` ).
-    add_new( iv_new = `DATA FOO TYPE I.` ).
+    add_new( `write 'test'` ).
+    add_new( `DATA FOO TYPE I.` ).
 
-    add_old( iv_old = `WRITE 'test'` ).
-    add_old( iv_old = `DATA foo TYPE i.` ).
+    add_old( `WRITE 'test'` ).
+    add_old( `DATA foo TYPE i.` ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = `write 'test'`
@@ -404,16 +411,16 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff12.
 
     " adjusted diffs for insert (workaround for kernel issue)
-    add_new( iv_new = `REPORT zprog_diff.` ).
-    add_new( iv_new = `*` ).
-    add_new( iv_new = `FORM t_1.` ).
-    add_new( iv_new = `ENDFORM.` ).
-    add_new( iv_new = `FORM t_2.` ).
-    add_new( iv_new = `ENDFORM.` ).
+    add_new( `REPORT zprog_diff.` ).
+    add_new( `*` ).
+    add_new( `FORM t_1.` ).
+    add_new( `ENDFORM.` ).
+    add_new( `FORM t_2.` ).
+    add_new( `ENDFORM.` ).
 
-    add_old( iv_old = `REPORT zprog_diff.` ).
-    add_old( iv_old = `FORM t_1.` ).
-    add_old( iv_old = `ENDFORM.` ).
+    add_old( `REPORT zprog_diff.` ).
+    add_old( `FORM t_1.` ).
+    add_old( `ENDFORM.` ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = `REPORT zprog_diff.`
@@ -459,16 +466,16 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff13.
 
     " adjusted diffs for delete (workaround for kernel issue)
-    add_old( iv_old = `REPORT zprog_diff.` ).
-    add_old( iv_old = `*` ).
-    add_old( iv_old = `FORM t_1.` ).
-    add_old( iv_old = `ENDFORM.` ).
-    add_old( iv_old = `FORM t_2.` ).
-    add_old( iv_old = `ENDFORM.` ).
+    add_old( `REPORT zprog_diff.` ).
+    add_old( `*` ).
+    add_old( `FORM t_1.` ).
+    add_old( `ENDFORM.` ).
+    add_old( `FORM t_2.` ).
+    add_old( `ENDFORM.` ).
 
-    add_new( iv_new = `REPORT zprog_diff.` ).
-    add_new( iv_new = `FORM t_1.` ).
-    add_new( iv_new = `ENDFORM.` ).
+    add_new( `REPORT zprog_diff.` ).
+    add_new( `FORM t_1.` ).
+    add_new( `ENDFORM.` ).
 
     add_expected( iv_old_num = '    1'
                   iv_old     = `REPORT zprog_diff.`
@@ -514,17 +521,17 @@ CLASS ltcl_diff IMPLEMENTATION.
   METHOD diff14.
 
     " lines with different whitespace
-    add_new( iv_new = 'A' ).
-    add_new( iv_new = `` ). " empty line
-    add_new( iv_new = ` ` ). " one space
-    add_new( iv_new = `   ` ). " some spaces
-    add_new( iv_new = 'E' ).
+    add_new( 'A' ).
+    add_new( `` ). " empty line
+    add_new( ` ` ). " one space
+    add_new( `   ` ). " some spaces
+    add_new( 'E' ).
 
-    add_old( iv_old = 'A' ).
-    add_old( iv_old = `     ` ). " some spaces
-    add_old( iv_old = `  ` ). " two spaces
-    add_old( iv_old = `` ). " empty line
-    add_old( iv_old = 'E' ).
+    add_old( 'A' ).
+    add_old( `     ` ). " some spaces
+    add_old( `  ` ). " two spaces
+    add_old( `` ). " empty line
+    add_old( 'E' ).
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -556,4 +563,43 @@ CLASS ltcl_diff IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD map_beacons.
+
+    add_new( `REPORT ztest_beacon.` ).
+    add_new( `` ).
+    add_new( `DATA report TYPE string.` ).
+    add_new( `report = 'TEST'.` ).
+    add_new( `` ).
+    add_new( `CLASS lcl_test DEFINITION.` ).
+    add_new( `  PUBLIC SECTION.` ).
+    add_new( `    CLASS-METHODS test.` ).
+    add_new( `ENDCLASS.` ).
+    add_new( `` ).
+    add_new( `CLASS lcl_test IMPLEMENTATION.` ).
+    add_new( `  METHOD test.` ).
+    add_new( `    DATA method TYPE i.` ).
+    add_new( `    method = 10.` ).
+    add_new( `  ENDMETHOD.` ).
+    add_new( `ENDCLASS.` ).
+    add_new( `` ).
+    add_new( `TYPE-POOLS abap.` ).
+    add_new( `` ).
+    add_new( `START-OF-SELECTION.` ).
+    add_new( `  CALL METHOD lcl_test=>test.` ).
+    add_new( `` ).
+    add_new( `AT SELECTION-SCREEN.` ).
+    add_new( `  BREAK-POINT.` ).
+
+    add_old( '' ).
+
+    add_beacon( `REPORT ztest_beacon` ).
+    add_beacon( `CLASS lcl_test DEFINITION` ).
+    add_beacon( `CLASS lcl_test IMPLEMENTATION` ).
+    add_beacon( `CLASS lcl_test => METHOD test` ).
+    add_beacon( `START-OF-SELECTION` ).
+    add_beacon( `AT SELECTION-SCREEN` ).
+
+    test( iv_check_beacons = abap_true ).
+
+  ENDMETHOD.
 ENDCLASS.

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -181,6 +181,7 @@
       {"object": "ZCL_ABAPGIT_PERSISTENCE_USER", "class": "ltcl_user", "method": "set_get_repo_show",  "note": "skip, this changes database"},
       {"object": "ZCL_ABAPGIT_PERSISTENCE_USER", "class": "ltcl_user", "method": "set_get_settings",   "note": "skip, this changes database"},
       {"object": "ZCL_ABAPGIT_PERSISTENCE_USER", "class": "ltcl_user", "method": "set_get_repo_login", "note": "skip, this changes database"},
+
       {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "diff01", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
       {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "diff02", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
       {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "diff03", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
@@ -195,7 +196,10 @@
       {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "diff12", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
       {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "diff13", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
       {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "diff14", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
+      {"object": "ZCL_ABAPGIT_DIFF", "class": "ltcl_diff", "method": "map_beacons", "note": "fm RS_CMP_COMPUTE_DELTA + Void type: RSWSOURCET"},
+
       {"object": "ZCL_ABAPGIT_USER_RECORD", "class": "ltcl_user_record", "method": "test_invalid_user",                   "note": "Void type: BAPIADDR3"},
+
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "raise_error_if_package_exists", "note": "Void type: SCOMPKDTLN"},
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_given_in_popup",        "note": "Void type: SCOMPKDTLN"},
       {"object": "ZCL_ABAPGIT_SERVICES_BASIS", "class": "ltcl_create_package", "method": "package_not_created_when_canc", "note": "Void type: SCOMPKDTLN"},


### PR DESCRIPTION
1. Cases like `report = 'SAPMSVIM'` were detected as beacons:

![image](https://user-images.githubusercontent.com/59966492/205402320-63596263-57d0-46d1-bdfd-538d6eaf7f1f.png)

Here's another example. Entries 2 and 6 should not be beacons:

![image](https://user-images.githubusercontent.com/59966492/205402445-e0221f84-2dd9-41e5-9bff-03e82105cff2.png)

Updated regex avoids such cases. 

2. Shorten beacon for methods from `CLASS xyz IMPLEMENTATION => METHOD abc` to `CLASS xyz => METHOD abc`

3. Add beacons for `CLASS xyz PUBLIC|PROTECTED|PRIVATE SECTION`

4. Add unit test.

5. Make beacon reference beginning of diff instead of 8 lines before. 
Closes #3973