### PR TITLE
APACK user exit

### DIFF
--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -201,6 +201,11 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
         IF lo_manifest_provider IS BOUND.
           copy_manifest_descriptor( lo_manifest_provider ).
         ENDIF.
+      ELSE.
+        DATA(ls_descriptor) = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor( iv_package_name = mv_package_name ).
+        IF ls_descriptor IS NOT INITIAL.
+          set_manifest_descriptor( ls_descriptor ).
+        ENDIF.
       ENDIF.
 
       mv_is_cached = abap_true.

--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -206,8 +206,9 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
           copy_manifest_descriptor( lo_manifest_provider ).
         ENDIF.
       ELSE.
-        ls_descriptor = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor(
-                            iv_package_name = mv_package_name ).
+        ls_descriptor = zcl_abapgit_exit=>get_instance( )->repo_apack_manifest(
+            iv_package = mv_package_name
+            iv_event = zif_abapgit_apack_definitions=>c_event_read_local ).
         IF ls_descriptor IS NOT INITIAL.
           set_manifest_descriptor( ls_descriptor ).
         ENDIF.

--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -171,7 +171,8 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
   METHOD get_manifest_descriptor.
 
     DATA: lo_manifest_provider       TYPE REF TO object,
-          ls_manifest_implementation TYPE ty_s_manifest_declaration.
+          ls_manifest_implementation TYPE ty_s_manifest_declaration,
+          ls_descriptor TYPE zif_abapgit_apack_definitions=>ty_descriptor.
 
     IF mv_is_cached IS INITIAL AND mv_package_name IS NOT INITIAL.
       SELECT SINGLE seometarel~clsname tadir~devclass FROM seometarel "#EC CI_NOORDER
@@ -202,10 +203,8 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
           copy_manifest_descriptor( lo_manifest_provider ).
         ENDIF.
       ELSE.
-        DATA ls_descriptor TYPE zif_abapgit_apack_definitions=>ty_descriptor.
         ls_descriptor = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor(
-                            iv_package_name = mv_package_name
-                        ).
+                            iv_package_name = mv_package_name ).
         IF ls_descriptor IS NOT INITIAL.
           set_manifest_descriptor( ls_descriptor ).
         ENDIF.

--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -202,7 +202,10 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
           copy_manifest_descriptor( lo_manifest_provider ).
         ENDIF.
       ELSE.
-        data(ls_descriptor) = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor( iv_package_name = mv_package_name ).
+        DATA ls_descriptor TYPE zif_abapgit_apack_definitions=>ty_descriptor.
+        ls_descriptor = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor(
+                            iv_package_name = mv_package_name
+                        ).
         IF ls_descriptor IS NOT INITIAL.
           set_manifest_descriptor( ls_descriptor ).
         ENDIF.

--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -202,7 +202,7 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
           copy_manifest_descriptor( lo_manifest_provider ).
         ENDIF.
       ELSE.
-        DATA(ls_descriptor) = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor( iv_package_name = mv_package_name ).
+        data(ls_descriptor) = zcl_abapgit_exit=>get_instance( )->get_apack_manifest_descriptor( iv_package_name = mv_package_name ).
         IF ls_descriptor IS NOT INITIAL.
           set_manifest_descriptor( ls_descriptor ).
         ENDIF.

--- a/src/apack/zif_abapgit_apack_definitions.intf.abap
+++ b/src/apack/zif_abapgit_apack_definitions.intf.abap
@@ -27,7 +27,7 @@ INTERFACE zif_abapgit_apack_definitions PUBLIC .
     BEGIN OF ty_descriptor.
       INCLUDE TYPE ty_descriptor_wo_dependencies.
   TYPES:
-    dependencies TYPE ty_dependencies,
+      dependencies TYPE ty_dependencies,
     END OF ty_descriptor,
 
     ty_descriptors TYPE STANDARD TABLE OF ty_descriptor WITH NON-UNIQUE DEFAULT KEY.
@@ -36,4 +36,8 @@ INTERFACE zif_abapgit_apack_definitions PUBLIC .
   CONSTANTS c_repository_type_abapgit TYPE ty_repository_type VALUE 'abapGit' ##NO_TEXT.
   CONSTANTS c_apack_interface_sap TYPE seoclsname VALUE 'IF_APACK_MANIFEST' ##NO_TEXT.
   CONSTANTS c_apack_interface_cust TYPE seoclsname VALUE 'ZIF_APACK_MANIFEST' ##NO_TEXT.
+
+  CONSTANTS c_event_read_local TYPE i VALUE 0.
+  CONSTANTS c_event_create_local TYPE i VALUE 1.
+  CONSTANTS c_event_overwrite_local TYPE i VALUE 3.
 ENDINTERFACE.

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -345,8 +345,21 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
     IF gi_exit IS NOT INITIAL.
       TRY.
-          rs_manifest_descriptor = gi_exit->get_apack_manifest_descriptor(
-              iv_package_name        = iv_package_name ).
+          rs_manifest_descriptor = gi_exit->get_apack_manifest_descriptor( iv_package_name = iv_package_name ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_exit~apack_manifest_deserialize.
+
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->apack_manifest_deserialize(
+              io_repo                = io_repo
+              io_remote_apack        = io_remote_apack
+              is_ow_check            = is_ow_check ).
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -345,11 +345,9 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
     IF gi_exit IS NOT INITIAL.
       TRY.
-          gi_exit->get_apack_manifest_descriptor(
+          rs_manifest_descriptor = gi_exit->get_apack_manifest_descriptor(
             EXPORTING
-              iv_package_name        = iv_package_name
-            RECEIVING
-              rs_manifest_descriptor = rs_manifest_descriptor ).
+              iv_package_name        = iv_package_name ).
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -346,7 +346,6 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
     IF gi_exit IS NOT INITIAL.
       TRY.
           rs_manifest_descriptor = gi_exit->get_apack_manifest_descriptor(
-            EXPORTING
               iv_package_name        = iv_package_name ).
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -341,4 +341,19 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD zif_abapgit_exit~get_apack_manifest_descriptor.
+
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->get_apack_manifest_descriptor(
+            EXPORTING
+              iv_package_name        = iv_package_name
+            RECEIVING
+              rs_manifest_descriptor = rs_manifest_descriptor ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -341,25 +341,14 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_exit~get_apack_manifest_descriptor.
+  METHOD zif_abapgit_exit~repo_apack_manifest.
 
     IF gi_exit IS NOT INITIAL.
       TRY.
-          rs_manifest_descriptor = gi_exit->get_apack_manifest_descriptor( iv_package_name = iv_package_name ).
-        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-      ENDTRY.
-    ENDIF.
-
-  ENDMETHOD.
-
-  METHOD zif_abapgit_exit~apack_manifest_deserialize.
-
-    IF gi_exit IS NOT INITIAL.
-      TRY.
-          gi_exit->apack_manifest_deserialize(
-              io_repo                = io_repo
-              io_remote_apack        = io_remote_apack
-              is_ow_check            = is_ow_check ).
+          rs_apack_manifest = gi_exit->repo_apack_manifest(
+            iv_package      = iv_package
+            iv_event        = iv_event
+            io_remote_apack = io_remote_apack ).
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -117,4 +117,9 @@ INTERFACE zif_abapgit_exit
       iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
     CHANGING
       cv_transport_request TYPE trkorr.
+  METHODS get_apack_manifest_descriptor
+    IMPORTING
+      iv_package_name               TYPE devclass
+    RETURNING
+      VALUE(rs_manifest_descriptor) TYPE zif_abapgit_apack_definitions=>ty_descriptor.
 ENDINTERFACE.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -122,4 +122,9 @@ INTERFACE zif_abapgit_exit
       iv_package_name               TYPE devclass
     RETURNING
       VALUE(rs_manifest_descriptor) TYPE zif_abapgit_apack_definitions=>ty_descriptor.
+  METHODS apack_manifest_deserialize
+    IMPORTING
+      io_repo         TYPE REF TO zcl_abapgit_repo
+      io_remote_apack TYPE REF TO zcl_abapgit_apack_reader
+      is_ow_check     TYPE zif_abapgit_definitions=>ty_overwrite.
 ENDINTERFACE.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -117,14 +117,11 @@ INTERFACE zif_abapgit_exit
       iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
     CHANGING
       cv_transport_request TYPE trkorr.
-  METHODS get_apack_manifest_descriptor
+  METHODS repo_apack_manifest
     IMPORTING
-      iv_package_name               TYPE devclass
+      iv_package               TYPE devclass
+      iv_event                 TYPE i
+      io_remote_apack          TYPE REF TO zcl_abapgit_apack_reader OPTIONAL
     RETURNING
-      VALUE(rs_manifest_descriptor) TYPE zif_abapgit_apack_definitions=>ty_descriptor.
-  METHODS apack_manifest_deserialize
-    IMPORTING
-      io_repo         TYPE REF TO zcl_abapgit_repo
-      io_remote_apack TYPE REF TO zcl_abapgit_apack_reader
-      is_ow_check     TYPE zif_abapgit_definitions=>ty_overwrite.
+      VALUE(rs_apack_manifest) TYPE zif_abapgit_apack_definitions=>ty_descriptor.
 ENDINTERFACE.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -92,7 +92,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
   METHOD check_multiple_files.
 
     DATA:
-      lv_msg TYPE string,
+      lv_msg      TYPE string,
       lt_res_sort LIKE it_results,
       ls_file     TYPE zif_abapgit_definitions=>ty_file_signature.
 

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -213,10 +213,13 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       <ls_changes> LIKE LINE OF lt_changes.
 
     " collect all actions for object that have been changed
-    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL.
+    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL OR filename = '.apack-manifest.xml'.
 
       APPEND INITIAL LINE TO lt_changes ASSIGNING <ls_changes>.
       MOVE-CORRESPONDING <ls_result> TO <ls_changes>.
+      IF <ls_result>-filename EQ '.apack-manifest.xml'.
+        <ls_changes>-obj_name = 'APACK'.
+      ENDIF.
       <ls_changes>-devclass = <ls_result>-package.
 
       IF <ls_result>-packmove = abap_true.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -217,7 +217,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
 
       APPEND INITIAL LINE TO lt_changes ASSIGNING <ls_changes>.
       MOVE-CORRESPONDING <ls_result> TO <ls_changes>.
-      IF <ls_result>-filename EQ '.apack-manifest.xml'.
+      IF <ls_result>-filename = '.apack-manifest.xml'.
         <ls_changes>-obj_name = 'APACK'.
       ENDIF.
       <ls_changes>-devclass = <ls_result>-package.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -213,7 +213,8 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       <ls_changes> LIKE LINE OF lt_changes.
 
     " collect all actions for object that have been changed
-    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL OR filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
+    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL OR
+                                                   filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
 
       APPEND INITIAL LINE TO lt_changes ASSIGNING <ls_changes>.
       MOVE-CORRESPONDING <ls_result> TO <ls_changes>.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -217,8 +217,8 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
 
       APPEND INITIAL LINE TO lt_changes ASSIGNING <ls_changes>.
       MOVE-CORRESPONDING <ls_result> TO <ls_changes>.
-      IF <ls_result>-filename = '.apack-manifest.xml'.
-        <ls_changes>-obj_name = 'APACK'.
+      IF <ls_result>-filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
+        <ls_changes>-obj_name = <ls_result>-filename.
       ENDIF.
       <ls_changes>-devclass = <ls_result>-package.
 

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -213,7 +213,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       <ls_changes> LIKE LINE OF lt_changes.
 
     " collect all actions for object that have been changed
-    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL OR filename = '.apack-manifest.xml'.
+    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL OR filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
 
       APPEND INITIAL LINE TO lt_changes ASSIGNING <ls_changes>.
       MOVE-CORRESPONDING <ls_result> TO <ls_changes>.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -762,11 +762,9 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
       IF ls_apack_implementation IS INITIAL.
         " has to be updated by user exit
         zcl_abapgit_exit=>get_instance( )->repo_apack_manifest(
-          EXPORTING
             iv_package        = io_repo->get_package( )
             iv_event          = zif_abapgit_apack_definitions=>c_event_overwrite_local
-            io_remote_apack   = io_repo->find_remote_dot_apack( )
-        ).
+            io_remote_apack   = io_repo->find_remote_dot_apack( ) ).
       ENDIF.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -759,7 +759,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     SORT rt_accessed_files BY path ASCENDING filename ASCENDING.
     DELETE ADJACENT DUPLICATES FROM rt_accessed_files. " Just in case
 
-    update_apack( io_repo = io_repo is_checks = is_checks ).
+    update_apack( io_repo = io_repo
+                  is_checks = is_checks ).
 
     zcl_abapgit_default_transport=>get_instance( )->reset( ).
 

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -722,7 +722,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     ENDIF.
 
     READ TABLE is_checks-overwrite INTO ls_apack_ow_check WITH KEY obj_name = 'APACK'.
-    IF sy-subrc EQ 0.
+    IF sy-subrc = 0.
       zcl_abapgit_exit=>get_instance( )->apack_manifest_deserialize(
           io_repo         = me
           io_remote_apack = lo_remote_apack

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -47,6 +47,11 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(ro_dot) TYPE REF TO zcl_abapgit_dot_abapgit
       RAISING
         zcx_abapgit_exception .
+    METHODS find_remote_dot_apack
+      RETURNING
+        VALUE(ro_dot) TYPE REF TO zcl_abapgit_apack_reader
+      RAISING
+        zcx_abapgit_exception .
     METHODS set_files_remote
       IMPORTING
         !it_files TYPE zif_abapgit_definitions=>ty_files_tt .
@@ -56,7 +61,7 @@ CLASS zcl_abapgit_repo DEFINITION
       RAISING
         zcx_abapgit_exception .
     METHODS has_remote_source
-      ABSTRACT
+          ABSTRACT
       RETURNING
         VALUE(rv_yes) TYPE abap_bool .
     METHODS status
@@ -101,7 +106,7 @@ CLASS zcl_abapgit_repo DEFINITION
         zcx_abapgit_exception .
     METHODS check_and_create_package
       IMPORTING
-        iv_package TYPE devclass
+         iv_package TYPE devclass
       RAISING
         zcx_abapgit_exception .
   PROTECTED SECTION.
@@ -116,12 +121,6 @@ CLASS zcl_abapgit_repo DEFINITION
     DATA mo_apack_reader TYPE REF TO zcl_abapgit_apack_reader .
     DATA mi_data_config TYPE REF TO zif_abapgit_data_config .
 
-    METHODS find_remote_dot_apack
-      EXPORTING
-        eo_dot              TYPE REF TO zcl_abapgit_apack_reader
-        es_overwrite_action TYPE zif_abapgit_definitions=>ty_overwrite
-      RAISING
-        zcx_abapgit_exception .
     METHODS set_dot_apack
       IMPORTING
         !io_dot_apack TYPE REF TO zcl_abapgit_apack_reader
@@ -162,16 +161,11 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS normalize_local_settings
       CHANGING
         cs_local_settings TYPE zif_abapgit_persistence=>ty_local_settings.
-    METHODS check_apack_overwrite
-      CHANGING
-        ct_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt
-      RAISING
-        zcx_abapgit_exception.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 
   METHOD bind_listener.
@@ -226,17 +220,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD check_apack_overwrite.
-    DATA: ls_overwite_line           TYPE zif_abapgit_definitions=>ty_overwrite,
-          ls_manifest_implementation TYPE zcl_abapgit_apack_reader=>ty_s_manifest_declaration.
-
-    find_remote_dot_apack( IMPORTING es_overwrite_action = ls_overwite_line ).
-    ls_manifest_implementation = get_dot_apack( )->get_manifest_implementation( ).
-    IF ls_manifest_implementation IS INITIAL.
-      ls_overwite_line-obj_name = 'APACK'.
-      APPEND ls_overwite_line TO ct_overwrite.
-    ENDIF.
-  ENDMETHOD.
 
   METHOD check_language.
 
@@ -337,13 +320,8 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD find_remote_dot_apack.
-    DATA ls_current_apack_file TYPE zif_abapgit_definitions=>ty_file.
-    FIELD-SYMBOLS: <ls_remote> LIKE LINE OF mt_remote.
 
-    TRY.
-        ls_current_apack_file = zcl_abapgit_apack_helper=>to_file( iv_package = ms_data-package ).
-      CATCH zcx_abapgit_exception.
-    ENDTRY.
+    FIELD-SYMBOLS: <ls_remote> LIKE LINE OF mt_remote.
 
     get_files_remote( ).
 
@@ -352,30 +330,9 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       COMPONENTS path     = zif_abapgit_definitions=>c_root_dir
                  filename = zif_abapgit_apack_definitions=>c_dot_apack_manifest.
     IF sy-subrc = 0.
-      eo_dot = zcl_abapgit_apack_reader=>deserialize( iv_package_name = ms_data-package
+      ro_dot = zcl_abapgit_apack_reader=>deserialize( iv_package_name = ms_data-package
                                                       iv_xstr         = <ls_remote>-data ).
-      set_dot_apack( eo_dot ).
-      IF ls_current_apack_file IS INITIAL.
-        es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-add.
-        es_overwrite_action-icon   = icon_create.
-        es_overwrite_action-text   = 'Add local APACK'.
-      ELSE.
-        IF ls_current_apack_file-sha1 = <ls_remote>-sha1.
-          es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-none.
-        ELSE.
-          es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-overwrite.
-          es_overwrite_action-icon   = icon_change.
-          es_overwrite_action-text   = 'Overwrite local APACK'.
-        ENDIF.
-      ENDIF.
-    ELSE.
-      IF ls_current_apack_file IS INITIAL.
-        es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-none.
-      ELSE.
-        es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-delete.
-        es_overwrite_action-icon   = icon_delete.
-        es_overwrite_action-text   = 'Delete local APAC'.
-      ENDIF.
+      set_dot_apack( ro_dot ).
     ENDIF.
 
   ENDMETHOD.
@@ -697,14 +654,12 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
   METHOD zif_abapgit_repo~deserialize.
 
-    DATA: lt_updated_files  TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
-          lt_result         TYPE zif_abapgit_data_deserializer=>ty_results,
-          lx_error          TYPE REF TO zcx_abapgit_exception,
-          lo_remote_apack   TYPE REF TO zcl_abapgit_apack_reader,
-          ls_apack_ow_check TYPE zif_abapgit_definitions=>ty_overwrite.
+    DATA: lt_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
+          lt_result        TYPE zif_abapgit_data_deserializer=>ty_results,
+          lx_error         TYPE REF TO zcx_abapgit_exception.
 
     find_remote_dot_abapgit( ).
-    find_remote_dot_apack( IMPORTING eo_dot = lo_remote_apack ).
+    find_remote_dot_apack( ).
 
     check_write_protect( ).
     check_language( ).
@@ -719,15 +674,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
     IF is_checks-transport-required = abap_true AND is_checks-transport-transport IS INITIAL.
       zcx_abapgit_exception=>raise( |No transport request was supplied| ).
-    ENDIF.
-
-    READ TABLE is_checks-overwrite INTO ls_apack_ow_check WITH KEY obj_name = 'APACK'.
-    IF sy-subrc = 0.
-      zcl_abapgit_exit=>get_instance( )->apack_manifest_deserialize(
-          io_repo         = me
-          io_remote_apack = lo_remote_apack
-          is_ow_check     = ls_apack_ow_check
-      ).
     ENDIF.
 
     " Deserialize objects
@@ -776,8 +722,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     check_language( ).
 
     rs_checks = zcl_abapgit_objects=>deserialize_checks( me ).
-
-    check_apack_overwrite( CHANGING ct_overwrite = rs_checks-overwrite ).
 
     lt_requirements = get_dot_abapgit( )->get_data( )-requirements.
     rs_checks-requirements-met = zcl_abapgit_requirement_helper=>is_requirements_met( lt_requirements ).

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -231,7 +231,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
           ls_manifest_implementation TYPE zcl_abapgit_apack_reader=>ty_s_manifest_declaration.
 
     find_remote_dot_apack( IMPORTING es_overwrite_action = ls_overwite_line ).
-    ls_manifest_implementation = me->get_dot_apack( )->get_manifest_implementation( ).
+    ls_manifest_implementation = get_dot_apack( )->get_manifest_implementation( ).
     IF ls_manifest_implementation IS INITIAL.
       ls_overwite_line-obj_name = 'APACK'.
       APPEND ls_overwite_line TO ct_overwrite.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -360,7 +360,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
         es_overwrite_action-icon   = icon_create.
         es_overwrite_action-text   = 'Add local APACK'.
       ELSE.
-        IF ls_current_apack_file-sha1 EQ <ls_remote>-sha1.
+        IF ls_current_apack_file-sha1 = <ls_remote>-sha1.
           es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-none.
         ELSE.
           es_overwrite_action-action = zif_abapgit_objects=>c_deserialize_action-overwrite.


### PR DESCRIPTION
If a manifest class implementing either ZIF_APACK_MANIFEST or IF_APACK_MANIFEST, it will fallback to the user exit, that, if implemented, will provide the APACK values.