### PR TITLE
TABL: Fix activation of secondary indexes

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -350,8 +350,6 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
     LOOP AT lt_dd12v INTO ls_dd12v.
 
-* todo, call corr_insert?
-
       CLEAR lt_secondary.
       LOOP AT lt_dd17v INTO ls_dd17v
           WHERE sqltab = ls_dd12v-sqltab AND indexname = ls_dd12v-indexname.
@@ -384,8 +382,8 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
         IMPORTING
           obj_name = lv_tname.
 
-      zcl_abapgit_objects_activation=>add( iv_type = 'INDX'
-                                           iv_name = lv_tname ).
+      " Secondary indexes are automatically activated as part of R3TR TABL
+      " So there's no need to add them to activation queue
 
     ENDLOOP.
 


### PR DESCRIPTION
In certain cases, tables with include structures that have a secondary index on a field of the include could not be activated by abapGit. 

Complex case: https://github.com/stockbal/abap-db-browser/issues/22

Simplified test repo: https://github.com/abapGit-tests/TABL_struct_with_INDX

The issue was caused by adding the secondary index to the activation queue. This is not necessary since `R3TR TABL` will activate the complete table including any indexes.