### PR TITLE
TABU: No error when table not yet exists

### DIFF
--- a/src/data/zcl_abapgit_data_serializer.clas.abap
+++ b/src/data/zcl_abapgit_data_serializer.clas.abap
@@ -116,14 +116,20 @@ CLASS ZCL_ABAPGIT_DATA_SERIALIZER IMPLEMENTATION.
       ASSERT ls_config-type = zif_abapgit_data_config=>c_data_type-tabu. " todo
       ASSERT ls_config-name IS NOT INITIAL.
 
-      lr_data = read_database_table(
-        iv_name  = ls_config-name
-        it_where = ls_config-where ).
+      TRY.
+          lr_data = read_database_table(
+                      iv_name  = ls_config-name
+                      it_where = ls_config-where ).
+
+          ls_file-data = convert_itab_to_json(
+            ir_data         = lr_data
+            iv_skip_initial = ls_config-skip_initial ).
+
+        CATCH zcx_abapgit_exception.
+          " DB table might not yet exist
+      ENDTRY.
 
       ls_file-filename = zcl_abapgit_data_utils=>build_filename( ls_config ).
-      ls_file-data = convert_itab_to_json(
-        ir_data         = lr_data
-        iv_skip_initial = ls_config-skip_initial ).
       ls_file-sha1 = zcl_abapgit_hash=>sha1_blob( ls_file-data ).
       APPEND ls_file TO rt_files.
     ENDLOOP.

--- a/src/data/zcl_abapgit_data_serializer.clas.testclasses.abap
+++ b/src/data/zcl_abapgit_data_serializer.clas.testclasses.abap
@@ -57,8 +57,8 @@ CLASS ltcl_test IMPLEMENTATION.
 
     TRY.
         mi_cut->serialize( mi_config ).
-        cl_abap_unit_assert=>fail( ).
       CATCH zcx_abapgit_exception.
+        cl_abap_unit_assert=>fail( ).
     ENDTRY.
 
   ENDMETHOD.
@@ -77,8 +77,8 @@ CLASS ltcl_test IMPLEMENTATION.
 
     TRY.
         mi_cut->serialize( mi_config ).
-        cl_abap_unit_assert=>fail( ).
       CATCH zcx_abapgit_exception.
+        cl_abap_unit_assert=>fail( ).
     ENDTRY.
 
   ENDMETHOD.

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -79,7 +79,6 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
           IF sy-subrc <> 0.
             zcx_abapgit_exception=>raise( |Table { iv_name } not found for data serialization| ).
           ENDIF.
-          lt_fields = lo_data->get_ddic_field_list( ).
 
           APPEND INITIAL LINE TO lt_keys ASSIGNING <ls_key>.
           <ls_key>-access_kind = cl_abap_tabledescr=>tablekind_sorted.

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -69,6 +69,16 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
 
         " Get primary key to ensure unique entries
         IF lo_data->is_ddic_type( ) = abap_true.
+          lo_data->get_ddic_field_list(
+            RECEIVING
+              p_field_list             = lt_fields
+            EXCEPTIONS
+              not_found                = 1
+              no_ddic_type             = 2
+              OTHERS                   = 3 ).
+          IF sy-subrc <> 0.
+            zcx_abapgit_exception=>raise( |Table { iv_name } not found for data serialization| ).
+          ENDIF.
           lt_fields = lo_data->get_ddic_field_list( ).
 
           APPEND INITIAL LINE TO lt_keys ASSIGNING <ls_key>.


### PR DESCRIPTION
#3441
Gven test repo containing DB table and corresponding TABU data
https://gitlab.com/christianguenter/test_db_sys.git

Before this change deserializing the repo is not possible 
![grafik](https://user-images.githubusercontent.com/17437789/210064940-4659b0f4-374a-4004-87fc-120d076a2ca4.png)
and sometimes it also dumps because the db table doesn't exist
![grafik](https://user-images.githubusercontent.com/17437789/210064306-519656e3-9903-4a19-a1af-463a8118c75a.png)
![grafik](https://user-images.githubusercontent.com/17437789/210064358-f1842c87-ccdb-4fa3-a0f3-be0ca8b330cf.png)
![grafik](https://user-images.githubusercontent.com/17437789/210064295-0bf30b99-4ab5-4c04-83ef-94301d178266.png)

Reopen the repo shows this error and it's not possible to pull
![grafik](https://user-images.githubusercontent.com/17437789/210064409-847f0526-48f8-4c9d-94fe-bc2570fdc0cc.png)

After this change pull is possible 
![grafik](https://user-images.githubusercontent.com/17437789/210064473-b45a9275-f83d-4eed-b115-142498c0bbca.png)
![grafik](https://user-images.githubusercontent.com/17437789/210064554-1dc692db-49e7-44da-93f3-50a976fb1544.png)

