### PR TITLE
Improve repository URL validation

### DIFF
--- a/src/git_platform/zcl_abapgit_git_url.clas.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.abap
@@ -13,7 +13,7 @@ CLASS zcl_abapgit_git_url DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-    METHODS validate
+    METHODS validate_url
       IMPORTING
         !iv_url TYPE string
       RAISING
@@ -90,7 +90,7 @@ CLASS zcl_abapgit_git_url IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD validate.
+  METHOD validate_url.
 
     DATA lv_provider TYPE string.
 

--- a/src/git_platform/zcl_abapgit_git_url.clas.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.abap
@@ -96,10 +96,16 @@ CLASS zcl_abapgit_git_url IMPLEMENTATION.
 
     lv_provider = zcl_abapgit_url=>host( to_lower( iv_url ) ).
 
+    " Provider-specific check for URLs that don't work
     IF lv_provider CS 'gitlab.com'.
       FIND REGEX '\.git$' IN iv_url IGNORING CASE.
       IF sy-subrc <> 0.
         zcx_abapgit_exception=>raise( 'Repo URL for GitLab must end in ".git"' ).
+      ENDIF.
+    ELSEIF lv_provider CS 'dev.azure.com'.
+      FIND REGEX '\.git$' IN iv_url IGNORING CASE.
+      IF sy-subrc = 0.
+        zcx_abapgit_exception=>raise( 'Repo URL for Azure DevOps must not end in ".git"' ).
       ENDIF.
     ENDIF.
 

--- a/src/git_platform/zcl_abapgit_git_url.clas.abap
+++ b/src/git_platform/zcl_abapgit_git_url.clas.abap
@@ -12,6 +12,13 @@ CLASS zcl_abapgit_git_url DEFINITION
         VALUE(rv_url) TYPE string
       RAISING
         zcx_abapgit_exception .
+
+    METHODS validate
+      IMPORTING
+        !iv_url TYPE string
+      RAISING
+        zcx_abapgit_exception.
+
   PROTECTED SECTION.
 
     METHODS get_default_commit_display_url
@@ -27,7 +34,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GIT_URL IMPLEMENTATION.
+CLASS zcl_abapgit_git_url IMPLEMENTATION.
 
 
   METHOD get_commit_display_url.
@@ -78,6 +85,22 @@ CLASS ZCL_ABAPGIT_GIT_URL IMPLEMENTATION.
           REPLACE REGEX '\.git$' IN rv_commit_url WITH space.
           rv_commit_url = rv_commit_url && |/-/commit/| && iv_hash.
       ENDCASE.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD validate.
+
+    DATA lv_provider TYPE string.
+
+    lv_provider = zcl_abapgit_url=>host( to_lower( iv_url ) ).
+
+    IF lv_provider CS 'gitlab.com'.
+      FIND REGEX '\.git$' IN iv_url IGNORING CASE.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( 'Repo URL for GitLab must end in ".git"' ).
+      ENDIF.
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -72,6 +72,23 @@ ENDCLASS.
 CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
 
 
+  METHOD choose_labels.
+
+    DATA:
+      lv_old_labels TYPE string,
+      lv_new_labels TYPE string.
+
+    lv_old_labels = mo_form_data->get( c_id-labels ).
+
+    lv_new_labels = zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_labels( lv_old_labels ).
+
+    mo_form_data->set(
+      iv_key = c_id-labels
+      iv_val = lv_new_labels ).
+
+  ENDMETHOD.
+
+
   METHOD constructor.
     super->constructor( ).
     CREATE OBJECT mo_validation_log.
@@ -168,13 +185,21 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
 
   METHOD validate_form.
 
-    DATA lx_err TYPE REF TO zcx_abapgit_exception.
+    DATA:
+      lv_url TYPE string,
+      lo_url TYPE REF TO zcl_abapgit_git_url,
+      lx_err TYPE REF TO zcx_abapgit_exception.
 
     ro_validation_log = mo_form_util->validate( io_form_data ).
 
-    IF io_form_data->get( c_id-url ) IS NOT INITIAL.
+    lv_url = io_form_data->get( c_id-url ).
+    IF lv_url IS NOT INITIAL.
       TRY.
-          zcl_abapgit_repo_srv=>get_instance( )->validate_url( io_form_data->get( c_id-url ) ).
+          zcl_abapgit_repo_srv=>get_instance( )->validate_url( lv_url ).
+
+          " Provider-specific URL check
+          CREATE OBJECT lo_url.
+          lo_url->validate( lv_url ).
         CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-url
@@ -312,22 +337,4 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
       io_validation_log = mo_validation_log ) ).
     ri_html->add( '</div>' ).
   ENDMETHOD.
-
-
-  METHOD choose_labels.
-
-    DATA:
-      lv_old_labels TYPE string,
-      lv_new_labels TYPE string.
-
-    lv_old_labels = mo_form_data->get( c_id-labels ).
-
-    lv_new_labels = zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_labels( lv_old_labels ).
-
-    mo_form_data->set(
-      iv_key = c_id-labels
-      iv_val = lv_new_labels ).
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -199,7 +199,7 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
 
           " Provider-specific URL check
           CREATE OBJECT lo_url.
-          lo_url->validate( lv_url ).
+          lo_url->validate_url( lv_url ).
         CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-url

--- a/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -796,6 +796,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
     DATA:
       lx_error                 TYPE REF TO zcx_abapgit_exception,
       lo_branch_list           TYPE REF TO zcl_abapgit_git_branch_list,
+      lo_url                   TYPE REF TO zcl_abapgit_git_url,
       lv_offline               TYPE abap_bool,
       lv_head_type             TYPE ty_head_type,
       lv_branch                TYPE ty_remote_settings-branch,
@@ -823,6 +824,10 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
           zcl_abapgit_url=>name(
             iv_url      = lv_url
             iv_validate = abap_true ).
+
+          " Provider-specific URL check
+          CREATE OBJECT lo_url.
+          lo_url->validate( lv_url ).
         CATCH zcx_abapgit_exception INTO lx_error.
           ro_validation_log->set(
             iv_key = c_id-url

--- a/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -827,7 +827,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
 
           " Provider-specific URL check
           CREATE OBJECT lo_url.
-          lo_url->validate( lv_url ).
+          lo_url->validate_url( lv_url ).
         CATCH zcx_abapgit_exception INTO lx_error.
           ro_validation_log->set(
             iv_key = c_id-url


### PR DESCRIPTION
Certain providers require that repo URLs end with `.git`. The new online repo and remote settings dialogs now validate entered URLs in this regard. Currently, the check is done for GitLab, only. If other providers require the same check, we can add them easily. 

![image](https://user-images.githubusercontent.com/59966492/206610811-eb33ee93-4cbd-4412-b30c-1262c05599a7.png)

Closes #4319