### PR TITLE
Refactor: Order exit methods

### DIFF
--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -1,14 +1,13 @@
 INTERFACE zif_abapgit_exit
-  PUBLIC .
-
+  PUBLIC.
 
   TYPES:
     BEGIN OF ty_ci_repo,
       name      TYPE string,
       clone_url TYPE string,
-    END OF ty_ci_repo .
+    END OF ty_ci_repo.
   TYPES:
-    ty_ci_repos TYPE TABLE OF ty_ci_repo .
+    ty_ci_repos TYPE TABLE OF ty_ci_repo.
 
   METHODS adjust_display_commit_url
     IMPORTING
@@ -19,41 +18,55 @@ INTERFACE zif_abapgit_exit
     CHANGING
       !cv_display_url TYPE csequence
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
+
+  METHODS adjust_display_filename
+    IMPORTING
+      iv_filename        TYPE string
+    RETURNING
+      VALUE(rv_filename) TYPE string.
+
   METHODS allow_sap_objects
     RETURNING
-      VALUE(rv_allowed) TYPE abap_bool .
+      VALUE(rv_allowed) TYPE abap_bool.
+
   METHODS change_local_host
     CHANGING
-      !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt .
+      !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt.
+
   METHODS change_proxy_authentication
     IMPORTING
       !iv_repo_url             TYPE csequence
     CHANGING
-      !cv_proxy_authentication TYPE abap_bool .
+      !cv_proxy_authentication TYPE abap_bool.
+
   METHODS change_proxy_port
     IMPORTING
       !iv_repo_url   TYPE csequence
     CHANGING
-      !cv_proxy_port TYPE string .
+      !cv_proxy_port TYPE string.
+
   METHODS change_proxy_url
     IMPORTING
       !iv_repo_url  TYPE csequence
     CHANGING
-      !cv_proxy_url TYPE string .
+      !cv_proxy_url TYPE string.
+
   METHODS change_tadir
     IMPORTING
       !iv_package TYPE devclass
       !ii_log     TYPE REF TO zif_abapgit_log
     CHANGING
-      !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt .
+      !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt.
+
   METHODS create_http_client
     IMPORTING
       !iv_url          TYPE string
     RETURNING
       VALUE(ri_client) TYPE REF TO if_http_client
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
+
   METHODS custom_serialize_abap_clif
     IMPORTING
       !is_class_key    TYPE seoclskey
@@ -61,56 +74,13 @@ INTERFACE zif_abapgit_exit
     RETURNING
       VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
+
   METHODS deserialize_postprocess
     IMPORTING
       !is_step TYPE zif_abapgit_objects=>ty_step_data
-      !ii_log  TYPE REF TO zif_abapgit_log .
-  METHODS get_ci_tests
-    IMPORTING
-      !iv_object   TYPE tadir-object
-    CHANGING
-      !ct_ci_repos TYPE ty_ci_repos .
-  METHODS get_ssl_id
-    RETURNING
-      VALUE(rv_ssl_id) TYPE ssfapplssl .
-  METHODS http_client
-    IMPORTING
-      !iv_url    TYPE string
-      !ii_client TYPE REF TO if_http_client .
-  METHODS pre_calculate_repo_status
-    IMPORTING
-      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-    CHANGING
-      !ct_local     TYPE zif_abapgit_definitions=>ty_files_item_tt
-      !ct_remote    TYPE zif_abapgit_git_definitions=>ty_files_tt
-    RAISING
-      zcx_abapgit_exception .
-  METHODS wall_message_list
-    IMPORTING
-      !ii_html TYPE REF TO zif_abapgit_html .
-  METHODS wall_message_repo
-    IMPORTING
-      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-      !ii_html      TYPE REF TO zif_abapgit_html .
-  METHODS on_event
-    IMPORTING
-      !ii_event         TYPE REF TO zif_abapgit_gui_event
-    RETURNING
-      VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
-    RAISING
-      zcx_abapgit_exception .
-  METHODS serialize_postprocess
-    IMPORTING
-      !iv_package TYPE devclass
-      !ii_log     TYPE REF TO zif_abapgit_log
-    CHANGING
-      !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt.
-  METHODS adjust_display_filename
-    IMPORTING
-      iv_filename        TYPE string
-    RETURNING
-      VALUE(rv_filename) TYPE string.
+      !ii_log  TYPE REF TO zif_abapgit_log.
+
   METHODS determine_transport_request
     IMPORTING
       io_repo              TYPE REF TO zcl_abapgit_repo
@@ -118,12 +88,60 @@ INTERFACE zif_abapgit_exit
     CHANGING
       cv_transport_request TYPE trkorr.
 
+  METHODS get_ci_tests
+    IMPORTING
+      !iv_object   TYPE tadir-object
+    CHANGING
+      !ct_ci_repos TYPE ty_ci_repos.
+
+  METHODS get_ssl_id
+    RETURNING
+      VALUE(rv_ssl_id) TYPE ssfapplssl.
+
+  METHODS http_client
+    IMPORTING
+      !iv_url    TYPE string
+      !ii_client TYPE REF TO if_http_client.
+
+  METHODS on_event
+    IMPORTING
+      !ii_event         TYPE REF TO zif_abapgit_gui_event
+    RETURNING
+      VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS pre_calculate_repo_status
+    IMPORTING
+      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+    CHANGING
+      !ct_local     TYPE zif_abapgit_definitions=>ty_files_item_tt
+      !ct_remote    TYPE zif_abapgit_git_definitions=>ty_files_tt
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS serialize_postprocess
+    IMPORTING
+      !iv_package TYPE devclass
+      !ii_log     TYPE REF TO zif_abapgit_log
+    CHANGING
+      !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt.
+
   METHODS validate_before_push
     IMPORTING
-      !is_comment     TYPE zif_abapgit_git_definitions=>ty_comment
-      !io_stage       TYPE REF TO zcl_abapgit_stage
-      !io_repo        TYPE REF TO zcl_abapgit_repo_online
+      !is_comment TYPE zif_abapgit_git_definitions=>ty_comment
+      !io_stage   TYPE REF TO zcl_abapgit_stage
+      !io_repo    TYPE REF TO zcl_abapgit_repo_online
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
+
+  METHODS wall_message_list
+    IMPORTING
+      !ii_html TYPE REF TO zif_abapgit_html.
+
+  METHODS wall_message_repo
+    IMPORTING
+      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+      !ii_html      TYPE REF TO zif_abapgit_html.
 
 ENDINTERFACE.


### PR DESCRIPTION
Sorted methods alphabetically making them easier to find.

Updated docs to match order (https://github.com/abapGit/docs.abapgit.org/pull/102)