### PR TITLE
Fix syntax highlight for XML, CSS, JS

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_css.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_css.clas.abap
@@ -93,7 +93,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SYNTAX_CSS IMPLEMENTATION.
+CLASS zcl_abapgit_syntax_css IMPLEMENTATION.
 
 
   METHOD class_constructor.
@@ -107,8 +107,10 @@ CLASS ZCL_ABAPGIT_SYNTAX_CSS IMPLEMENTATION.
 
     super->constructor( ).
 
-    " Initialize instances of regular expression
+    " Reset indicator for multi-line comments
+    CLEAR gv_comment.
 
+    " Initialize instances of regular expression
     add_rule( iv_regex = c_regex-keyword
               iv_token = c_token-keyword
               iv_style = c_css-keyword ).

--- a/src/syntax/zcl_abapgit_syntax_js.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_js.clas.abap
@@ -63,7 +63,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SYNTAX_JS IMPLEMENTATION.
+CLASS zcl_abapgit_syntax_js IMPLEMENTATION.
 
 
   METHOD class_constructor.
@@ -77,8 +77,10 @@ CLASS ZCL_ABAPGIT_SYNTAX_JS IMPLEMENTATION.
 
     super->constructor( ).
 
-    " Initialize instances of regular expression
+    " Reset indicator for multi-line comments
+    CLEAR gv_comment.
 
+    " Initialize instances of regular expression
     add_rule( iv_regex = c_regex-keyword
               iv_token = c_token-keyword
               iv_style = c_css-keyword ).

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.abap
@@ -48,8 +48,10 @@ CLASS zcl_abapgit_syntax_xml IMPLEMENTATION.
 
     super->constructor( ).
 
-    " Initialize instances of regular expressions
+    " Reset indicator for multi-line comments
+    CLEAR gv_comment.
 
+    " Initialize instances of regular expressions
     add_rule( iv_regex    = c_regex-xml_tag
               iv_token    = c_token-xml_tag
               iv_style    = c_css-xml_tag

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
@@ -14,7 +14,8 @@ CLASS ltcl_abapgit_syntax_xml DEFINITION FINAL FOR TESTING
       empty_attributes FOR TESTING RAISING cx_static_check,
       open_tags FOR TESTING RAISING cx_static_check,
       attributes_only FOR TESTING RAISING cx_static_check,
-      attribute_value_equal_signs FOR TESTING RAISING cx_static_check.
+      attribute_value_equal_signs FOR TESTING RAISING cx_static_check,
+      multi_line_comments FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -98,7 +99,6 @@ CLASS ltcl_abapgit_syntax_xml IMPLEMENTATION.
          && |<span class="attr_val">"1.5"</span>|
       act = mo_cut->process_line( |<ECTD SAPRL="751" VERSION="1.5"| ) ).
 
-
   ENDMETHOD.
 
   METHOD attribute_value_equal_signs.
@@ -114,6 +114,20 @@ CLASS ltcl_abapgit_syntax_xml IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD multi_line_comments.
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = |<span class="comment">&lt;!-- comment</span>|
+      act = mo_cut->process_line( |<!-- comment| ) ).
+
+    " New instance (i.e. different file)
+    CREATE OBJECT mo_cut.
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = |<span class="xml_tag">&lt;tag&gt;</span>|
+      act = mo_cut->process_line( |<tag>| ) ).
+
+  ENDMETHOD.
 
 ENDCLASS.
 


### PR DESCRIPTION
If a file ended with a multi-line comment, highlighting for the subsequent file does not work properly. 

The fix resets the corresponding flag.

Before:

![image](https://user-images.githubusercontent.com/59966492/210562300-c1d3d07e-a54e-466a-9a4f-ba908003547b.png)

After:

![image](https://user-images.githubusercontent.com/59966492/210562412-a7ead2a0-4c59-4414-ab79-fee1fb92f44e.png)

