### PR TITLE
Escape output for plain text highlighter

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_txt.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_txt.clas.abap
@@ -29,7 +29,9 @@ CLASS zcl_abapgit_syntax_txt IMPLEMENTATION.
 
   METHOD process_line.
 
-    rv_line = show_hidden_chars( iv_line ).
+    rv_line = apply_style(
+      iv_line  = iv_line
+      iv_class = '' ).
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
`apply_style` escapes data and calls `show_hidden_chars`