### PR TITLE
ENHO: Fix error deserializing enhancements

### DIFF
--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -37,7 +37,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_FILE_DESERIALIZE IMPLEMENTATION.
+CLASS zcl_abapgit_file_deserialize IMPLEMENTATION.
 
 
   METHOD filter_files_to_deserialize.
@@ -239,7 +239,7 @@ CLASS ZCL_ABAPGIT_FILE_DESERIALIZE IMPLEMENTATION.
           DELETE lt_requires WHERE obj_type <> 'ENHO'.
         WHEN 'ENHO'.
           lt_requires = lt_items.
-          DELETE lt_requires WHERE obj_type <> 'ENSC'.
+          DELETE lt_requires WHERE obj_type <> 'ENSC' AND obj_type <> 'ENHS'.
         WHEN 'ENSC'.
           lt_requires = lt_items.
           DELETE lt_requires WHERE obj_type <> 'ENHS'.


### PR DESCRIPTION
Add dependency between enhancement (`ENHO`) and enhancement spot (`ENHS`).