### PR TITLE
Add "ignore sub-packages" option for offline repos

### DIFF
--- a/src/repo/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/repo/zcl_abapgit_repo_content_list.clas.abap
@@ -122,8 +122,10 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read(
-      iv_package = mo_repo->get_package( )
-      io_dot     = mo_repo->get_dot_abapgit( ) ).
+      iv_package            = mo_repo->get_package( )
+      iv_ignore_subpackages = mo_repo->get_local_settings( )-ignore_subpackages
+      iv_only_local_objects = mo_repo->get_local_settings( )-only_local_objects
+      io_dot                = mo_repo->get_dot_abapgit( ) ).
 
     LOOP AT lt_tadir ASSIGNING <ls_tadir>.
       APPEND INITIAL LINE TO rt_repo_items ASSIGNING <ls_repo_item>.

--- a/src/repo/zif_abapgit_repo_srv.intf.abap
+++ b/src/repo/zif_abapgit_repo_srv.intf.abap
@@ -48,6 +48,7 @@ INTERFACE zif_abapgit_repo_srv
       !iv_package        TYPE devclass
       !iv_folder_logic   TYPE string DEFAULT zif_abapgit_dot_abapgit=>c_folder_logic-full
       !iv_labels         TYPE string OPTIONAL
+      !iv_ign_subpkg     TYPE abap_bool DEFAULT abap_false
       !iv_main_lang_only TYPE abap_bool DEFAULT abap_false
     RETURNING
       VALUE(ri_repo)     TYPE REF TO zif_abapgit_repo

--- a/src/ui/pages/zcl_abapgit_gui_page_addofflin.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_addofflin.clas.abap
@@ -24,11 +24,12 @@ CLASS zcl_abapgit_gui_page_addofflin DEFINITION
 
     CONSTANTS:
       BEGIN OF c_id,
-        url            TYPE string VALUE 'url',
-        package        TYPE string VALUE 'package',
-        folder_logic   TYPE string VALUE 'folder_logic',
-        labels         TYPE string VALUE 'labels',
-        main_lang_only TYPE string VALUE 'main_lang_only',
+        url                TYPE string VALUE 'url',
+        package            TYPE string VALUE 'package',
+        folder_logic       TYPE string VALUE 'folder_logic',
+        labels             TYPE string VALUE 'labels',
+        ignore_subpackages TYPE string VALUE 'ignore_subpackages',
+        main_lang_only     TYPE string VALUE 'main_lang_only',
       END OF c_id .
 
     CONSTANTS:
@@ -66,6 +67,23 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
+
+
+  METHOD choose_labels.
+
+    DATA:
+      lv_old_labels TYPE string,
+      lv_new_labels TYPE string.
+
+    lv_old_labels = mo_form_data->get( c_id-labels ).
+
+    lv_new_labels = zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_labels( lv_old_labels ).
+
+    mo_form_data->set(
+      iv_key = c_id-labels
+      iv_val = lv_new_labels ).
+
+  ENDMETHOD.
 
 
   METHOD constructor.
@@ -129,6 +147,10 @@ CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
       iv_label       = |Labels (comma-separated, allowed chars: "{ zcl_abapgit_repo_labels=>c_allowed_chars }")|
       iv_hint        = 'Comma-separated labels for grouping and repo organization (optional)'
     )->checkbox(
+      iv_name        = c_id-ignore_subpackages
+      iv_label       = 'Ignore Subpackages'
+      iv_hint        = 'Synchronize root package only'
+    )->checkbox(
       iv_name        = c_id-main_lang_only
       iv_label       = 'Serialize Main Language Only'
       iv_hint        = 'Ignore translations, serialize just main language'
@@ -154,7 +176,9 @@ CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
 
     IF io_form_data->get( c_id-package ) IS NOT INITIAL.
       TRY.
-          zcl_abapgit_repo_srv=>get_instance( )->validate_package( |{ io_form_data->get( c_id-package ) }| ).
+          zcl_abapgit_repo_srv=>get_instance( )->validate_package(
+            iv_package    = |{ io_form_data->get( c_id-package ) }|
+            iv_ign_subpkg = |{ io_form_data->get( c_id-ignore_subpackages ) }| ).
         CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-package
@@ -255,22 +279,4 @@ CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
     ri_html->add( '</div>' ).
 
   ENDMETHOD.
-
-
-  METHOD choose_labels.
-
-    DATA:
-      lv_old_labels TYPE string,
-      lv_new_labels TYPE string.
-
-    lv_old_labels = mo_form_data->get( c_id-labels ).
-
-    lv_new_labels = zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_labels( lv_old_labels ).
-
-    mo_form_data->set(
-      iv_key = c_id-labels
-      iv_val = lv_new_labels ).
-
-  ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
The option existed in the local setting for offline repos but was not working. Neither was it possible to set the option when creating a new offline repo. It's now working properly.

Closes #5924

![image](https://user-images.githubusercontent.com/59966492/207926390-c12989ae-6f27-4871-a0d8-77a7ccb3faf7.png)

PS: A bit of SE80 reorder.