### PR TITLE
Fix "duplicate file error" during pull

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -96,7 +96,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       lv_lstate   TYPE c LENGTH 2,
       lv_rstate   TYPE c LENGTH 2,
       lt_res_sort LIKE it_results,
-      ls_result   TYPE LINE OF it_results.
+      ls_result   LIKE LINE OF it_results.
 
     FIELD-SYMBOLS <ls_result> LIKE LINE OF it_results.
 

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -92,7 +92,9 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
   METHOD check_multiple_files.
 
     DATA:
-      lv_msg TYPE string,
+      lv_msg      TYPE string,
+      lv_lstate   TYPE c LENGTH 2,
+      lv_rstate   TYPE c LENGTH 2,
       lt_res_sort LIKE it_results,
       ls_file     TYPE zif_abapgit_definitions=>ty_file_signature.
 
@@ -104,7 +106,10 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
     " Prevent pulling if there is more than one file with the same name
     LOOP AT lt_res_sort ASSIGNING <ls_result>
       WHERE obj_type <> 'DEVC' AND packmove = abap_false AND filename IS NOT INITIAL.
-      IF <ls_result>-filename = ls_file-filename.
+      CONCATENATE <ls_result>-lstate ls_file-lstate INTO lv_lstate RESPECTING BLANKS.
+      CONCATENATE <ls_result>-rstate ls_file-rstate INTO lv_rstate RESPECTING BLANKS.
+      IF <ls_result>-filename = ls_file-filename AND
+        lv_lstate <> 'AD' AND lv_lstate <> 'DA' AND lv_rstate <> 'AD' AND lv_rstate <> 'DA'.
         lv_msg = |Pull not possible since there are multiple files with same filename, { <ls_result>-filename }.|
           && | Keep one of the files and delete the other in the repository.|.
         zcx_abapgit_exception=>raise( lv_msg ).

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -96,7 +96,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       lv_lstate   TYPE c LENGTH 2,
       lv_rstate   TYPE c LENGTH 2,
       lt_res_sort LIKE it_results,
-      ls_file     TYPE zif_abapgit_definitions=>ty_file_signature.
+      ls_result   TYPE LINE OF it_results.
 
     FIELD-SYMBOLS <ls_result> LIKE LINE OF it_results.
 
@@ -106,15 +106,16 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
     " Prevent pulling if there is more than one file with the same name
     LOOP AT lt_res_sort ASSIGNING <ls_result>
       WHERE obj_type <> 'DEVC' AND packmove = abap_false AND filename IS NOT INITIAL.
-      CONCATENATE <ls_result>-lstate ls_file-lstate INTO lv_lstate RESPECTING BLANKS.
-      CONCATENATE <ls_result>-rstate ls_file-rstate INTO lv_rstate RESPECTING BLANKS.
-      IF <ls_result>-filename = ls_file-filename AND
+      " Changing package and object at the same time is ok (state: Add + Delete)
+      CONCATENATE <ls_result>-lstate ls_result-lstate INTO lv_lstate RESPECTING BLANKS.
+      CONCATENATE <ls_result>-rstate ls_result-rstate INTO lv_rstate RESPECTING BLANKS.
+      IF <ls_result>-filename = ls_result-filename AND
         lv_lstate <> 'AD' AND lv_lstate <> 'DA' AND lv_rstate <> 'AD' AND lv_rstate <> 'DA'.
         lv_msg = |Pull not possible since there are multiple files with same filename, { <ls_result>-filename }.|
           && | Keep one of the files and delete the other in the repository.|.
         zcx_abapgit_exception=>raise( lv_msg ).
       ENDIF.
-      MOVE-CORRESPONDING <ls_result> TO ls_file.
+      MOVE-CORRESPONDING <ls_result> TO ls_result.
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.testclasses.abap
@@ -18,7 +18,9 @@ CLASS ltcl_warning_overwrite_find DEFINITION FINAL FOR TESTING
       warning_overwrite_find_04 FOR TESTING RAISING cx_static_check,
       warning_overwrite_find_05 FOR TESTING RAISING cx_static_check,
       warning_overwrite_find_06 FOR TESTING RAISING cx_static_check,
-      check_multiple_files FOR TESTING RAISING cx_static_check,
+      check_multiple_files_01 FOR TESTING RAISING cx_static_check,
+      check_multiple_files_02 FOR TESTING RAISING cx_static_check,
+      check_multiple_files_03 FOR TESTING RAISING cx_static_check,
 
       given_result
         IMPORTING
@@ -175,7 +177,7 @@ CLASS ltcl_warning_overwrite_find IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD check_multiple_files.
+  METHOD check_multiple_files_01.
 
     " same filename but different packages (paths)
     given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;A;;| ).
@@ -185,6 +187,34 @@ CLASS ltcl_warning_overwrite_find IMPLEMENTATION.
         mo_objects->check_multiple_files( mt_result ).
         cl_abap_unit_assert=>fail( ).
       CATCH zcx_abapgit_exception ##NO_HANDLER.
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD check_multiple_files_02.
+
+    " same filename but change of package and object (local add + delete)
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;A;;| ).
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/sub;zag_unit_test.clas.abap;;;D;;| ).
+
+    TRY.
+        mo_objects->check_multiple_files( mt_result ).
+      CATCH zcx_abapgit_exception ##NO_HANDLER.
+        cl_abap_unit_assert=>fail( ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD check_multiple_files_03.
+
+    " same filename but change of package and object (remote add + delete)
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;;A;| ).
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/sub;zag_unit_test.clas.abap;;;;D;| ).
+
+    TRY.
+        mo_objects->check_multiple_files( mt_result ).
+      CATCH zcx_abapgit_exception ##NO_HANDLER.
+        cl_abap_unit_assert=>fail( ).
     ENDTRY.
 
   ENDMETHOD.


### PR DESCRIPTION
Fixes error that occurs if an object is moved to another package and changed at the same time. 

Closes #5967