### PR TITLE
Repo View: Activate objects

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -271,6 +271,9 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     CREATE OBJECT ro_advanced_dropdown.
 
+    ro_advanced_dropdown->add( iv_txt = 'Activate Objects'
+                               iv_act = |{ zif_abapgit_definitions=>c_action-repo_activate_objects }?key={ mv_key }| ).
+
     IF mo_repo->is_offline( ) = abap_false. " Online ?
       ro_advanced_dropdown->add(
         iv_txt = 'Transport to Branch'

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -617,6 +617,9 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         zcl_abapgit_services_repo=>remove( lv_key ).
         CREATE OBJECT rs_handled-page TYPE zcl_abapgit_gui_page_main EXPORTING iv_only_favorites = abap_true.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page_replacing.
+      WHEN zif_abapgit_definitions=>c_action-repo_activate_objects.           " Repo activate objects
+        zcl_abapgit_services_repo=>activate_objects( lv_key ).
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-repo_newonline.                  " New offline repo
         rs_handled-page  = zcl_abapgit_gui_page_addonline=>create( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -446,6 +446,7 @@ INTERFACE zif_abapgit_definitions
       repo_background               TYPE string VALUE 'repo_background',
       repo_infos                    TYPE string VALUE 'repo_infos',
       repo_purge                    TYPE string VALUE 'repo_purge',
+      repo_activate_objects         TYPE string VALUE 'activate_objects',
       repo_newonline                TYPE string VALUE 'repo_newonline',
       repo_newoffline               TYPE string VALUE 'repo_newoffline',
       repo_add_all_obj_to_trans_req TYPE string VALUE 'repo_add_all_obj_to_trans_req',


### PR DESCRIPTION
Add menu item "Activate Objects" which selects all inactive objects from the repo and attempts to activate them.

![image](https://user-images.githubusercontent.com/59966492/212672919-2db2c5fe-c6bc-42cf-9e44-4cce6a1ea24e.png)

This is helpful, for example, is situations like this:

![image](https://user-images.githubusercontent.com/59966492/212670615-559627a5-bc86-469d-b064-5a6d3c0afbc4.png)

