### PR TITLE
delete, fix dump

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -477,10 +477,12 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     lt_tadir = it_tadir.
 
-    IF lines( lt_tadir ) = 1.
-      ii_log->add_info( |>>> Deleting 1 object| ).
-    ELSE.
-      ii_log->add_info( |>>> Deleting { lines( lt_tadir ) } objects| ).
+    IF ii_log IS BOUND.
+      IF lines( lt_tadir ) = 1.
+        ii_log->add_info( |>>> Deleting 1 object| ).
+      ELSE.
+        ii_log->add_info( |>>> Deleting { lines( lt_tadir ) } objects| ).
+      ENDIF.
     ENDIF.
 
     IF is_checks-transport-required = abap_true.
@@ -526,8 +528,10 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
             " make sure to save object deletions
             COMMIT WORK.
 
-            ii_log->add_info( iv_msg  = |Object { ls_item-obj_type } { ls_item-obj_name } deleted|
-                              is_item = ls_item ).
+            IF ii_log IS BOUND.
+              ii_log->add_info( iv_msg  = |Object { ls_item-obj_type } { ls_item-obj_name } deleted|
+                                is_item = ls_item ).
+            ENDIF.
 
           CATCH zcx_abapgit_exception INTO lx_error.
             IF ii_log IS BOUND.


### PR DESCRIPTION
dont use `ii_log` if it is not supplied/bound in object `delete()`