### PR TITLE
SMIM: Record deletion of objects in transport

### DIFF
--- a/src/objects/zcl_abapgit_object_smim.clas.abap
+++ b/src/objects/zcl_abapgit_object_smim.clas.abap
@@ -148,6 +148,8 @@ CLASS zcl_abapgit_object_smim IMPLEMENTATION.
     TRY.
         get_url_for_io( IMPORTING ev_url  = lv_url ).
       CATCH zcx_abapgit_not_found.
+        " Deleted already (maybe by "folder with children") but record deletion in transport
+        corr_insert( iv_package ).
         RETURN.
     ENDTRY.
 


### PR DESCRIPTION
Record the deletion of MIME objects in a transport in case they were deleted via "folder with children"