### PR TITLE
CLAS: Fix recording of changes in transport

### DIFF
--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -779,6 +779,8 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
         deserialize_pre_ddic(
           ii_xml     = io_xml
           iv_package = iv_package ).
+      ELSE.
+        corr_insert( iv_package ).
       ENDIF.
 
     ENDIF.

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -545,6 +545,8 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
         deserialize_pre_ddic(
           ii_xml     = io_xml
           iv_package = iv_package ).
+      ELSE.
+        corr_insert( iv_package ).
       ENDIF.
 
     ENDIF.


### PR DESCRIPTION
If the class or interface already existed, changes to parts of the class (like methods) were not recorded properly in transports. The fix makes sure that the class is added to the transport (as `R3TR CLAS`).

Closes #6004

PS: Same logic for interfaces (although they currently don't have subparts).

PPS: Issue was side effect of https://github.com/abapGit/abapGit/pull/5393