### PR TITLE
Pull log: Include object counts

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -186,6 +186,13 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
 
       lv_logname = |ABAPGIT_{ sy-datum }_{ sy-uzeit }|.
 
+      IF lines( lt_gentab ) = 1.
+        ii_log->add_info( |> Mass activating 1 DDIC object| ).
+      ELSE.
+        ii_log->add_info( |> Mass activating { lines( lt_gentab ) } DDIC objects| ).
+      ENDIF.
+      ii_log->add_info( |Log name: { lv_logname }| ).
+
       CALL FUNCTION 'DD_MASS_ACT_C3'
         EXPORTING
           ddmode         = 'O'         " activate changes in Original System
@@ -277,6 +284,15 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
       ENDIF.
 
       lv_no_ui = boolc( lv_popup = abap_false ).
+
+      IF iv_ddic = abap_true.
+        lv_msg = |(with DDIC)|.
+      ENDIF.
+      IF lines( gt_objects ) = 1.
+        ii_log->add_info( |> Activating 1 object { lv_msg }| ).
+      ELSE.
+        ii_log->add_info( |> Activating { lines( gt_objects ) } objects { lv_msg }| ).
+      ENDIF.
 
       TRY.
           CALL FUNCTION 'RS_WORKING_OBJECTS_ACTIVATE'
@@ -374,6 +390,8 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
       IF strlen( <ls_message>-object_text ) > 5.
         ls_item-obj_type = <ls_message>-object_text(4).
         ls_item-obj_name = <ls_message>-object_text+5(*).
+      ELSE.
+        ls_item-obj_name = <ls_message>-show_req->object_name.
       ENDIF.
       LOOP AT <ls_message>-mtext ASSIGNING <lv_msg>.
         ii_log->add_error(
@@ -420,6 +438,8 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
       ii_log->add( iv_msg  = <ls_line>-line
                    iv_type = <ls_line>-severity ).
     ENDLOOP.
+
+    ii_log->add_info( |View complete activation log in program RSPUTPRT (type D, log name { iv_logname })| ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -777,7 +777,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     zcl_abapgit_objects_activation=>clear( ).
 
-    ii_log->add_success( |Step { is_step-order } - { is_step-descr }| ).
+    ii_log->add_success( |>> Step { is_step-order } - { is_step-descr }| ).
 
     li_progress = zcl_abapgit_progress=>get_instance( lines( is_step-objects ) ).
 


### PR DESCRIPTION
- Show number of objects delete, deserialized, and activated
- Add message on how to view complete DDIC mass activation log
- Minor optimization to skip a phase if no object are processed

Ref #5974 

Example:

![image](https://user-images.githubusercontent.com/59966492/212366538-05ee55b2-5ffd-48bb-8560-c5a167d437bc.png)

![image](https://user-images.githubusercontent.com/59966492/212366654-47cd32fd-a6d0-4a90-866c-c78127302700.png)

![image](https://user-images.githubusercontent.com/59966492/212366733-e5c9b819-50b9-4568-8562-9603ae75989f.png)

![image](https://user-images.githubusercontent.com/59966492/212366811-1f50cb1b-e3fa-48c2-be15-c8514689326b.png)

![image](https://user-images.githubusercontent.com/59966492/212366934-bf5f02a3-df04-4dd8-883d-59799f979ff6.png)
