### PR TITLE
SHLP: Avoid double activation

### DIFF
--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -31,7 +31,7 @@ CLASS zcl_abapgit_object_shlp IMPLEMENTATION.
 
   METHOD adjust_exit.
 
-    CONSTANTS lc_standard_exit TYPE dd30v-selmexit VALUE 'RS_DD_SELMEXIT' ##NO_TEXT.
+    CONSTANTS lc_standard_exit TYPE dd30v-selmexit VALUE 'RS_DD_SELMEXIT'.
 
     IF cv_exit IS NOT INITIAL.
       " If exit function does not exist, replace it with standard SAP function


### PR DESCRIPTION
Refactor handling of dependencies on exit function (using same methods as `DOMA` #5998). This avoids activating the search help twice if the exit function already exists.

Recap of two-phase approach:

1. DDIC phase:
    If function does not exit, replace it with a standard SAP function
2. LATE phase:
    If function was replaced, change it to the correct exit function

Existing test repo: https://github.com/abapGit-tests/SHLP_with_exit