### PR TITLE
Set transport request in local repo settings or user exit

### DIFF
--- a/src/cts/zcl_abapgit_transport.clas.abap
+++ b/src/cts/zcl_abapgit_transport.clas.abap
@@ -36,6 +36,12 @@ CLASS zcl_abapgit_transport DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+    CLASS-METHODS validate_transport_request
+      IMPORTING
+        iv_transport_request TYPE trkorr
+      RAISING
+        zcx_abapgit_exception.
+
   PROTECTED SECTION.
 
     CLASS-METHODS read_requests
@@ -365,6 +371,33 @@ CLASS ZCL_ABAPGIT_TRANSPORT IMPLEMENTATION.
 
     lt_requests = read_requests( it_transport_headers ).
     rt_tadir = resolve( lt_requests ).
+  ENDMETHOD.
+
+
+  METHOD validate_transport_request.
+
+    CONSTANTS:
+      BEGIN OF c_tr_status,
+        modifiable                   TYPE trstatus VALUE 'D',
+        modifiable_protected         TYPE trstatus VALUE 'L',
+        release_started              TYPE trstatus VALUE 'O',
+        released                     TYPE trstatus VALUE 'R',
+        released_with_import_protect TYPE trstatus VALUE 'N', " Released (with Import Protection for Repaired Objects)
+      END OF c_tr_status.
+
+    DATA:
+      ls_trkorr  TYPE trwbo_request_header,
+      ls_request TYPE trwbo_request.
+
+    ls_trkorr-trkorr = iv_transport_request.
+
+    ls_request = read( ls_trkorr ).
+
+    IF  ls_request-h-trstatus <> c_tr_status-modifiable
+    AND ls_request-h-trstatus <> c_tr_status-modifiable_protected.
+      zcx_abapgit_exception=>raise( |Transport request { iv_transport_request } was already released| ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/cts/zcl_abapgit_transport.clas.abap
+++ b/src/cts/zcl_abapgit_transport.clas.abap
@@ -387,7 +387,8 @@ CLASS ZCL_ABAPGIT_TRANSPORT IMPLEMENTATION.
 
     DATA:
       ls_trkorr  TYPE trwbo_request_header,
-      ls_request TYPE trwbo_request.
+      ls_request TYPE trwbo_request,
+      lv_text    TYPE string.
 
     ls_trkorr-trkorr = iv_transport_request.
 
@@ -395,7 +396,9 @@ CLASS ZCL_ABAPGIT_TRANSPORT IMPLEMENTATION.
 
     IF  ls_request-h-trstatus <> c_tr_status-modifiable
     AND ls_request-h-trstatus <> c_tr_status-modifiable_protected.
-      zcx_abapgit_exception=>raise( |Transport request { iv_transport_request } was already released| ).
+      " Task/request &1 has already been released
+      MESSAGE e064(tk) WITH iv_transport_request INTO lv_text.
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -11,6 +11,7 @@ CLASS zcl_abapgit_objects_check DEFINITION
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS class_constructor.
     CLASS-METHODS checks_adjust
       IMPORTING
         !io_repo    TYPE REF TO zcl_abapgit_repo
@@ -22,6 +23,7 @@ CLASS zcl_abapgit_objects_check DEFINITION
   PROTECTED SECTION.
 
   PRIVATE SECTION.
+    CLASS-DATA: gi_exit TYPE REF TO zif_abapgit_exit.
 
     CLASS-METHODS warning_overwrite_adjust
       IMPORTING
@@ -56,6 +58,12 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_objects_check IMPLEMENTATION.
+
+  METHOD class_constructor.
+
+    gi_exit = zcl_abapgit_exit=>get_instance( ).
+
+  ENDMETHOD.
 
 
   METHOD checks_adjust.
@@ -95,6 +103,14 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       rs_checks-transport-required = li_package->are_changes_recorded_in_tr_req( ).
       IF NOT rs_checks-transport-required IS INITIAL.
         rs_checks-transport-type = li_package->get_transport_type( ).
+        rs_checks-transport-transport = io_repo->get_local_settings( )-transport_request.
+
+        gi_exit->determine_transport_request(
+          EXPORTING
+            io_repo              = io_repo
+            iv_transport_type    = rs_checks-transport-type
+          CHANGING
+            cv_transport_request = rs_checks-transport-transport ).
       ENDIF.
     ENDIF.
 

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -28,6 +28,7 @@ INTERFACE zif_abapgit_persistence PUBLIC.
       block_commit                 TYPE abap_bool,
       main_language_only           TYPE abap_bool,
       labels                       TYPE string,
+      transport_request            TYPE trkorr,
     END OF ty_local_settings.
 
   TYPES: ty_local_checksum_tt TYPE STANDARD TABLE OF ty_local_checksum WITH DEFAULT KEY.

--- a/src/ui/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -124,6 +124,10 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
 
   METHOD get_form_schema.
 
+    DATA: li_package TYPE REF TO zif_abapgit_sap_package.
+
+    li_package = zcl_abapgit_factory=>get_sap_package( mo_repo->get_package( ) ).
+
     ro_form = zcl_abapgit_html_form=>create(
       iv_form_id   = 'repo-local-settings-form'
       iv_help_page = 'https://docs.abapgit.org/settings-local.html' ).
@@ -135,13 +139,17 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
     )->text(
       iv_name        = c_id-display_name
       iv_label       = 'Display Name'
-      iv_hint        = 'Name to show instead of original repo name (optional)'
-    )->text(
-      iv_name        = c_id-transport_request
-      iv_side_action = c_event-choose_transport_request
-      iv_label       = |Transport request|
-      iv_hint        = 'Transport request; All changes are recorded therein and no transport popup appears|'
-    )->text(
+      iv_hint        = 'Name to show instead of original repo name (optional)' ).
+
+    IF li_package->are_changes_recorded_in_tr_req( ) = abap_true.
+      ro_form->text(
+        iv_name        = c_id-transport_request
+        iv_side_action = c_event-choose_transport_request
+        iv_label       = |Transport request|
+        iv_hint        = 'Transport request; All changes are recorded therein and no transport popup appears|' ).
+    ENDIF.
+
+    ro_form->text(
       iv_name        = c_id-labels
       iv_side_action = c_event-choose_labels
       iv_label       = |Labels (comma-separated, allowed chars: "{ zcl_abapgit_repo_labels=>c_allowed_chars }")|

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -295,7 +295,8 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
       zcl_abapgit_apack_helper=>dependencies_popup( lt_dependencies ).
     ENDIF.
 
-    IF cs_checks-transport-required = abap_true.
+    IF  cs_checks-transport-required = abap_true
+    AND cs_checks-transport-transport IS INITIAL.
       cs_checks-transport-transport = zcl_abapgit_ui_factory=>get_popups( )->popup_transport_request(
         is_transport_type = cs_checks-transport-type ).
     ENDIF.

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -107,8 +107,9 @@ INTERFACE zif_abapgit_popups
       zcx_abapgit_exception .
   METHODS popup_transport_request
     IMPORTING
-      !is_transport_type        TYPE zif_abapgit_definitions=>ty_transport_type
+      !is_transport_type        TYPE zif_abapgit_definitions=>ty_transport_type OPTIONAL
       !iv_use_default_transport TYPE abap_bool DEFAULT abap_false
+      PREFERRED PARAMETER is_transport_type
     RETURNING
       VALUE(rv_transport)       TYPE trkorr
     RAISING

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -323,4 +323,22 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~determine_transport_request.
+
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->determine_transport_request(
+            EXPORTING
+              io_repo              = io_repo
+              iv_transport_type    = iv_transport_type
+            CHANGING
+              cv_transport_request = cv_transport_request ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -108,7 +108,13 @@ INTERFACE zif_abapgit_exit
       !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt.
   METHODS adjust_display_filename
     IMPORTING
-      !iv_filename       TYPE string
+      iv_filename        TYPE string
     RETURNING
       VALUE(rv_filename) TYPE string.
+  METHODS determine_transport_request
+    IMPORTING
+      io_repo              TYPE REF TO zcl_abapgit_repo
+      iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
+    CHANGING
+      cv_transport_request TYPE trkorr.
 ENDINTERFACE.


### PR DESCRIPTION
fixes #5833 

- New local repo setting for transport request.
![grafik](https://user-images.githubusercontent.com/17437789/205950878-ad14a7d9-0b5a-4513-be6e-28f125b2efd4.png)

- New user exit `determine_transport_request` 

If transport request is set via either method, no transport request popup appears and the transport is used for pull/delete.

If transport request is released in the meantime this error occurs.
![grafik](https://user-images.githubusercontent.com/17437789/205950815-a2a29a48-0f16-407e-af7c-0dcaed88bfe4.png)
