### PR TITLE
Debug Info: Display of Deserialization Step

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -322,7 +322,7 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
     rv_html = rv_html && |<table border="1px"><thead><tr>|.
     rv_html = rv_html && |<td>Object</td><td>Description</td><td>Class</td><td>Version</td>|.
-    rv_html = rv_html && |<td class="center">Delete TADIR</td><td>Steps</td>|.
+    rv_html = rv_html && |<td>Steps</td>|.
     rv_html = rv_html && |</tr></thead><tbody>|.
 
     LOOP AT lt_types INTO lv_type.
@@ -372,6 +372,18 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
       CLEAR lv_list.
       LOOP AT lt_steps INTO lv_step.
+        CASE lv_step.
+          WHEN zif_abapgit_object=>gc_step_id-early.
+            lv_step = |<i>{ lv_step } (1)</i>|.
+          WHEN zif_abapgit_object=>gc_step_id-ddic.
+            lv_step = |<strong>{ lv_step } (2)</strong>|.
+          WHEN zif_abapgit_object=>gc_step_id-abap.
+            lv_step = |{ lv_step } (3)|.
+          WHEN zif_abapgit_object=>gc_step_id-late.
+            lv_step = |<i>{ lv_step } (4)</i>|.
+          WHEN OTHERS.
+            ASSERT 1 = 2.
+        ENDCASE.
         IF lv_list IS INITIAL.
           lv_list = lv_step.
         ELSE.


### PR DESCRIPTION
Little improvements to make it easier to identify in which order objects are deserialized:

- Fix table header (ref #5949)
- Add step order number
- Format step names differently

![image](https://user-images.githubusercontent.com/59966492/212196152-2dc26d33-26a5-439d-960f-ada4de8d8a31.png)
