### PR TITLE
Repo View: Consolidate "Pull" and "Selective Pull"

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -412,7 +412,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
 
     lo_toolbar->add(
       iv_txt      = |Pull|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-git_reset }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-git_pull }{ lc_dummy_key }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
@@ -903,7 +903,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
     ls_hotkey_action-description   = |Pull|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-git_reset.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-git_pull.
     ls_hotkey_action-hotkey = |p|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -271,12 +271,6 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     CREATE OBJECT ro_advanced_dropdown.
 
-    IF mo_repo_aggregated_state->is_unchanged( ) = abap_false. " In case of asyncronicities
-      ro_advanced_dropdown->add( iv_txt = 'Selective Pull'
-                                 iv_act = |{ zif_abapgit_definitions=>c_action-git_reset }?key={ mv_key }|
-                                 iv_opt = get_crossout( iv_protected = abap_true ) ).
-    ENDIF.
-
     IF mo_repo->is_offline( ) = abap_false. " Online ?
       ro_advanced_dropdown->add(
         iv_txt = 'Transport to Branch'
@@ -430,14 +424,11 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     IF mo_repo->is_offline( ) = abap_false.
       " online repo
 
-      IF mo_repo_aggregated_state->remote( ) IS NOT INITIAL
-         OR mo_repo_aggregated_state->is_reassigned( ) = abap_true. " Something new at remote
+      IF mo_repo_aggregated_state->is_unchanged( ) = abap_false. " Any changes
         ro_toolbar->add( iv_txt = 'Pull'
                          iv_act = |{ zif_abapgit_definitions=>c_action-git_pull }?key={ mv_key }|
                          iv_opt = get_crossout( iv_protected = abap_true
                                                 iv_strong    = abap_true ) ).
-      ENDIF.
-      IF mo_repo_aggregated_state->is_unchanged( ) = abap_false. " Any changes
         ro_toolbar->add( iv_txt = 'Stage'
                          iv_act = |{ zif_abapgit_definitions=>c_action-go_stage }?key={ mv_key }|
                          iv_opt = zif_abapgit_html=>c_html_opt-strong ).

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -456,9 +456,6 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-git_pull.                      " GIT Pull
         zcl_abapgit_services_git=>pull( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
-      WHEN zif_abapgit_definitions=>c_action-git_reset.                     " GIT Reset
-        zcl_abapgit_services_git=>reset( lv_key ).
-        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-git_branch_create.             " GIT Create new branch
         zcl_abapgit_services_git=>create_branch( lv_key ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/routing/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_git.clas.abap
@@ -9,11 +9,6 @@ CLASS zcl_abapgit_services_git DEFINITION
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
       RAISING
         zcx_abapgit_exception.
-    CLASS-METHODS reset
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception.
     CLASS-METHODS create_branch
       IMPORTING
         !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
@@ -192,23 +187,6 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
     lo_repo->refresh( ).
 
     zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
-
-  ENDMETHOD.
-
-
-  METHOD reset.
-
-    DATA lo_repo TYPE REF TO zcl_abapgit_repo.
-
-    lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
-
-    IF lo_repo->get_local_settings( )-write_protected = abap_true.
-      zcx_abapgit_exception=>raise( 'Cannot pull. Local code is write-protected in repo settings' ).
-    ENDIF.
-
-    zcl_abapgit_services_repo=>gui_deserialize(
-      io_repo      = lo_repo
-      iv_reset_all = abap_true ).
 
   ENDMETHOD.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -468,7 +468,6 @@ INTERFACE zif_abapgit_definitions
       performance_test              TYPE string VALUE 'performance_test',
       ie_devtools                   TYPE string VALUE 'ie_devtools',
       git_pull                      TYPE string VALUE 'git_pull',
-      git_reset                     TYPE string VALUE 'git_reset',
       git_branch_create             TYPE string VALUE 'git_branch_create',
       git_branch_switch             TYPE string VALUE 'git_branch_switch',
       git_branch_delete             TYPE string VALUE 'git_branch_delete',


### PR DESCRIPTION
1. "Pull" remains visible on the toolbar
   
   Exception: There are no diffs. 

2. When clicking "Pull", it runs what was previously "Selective Pull" 

   A popup asking to confirm which objects should be pulled is shown.

   Exception: There are only new objects, for example, when doing the initial pull of a repo. In this case, no popup is shown and the objects are pulled automatically.

3. "Advanced > Selective Pull" has been removed from the toolbar

Closes #5013

- [ ] To-do: Update docs