### PR TITLE
Fix CI test runs triggered from unit tests

### DIFF
--- a/src/test/zcl_abapgit_objects_ci_tests.clas.abap
+++ b/src/test/zcl_abapgit_objects_ci_tests.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_CI_TESTS IMPLEMENTATION.
+CLASS zcl_abapgit_objects_ci_tests IMPLEMENTATION.
 
 
   METHOD run.
@@ -79,6 +79,10 @@ CLASS ZCL_ABAPGIT_OBJECTS_CI_TESTS IMPLEMENTATION.
         " Prepare input for CI repo test
         CREATE DATA ld_options TYPE ('ZIF_ABAPGIT_CI_DEFINITIONS=>TY_REPO_CHECK_OPTIONS').
         ASSIGN ld_options->* TO <ls_options>.
+
+        ASSIGN COMPONENT 'CREATE_PACKAGE' OF STRUCTURE <ls_options> TO <lv_option>.
+        ASSERT sy-subrc = 0.
+        <lv_option> = abap_true.
 
         ASSIGN COMPONENT 'CHECK_LOCAL' OF STRUCTURE <ls_options> TO <lv_option>.
         ASSERT sy-subrc = 0.


### PR DESCRIPTION
Fixes unit tests calling a CI test run (implemented for `TABL`). 

https://github.com/abapGit/CI/pull/144 made creating packages options in CI. abapGit integration now turns on this option properly.

![image](https://user-images.githubusercontent.com/59966492/212691013-7a7dbd24-9175-4fbc-ab57-b1aadb6c3c0e.png)
