### PR TITLE
DOCV,SAMC,SAPC,STYL: Add missing transport entry

### DIFF
--- a/src/objects/zcl_abapgit_object_docv.clas.abap
+++ b/src/objects/zcl_abapgit_object_docv.clas.abap
@@ -114,6 +114,8 @@ CLASS zcl_abapgit_object_docv IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
+    corr_insert( iv_package ).
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_saxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_saxx_super.clas.abap
@@ -212,6 +212,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
         zcx_abapgit_exception=>raise( |Error occured while deleting { ms_item-obj_type }| ).
     ENDTRY.
 
+    corr_insert( iv_package ).
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_styl.clas.abap
+++ b/src/objects/zcl_abapgit_object_styl.clas.abap
@@ -53,6 +53,8 @@ CLASS zcl_abapgit_object_styl IMPLEMENTATION.
         style    = lv_style
         language = '*'.
 
+    corr_insert( iv_package ).
+
   ENDMETHOD.
 
 
@@ -73,6 +75,8 @@ CLASS zcl_abapgit_object_styl IMPLEMENTATION.
         tabs         = ls_style-tabs.
 
     tadir_insert( iv_package ).
+
+    corr_insert( iv_package ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
New CI test cases found that some objects were not recorded in transports