### PR TITLE
TABL,VIEW: Simplify deserialize

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -110,9 +110,6 @@ CLASS zcl_abapgit_object_tabl DEFINITION
         !iv_tabclass               TYPE dd02l-tabclass
       RETURNING
         VALUE(rv_is_db_table_type) TYPE dd02l-tabclass .
-    METHODS clear_foreign_keys
-      CHANGING
-        !ct_dd08v TYPE ty_dd08v_tt.
 ENDCLASS.
 
 
@@ -206,30 +203,6 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
            cs_dd03p-decimals,
            cs_dd03p-lowercase,
            cs_dd03p-signflag.
-
-  ENDMETHOD.
-
-
-  METHOD clear_foreign_keys.
-
-    DATA:
-      ls_item  TYPE zif_abapgit_definitions=>ty_item,
-      lv_index TYPE sy-tabix.
-
-    FIELD-SYMBOLS <ls_dd08v> TYPE dd08v.
-
-    " Remove foreign key definitions where the check table/view does not exist (yet)
-    LOOP AT ct_dd08v ASSIGNING <ls_dd08v>.
-      lv_index = sy-tabix.
-      ls_item-obj_name = <ls_dd08v>-checktable.
-      ls_item-obj_type = 'TABL'.
-      IF zcl_abapgit_objects=>exists( ls_item ) = abap_false.
-        ls_item-obj_type = 'VIEW'.
-        IF zcl_abapgit_objects=>exists( ls_item ) = abap_false.
-          DELETE ct_dd08v INDEX lv_index.
-        ENDIF.
-      ENDIF.
-    ENDLOOP.
 
   ENDMETHOD.
 
@@ -807,17 +780,6 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
         <ls_dd36m>-tabname = lv_name.
       ENDLOOP.
 
-      " DDIC Step: Remove references to search helps and foreign keys
-      IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
-        CLEAR: lt_dd35v, lt_dd36m.
-        clear_foreign_keys( CHANGING ct_dd08v = lt_dd08v ).
-      ENDIF.
-
-      IF iv_step = zif_abapgit_object=>gc_step_id-late
-        AND lines( lt_dd35v ) = 0 AND lines( lt_dd08v ) = 0.
-        RETURN. " already active
-      ENDIF.
-
       corr_insert( iv_package = iv_package
                    ig_object_class = 'DICT' ).
 
@@ -926,7 +888,6 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -59,8 +59,6 @@ CLASS zcl_abapgit_object_tabl DEFINITION
     TYPES:
       ty_dd03p_tt TYPE STANDARD TABLE OF dd03p .
     TYPES:
-      ty_dd08v_tt TYPE STANDARD TABLE OF dd08v.
-    TYPES:
       BEGIN OF ty_dd02_text,
         ddlanguage TYPE dd02t-ddlanguage,
         ddtext     TYPE dd02t-ddtext,

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -58,11 +58,64 @@ CLASS zcl_abapgit_object_view DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
           is_dd25v TYPE dd25v
         RAISING
           zcx_abapgit_exception.
+
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_object_view IMPLEMENTATION.
+
+
+  METHOD deserialize_texts.
+
+    DATA:
+      lv_name       TYPE ddobjname,
+      lt_i18n_langs TYPE TABLE OF langu,
+      lt_dd25_texts TYPE ty_dd25_texts,
+      ls_dd25v_tmp  TYPE dd25v.
+
+    FIELD-SYMBOLS:
+      <lv_lang>      TYPE langu,
+      <ls_dd25_text> LIKE LINE OF lt_dd25_texts.
+
+    lv_name = ms_item-obj_name.
+
+    io_xml->read( EXPORTING iv_name = 'I18N_LANGS'
+                  CHANGING  cg_data = lt_i18n_langs ).
+
+    io_xml->read( EXPORTING iv_name = 'DD25_TEXTS'
+                  CHANGING  cg_data = lt_dd25_texts ).
+
+    SORT lt_i18n_langs.
+    SORT lt_dd25_texts BY ddlanguage.
+
+    LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
+
+      " View description
+      ls_dd25v_tmp = is_dd25v.
+      READ TABLE lt_dd25_texts ASSIGNING <ls_dd25_text> WITH KEY ddlanguage = <lv_lang>.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |DD25_TEXTS cannot find lang { <lv_lang> } in XML| ).
+      ENDIF.
+      MOVE-CORRESPONDING <ls_dd25_text> TO ls_dd25v_tmp.
+      CALL FUNCTION 'DDIF_VIEW_PUT'
+        EXPORTING
+          name              = lv_name
+          dd25v_wa          = ls_dd25v_tmp
+        EXCEPTIONS
+          view_not_found    = 1
+          name_inconsistent = 2
+          view_inconsistent = 3
+          put_failure       = 4
+          put_refused       = 5
+          OTHERS            = 6.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
 
 
   METHOD read_view.
@@ -90,6 +143,70 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
         OTHERS        = 2.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD serialize_texts.
+
+    DATA:
+      lv_index           TYPE i,
+      ls_dd25v           TYPE dd25v,
+      lt_dd25_texts      TYPE ty_dd25_texts,
+      lt_i18n_langs      TYPE TABLE OF langu,
+      lt_language_filter TYPE zif_abapgit_environment=>ty_system_language_filter.
+
+    FIELD-SYMBOLS:
+      <lv_lang>      LIKE LINE OF lt_i18n_langs,
+      <ls_dd25_text> LIKE LINE OF lt_dd25_texts.
+
+    IF io_xml->i18n_params( )-main_language_only = abap_true.
+      RETURN.
+    ENDIF.
+
+    " Collect additional languages, skip main lang - it was serialized already
+    lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+    SELECT DISTINCT ddlanguage AS langu INTO TABLE lt_i18n_langs
+      FROM dd25v
+      WHERE viewname = ms_item-obj_name
+      AND ddlanguage IN lt_language_filter
+      AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
+
+    LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
+      lv_index = sy-tabix.
+      CLEAR: ls_dd25v.
+
+      TRY.
+          read_view(
+            EXPORTING
+              iv_language = <lv_lang>
+            IMPORTING
+              es_dd25v    = ls_dd25v ).
+
+        CATCH zcx_abapgit_exception.
+          CONTINUE.
+      ENDTRY.
+
+      IF ls_dd25v-ddlanguage IS INITIAL.
+        DELETE lt_i18n_langs INDEX lv_index. " Don't save this lang
+        CONTINUE.
+      ENDIF.
+
+      APPEND INITIAL LINE TO lt_dd25_texts ASSIGNING <ls_dd25_text>.
+      MOVE-CORRESPONDING ls_dd25v TO <ls_dd25_text>.
+
+    ENDLOOP.
+
+    SORT lt_i18n_langs ASCENDING.
+    SORT lt_dd25_texts BY ddlanguage ASCENDING.
+
+    IF lines( lt_i18n_langs ) > 0.
+      io_xml->add( iv_name = 'I18N_LANGS'
+                   ig_data = lt_i18n_langs ).
+
+      io_xml->add( iv_name = 'DD25_TEXTS'
+                   ig_data = lt_dd25_texts ).
     ENDIF.
 
   ENDMETHOD.
@@ -144,19 +261,12 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD28V_TABLE'
                   CHANGING cg_data = lt_dd28v ).
 
-    " Process maintenance views during LATE to avoid issues with missing foreign key relationships (#4306)
-    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd25v-viewclass = 'C'.
-      RETURN.
-    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd25v-viewclass <> 'C'.
-      RETURN.
-    ENDIF.
-
     lv_name = ms_item-obj_name. " type conversion
 
     LOOP AT lt_dd27p ASSIGNING <ls_dd27p>.
       <ls_dd27p>-objpos = sy-tabix.
       <ls_dd27p>-viewname = lv_name.
-* rollname seems to be mandatory in the API, but is typically not defined in the VIEW
+      " rollname seems to be mandatory in the API, but is typically not defined in the VIEW
       SELECT SINGLE rollname FROM dd03l INTO <ls_dd27p>-rollname
         WHERE tabname = <ls_dd27p>-tabname
         AND fieldname = <ls_dd27p>-fieldname.
@@ -234,7 +344,6 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 
@@ -344,121 +453,4 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
                          iv_longtext_id = c_longtext_id_view ).
 
   ENDMETHOD.
-
-
-  METHOD serialize_texts.
-
-    DATA:
-      lv_index           TYPE i,
-      ls_dd25v           TYPE dd25v,
-      lt_dd25_texts      TYPE ty_dd25_texts,
-      lt_i18n_langs      TYPE TABLE OF langu,
-      lt_language_filter TYPE zif_abapgit_environment=>ty_system_language_filter.
-
-    FIELD-SYMBOLS:
-      <lv_lang>      LIKE LINE OF lt_i18n_langs,
-      <ls_dd25_text> LIKE LINE OF lt_dd25_texts.
-
-    IF io_xml->i18n_params( )-main_language_only = abap_true.
-      RETURN.
-    ENDIF.
-
-    " Collect additional languages, skip main lang - it was serialized already
-    lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
-    SELECT DISTINCT ddlanguage AS langu INTO TABLE lt_i18n_langs
-      FROM dd25v
-      WHERE viewname = ms_item-obj_name
-      AND ddlanguage IN lt_language_filter
-      AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
-
-    LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
-      lv_index = sy-tabix.
-      CLEAR: ls_dd25v.
-
-      TRY.
-          read_view(
-            EXPORTING
-              iv_language = <lv_lang>
-            IMPORTING
-              es_dd25v    = ls_dd25v ).
-
-        CATCH zcx_abapgit_exception.
-          CONTINUE.
-      ENDTRY.
-
-      IF ls_dd25v-ddlanguage IS INITIAL.
-        DELETE lt_i18n_langs INDEX lv_index. " Don't save this lang
-        CONTINUE.
-      ENDIF.
-
-      APPEND INITIAL LINE TO lt_dd25_texts ASSIGNING <ls_dd25_text>.
-      MOVE-CORRESPONDING ls_dd25v TO <ls_dd25_text>.
-
-    ENDLOOP.
-
-    SORT lt_i18n_langs ASCENDING.
-    SORT lt_dd25_texts BY ddlanguage ASCENDING.
-
-    IF lines( lt_i18n_langs ) > 0.
-      io_xml->add( iv_name = 'I18N_LANGS'
-                   ig_data = lt_i18n_langs ).
-
-      io_xml->add( iv_name = 'DD25_TEXTS'
-                   ig_data = lt_dd25_texts ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD deserialize_texts.
-
-    DATA:
-      lv_name       TYPE ddobjname,
-      lt_i18n_langs TYPE TABLE OF langu,
-      lt_dd25_texts TYPE ty_dd25_texts,
-      ls_dd25v_tmp  TYPE dd25v.
-
-    FIELD-SYMBOLS:
-      <lv_lang>      TYPE langu,
-      <ls_dd25_text> LIKE LINE OF lt_dd25_texts.
-
-    lv_name = ms_item-obj_name.
-
-    io_xml->read( EXPORTING iv_name = 'I18N_LANGS'
-                  CHANGING  cg_data = lt_i18n_langs ).
-
-    io_xml->read( EXPORTING iv_name = 'DD25_TEXTS'
-                  CHANGING  cg_data = lt_dd25_texts ).
-
-    SORT lt_i18n_langs.
-    SORT lt_dd25_texts BY ddlanguage.
-
-    LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
-
-      " View description
-      ls_dd25v_tmp = is_dd25v.
-      READ TABLE lt_dd25_texts ASSIGNING <ls_dd25_text> WITH KEY ddlanguage = <lv_lang>.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |DD25_TEXTS cannot find lang { <lv_lang> } in XML| ).
-      ENDIF.
-      MOVE-CORRESPONDING <ls_dd25_text> TO ls_dd25v_tmp.
-      CALL FUNCTION 'DDIF_VIEW_PUT'
-        EXPORTING
-          name              = lv_name
-          dd25v_wa          = ls_dd25v_tmp
-        EXCEPTIONS
-          view_not_found    = 1
-          name_inconsistent = 2
-          view_inconsistent = 3
-          put_failure       = 4
-          put_refused       = 5
-          OTHERS            = 6.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise_t100( ).
-      ENDIF.
-
-    ENDLOOP.
-
-  ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
Over the years, various workarounds have been implemented to handle dependencies used in tables and views like foreign keys, references to classes or interfaces, or search helps. This led to a two-phase deserialize (`DDIC` and `LATE`). Nevertheless, some test scenarios were still failing (for example, [function group with maintenance views](https://github.com/abapGit-tests/FUGR_maint_view_var)). 

I created a new test repo covering all these "DDIC dependency scenarios". It also covers dependencies between ABAP and DDIC. See [repo and its readme](https://github.com/abapGit-tests/TABL_ddic_integration).

![image](https://user-images.githubusercontent.com/59966492/212199985-f8776eed-152d-4239-b6dc-2dc46cd51396.png)

After https://github.com/abapGit/abapGit/pull/3545, OO references are not a problem anymore and don't require two phases. It turns out that we don't need any of the work arounds and a single DDIC phase is sufficient to deserialize tables and views. 

The test repo can be deserialized and uninstalled without problems. I will run a complete CI test but am confident that all will work well.

Closes #5451 (too)