### PR TITLE
CLAS,INTF: Removing STATE field in XML

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -465,6 +465,10 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
                       iv_clsname    = <lv_clsname>
                       it_attributes = it_attributes ).
 
+    " Hardcode STATE (#2612)
+    ls_properties = cg_properties.
+    ls_properties-state = '1'.
+
     TRY.
         CALL FUNCTION 'SEO_CLASS_CREATE_COMPLETE'
           EXPORTING
@@ -473,7 +477,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
             version         = seoc_version_active
             suppress_dialog = abap_true " Parameter missing in 702
           CHANGING
-            class           = cg_properties
+            class           = ls_properties
             attributes      = lt_vseoattrib
           EXCEPTIONS
             existing        = 1
@@ -490,7 +494,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
             overwrite       = abap_true
             version         = seoc_version_active
           CHANGING
-            class           = cg_properties
+            class           = ls_properties
             attributes      = lt_vseoattrib
           EXCEPTIONS
             existing        = 1
@@ -707,6 +711,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
     ENDIF.
 
     CLEAR:
+      " TODO 2023-08-01: Clear rs_class_properties-state (#2612)
       rs_class_properties-uuid,
       rs_class_properties-author,
       rs_class_properties-createdon,

--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -467,7 +467,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
 
     " Hardcode STATE (#2612)
     ls_properties = cg_properties.
-    ls_properties-state = '1'.
+    ls_properties-state = seoc_state_implemented.
 
     TRY.
         CALL FUNCTION 'SEO_CLASS_CREATE_COMPLETE'

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -188,6 +188,10 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
                       iv_clsname    = <lv_clsname>
                       it_attributes = it_attributes ).
 
+    " Hardcode STATE (#2612)
+    ls_properties = cg_properties.
+    ls_properties-state = '1'.
+
     TRY.
         CALL FUNCTION 'SEO_INTERFACE_CREATE_COMPLETE'
           EXPORTING
@@ -196,7 +200,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
             version         = seoc_version_active
             suppress_dialog = abap_true " Parameter missing in 702
           CHANGING
-            interface       = cg_properties
+            interface       = ls_properties
             attributes      = lt_vseoattrib
           EXCEPTIONS
             existing        = 1
@@ -213,7 +217,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
             overwrite       = abap_true
             version         = seoc_version_active
           CHANGING
-            interface       = cg_properties
+            interface       = ls_properties
             attributes      = lt_vseoattrib
           EXCEPTIONS
             existing        = 1
@@ -322,6 +326,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
     ENDIF.
 
     CLEAR:
+      " TODO 2023-08-01: Clear rs_interface_properties-state (#2612)
       rs_interface_properties-uuid,
       rs_interface_properties-author,
       rs_interface_properties-createdon,

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -190,7 +190,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
 
     " Hardcode STATE (#2612)
     ls_properties = cg_properties.
-    ls_properties-state = '1'.
+    ls_properties-state = seoc_state_implemented.
 
     TRY.
         CALL FUNCTION 'SEO_INTERFACE_CREATE_COMPLETE'


### PR DESCRIPTION
Hardcoding `state = 1` during deserialize. 

To-do: Clear `state` field later this year

Ref #2612