### PR TITLE
Fix menus with many items

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -755,6 +755,8 @@ div.tutorial h2 { font-size: 14pt;}
   z-index: 1;
   padding: 0;
   box-shadow: 1px 1px 3px 0px #bbb;
+  max-height: 700px;
+  overflow: auto;
 }
 
 .nav-container ul ul li {


### PR DESCRIPTION
Menus with many items are not accessible if the menu becomes longer than the screen height.

Before:

![image](https://user-images.githubusercontent.com/59966492/210563247-e74617d1-a1ca-4ffd-b865-e13314df748c.png)

After:

![image](https://user-images.githubusercontent.com/59966492/210563277-db510dc7-143a-416a-994d-da328a11499c.png)

Note: Setting a relative max-height does not seem to be feasible since it would be relative to the size of the sticky area. 