### PR TITLE
Repo View: Fallback to main if branch doesn't exist

### DIFF
--- a/src/repo/zcl_abapgit_repo_online.clas.abap
+++ b/src/repo/zcl_abapgit_repo_online.clas.abap
@@ -177,6 +177,39 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_repo_online~check_for_valid_branch.
+
+    DATA:
+      lo_branch_list TYPE REF TO zcl_abapgit_git_branch_list,
+      lv_branch      TYPE string,
+      lv_head        TYPE string,
+      lv_msg         TYPE string.
+
+    lv_branch = get_selected_branch( ).
+
+    IF lv_branch IS NOT INITIAL.
+      lo_branch_list = zcl_abapgit_git_transport=>branches( get_url( ) ).
+
+      TRY.
+          lo_branch_list->find_by_name( lv_branch ).
+        CATCH zcx_abapgit_exception.
+          " branch does not exist, fallback to head
+          lv_head = lo_branch_list->get_head_symref( ).
+          IF lo_branch_list->get_type( lv_branch ) = zif_abapgit_definitions=>c_git_branch_type-branch.
+            lv_msg = 'Branch'.
+          ELSE.
+            lv_msg = 'Tag'.
+          ENDIF.
+          lv_msg = |{ lv_msg } { lo_branch_list->get_display_name( lv_branch ) } does not exist.|
+                && | Switched to { lo_branch_list->get_display_name( lv_head ) }|.
+          MESSAGE lv_msg TYPE 'S'.
+          select_branch( lv_head ).
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_repo_online~create_branch.
 
     DATA: lv_sha1 TYPE zif_abapgit_definitions=>ty_sha1.

--- a/src/repo/zif_abapgit_repo_online.intf.abap
+++ b/src/repo/zif_abapgit_repo_online.intf.abap
@@ -55,4 +55,7 @@ INTERFACE zif_abapgit_repo_online
       !iv_from TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
     RAISING
       zcx_abapgit_exception .
+  METHODS check_for_valid_branch
+    RAISING
+      zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -184,6 +184,10 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
       RETURNING
         VALUE(rv_crossout) LIKE zif_abapgit_html=>c_html_opt-crossout.
 
+    METHODS check_branch
+      RAISING
+        zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -578,6 +582,18 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD check_branch.
+
+    DATA lo_repo TYPE REF TO zif_abapgit_repo_online.
+
+    IF mo_repo->is_offline( ) = abap_false.
+      lo_repo ?= mo_repo.
+      lo_repo->check_for_valid_branch( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD constructor.
 
     DATA: lo_settings         TYPE REF TO zcl_abapgit_settings,
@@ -799,6 +815,8 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     TRY.
         " Reinit, for the case of type change
         mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( mo_repo->get_key( ) ).
+
+        check_branch( ).
 
         mv_are_changes_recorded_in_tr = zcl_abapgit_factory=>get_sap_package( mo_repo->get_package( )
           )->are_changes_recorded_in_tr_req( ).


### PR DESCRIPTION
Instead of getting an error if the selected branch (or tag) does not exist, entering the repository view will automatically switch to the main branch (head) and issue a corresponding message in the status bar.

Old:

![image](https://user-images.githubusercontent.com/59966492/206569452-27b328ee-acca-437e-bc33-74a288025698.png)

New:

![image](https://user-images.githubusercontent.com/59966492/206569485-ec09014c-9d0e-40fa-9c52-fdebfe850208.png)


Closes https://github.com/abapGit/abapGit/issues/5331