### PR TITLE
Fix highlighting in case of back quotes

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_css.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_css.clas.abap
@@ -53,7 +53,7 @@ CLASS zcl_abapgit_syntax_css DEFINITION
         " comments /* ... */
         comment   TYPE string VALUE '\/\*.*\*\/|\/\*|\*\/', "#EC NOTEXT
         " single or double quoted strings
-        text      TYPE string VALUE '("[^"]*")|(''[^'']*'')', "#EC NOTEXT
+        text      TYPE string VALUE '("[^"]*")|(''[^'']*'')|(`[^`]*`)', "#EC NOTEXT
         " in general keywords don't contain numbers (except -ms-scrollbar-3dlight-color)
         keyword   TYPE string VALUE '\b[a-z3@\-]+\b',       "#EC NOTEXT
         " selectors begin with :

--- a/src/syntax/zcl_abapgit_syntax_css.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_css.clas.abap
@@ -20,47 +20,47 @@ CLASS zcl_abapgit_syntax_css DEFINITION
 
     CONSTANTS:
       BEGIN OF c_css,
-        keyword    TYPE string VALUE 'keyword',             "#EC NOTEXT
-        text       TYPE string VALUE 'text',                "#EC NOTEXT
-        comment    TYPE string VALUE 'comment',             "#EC NOTEXT
-        selectors  TYPE string VALUE 'selectors',           "#EC NOTEXT
-        units      TYPE string VALUE 'units',               "#EC NOTEXT
-        properties TYPE string VALUE 'properties',          "#EC NOTEXT
-        values     TYPE string VALUE 'values',              "#EC NOTEXT
-        functions  TYPE string VALUE 'functions',           "#EC NOTEXT
-        colors     TYPE string VALUE 'colors',              "#EC NOTEXT
-        extensions TYPE string VALUE 'extensions',          "#EC NOTEXT
-        at_rules   TYPE string VALUE 'at_rules',            "#EC NOTEXT
-        html       TYPE string VALUE 'html',                "#EC NOTEXT
+        keyword    TYPE string VALUE 'keyword',
+        text       TYPE string VALUE 'text',
+        comment    TYPE string VALUE 'comment',
+        selectors  TYPE string VALUE 'selectors',
+        units      TYPE string VALUE 'units',
+        properties TYPE string VALUE 'properties',
+        values     TYPE string VALUE 'values',
+        functions  TYPE string VALUE 'functions',
+        colors     TYPE string VALUE 'colors',
+        extensions TYPE string VALUE 'extensions',
+        at_rules   TYPE string VALUE 'at_rules',
+        html       TYPE string VALUE 'html',
       END OF c_css .
     CONSTANTS:
       BEGIN OF c_token,
-        keyword    TYPE c VALUE 'K',                        "#EC NOTEXT
-        text       TYPE c VALUE 'T',                        "#EC NOTEXT
-        comment    TYPE c VALUE 'C',                        "#EC NOTEXT
-        selectors  TYPE c VALUE 'S',                        "#EC NOTEXT
-        units      TYPE c VALUE 'U',                        "#EC NOTEXT
-        properties TYPE c VALUE 'P',                        "#EC NOTEXT
-        values     TYPE c VALUE 'V',                        "#EC NOTEXT
-        functions  TYPE c VALUE 'F',                        "#EC NOTEXT
-        colors     TYPE c VALUE 'Z',                        "#EC NOTEXT
-        extensions TYPE c VALUE 'E',                        "#EC NOTEXT
-        at_rules   TYPE c VALUE 'A',                        "#EC NOTEXT
-        html       TYPE c VALUE 'H',                        "#EC NOTEXT
+        keyword    TYPE c VALUE 'K',
+        text       TYPE c VALUE 'T',
+        comment    TYPE c VALUE 'C',
+        selectors  TYPE c VALUE 'S',
+        units      TYPE c VALUE 'U',
+        properties TYPE c VALUE 'P',
+        values     TYPE c VALUE 'V',
+        functions  TYPE c VALUE 'F',
+        colors     TYPE c VALUE 'Z',
+        extensions TYPE c VALUE 'E',
+        at_rules   TYPE c VALUE 'A',
+        html       TYPE c VALUE 'H',
       END OF c_token .
     CONSTANTS:
       BEGIN OF c_regex,
         " comments /* ... */
-        comment   TYPE string VALUE '\/\*.*\*\/|\/\*|\*\/', "#EC NOTEXT
+        comment   TYPE string VALUE '\/\*.*\*\/|\/\*|\*\/',
         " single or double quoted strings
-        text      TYPE string VALUE '("[^"]*")|(''[^'']*'')|(`[^`]*`)', "#EC NOTEXT
+        text      TYPE string VALUE '("[^"]*")|(''[^'']*'')|(`[^`]*`)',
         " in general keywords don't contain numbers (except -ms-scrollbar-3dlight-color)
-        keyword   TYPE string VALUE '\b[a-z3@\-]+\b',       "#EC NOTEXT
+        keyword   TYPE string VALUE '\b[a-z3@\-]+\b',
         " selectors begin with :
-        selectors TYPE string VALUE ':[:a-z]+\b',           "#EC NOTEXT
+        selectors TYPE string VALUE ':[:a-z]+\b',
         " units
         units     TYPE string
-        VALUE '\b[0-9\. ]+(ch|cm|em|ex|in|mm|pc|pt|px|vh|vmax|vmin|vw)\b|\b[0-9\. ]+%', "#EC NOTEXT
+        VALUE '\b[0-9\. ]+(ch|cm|em|ex|in|mm|pc|pt|px|vh|vmax|vmin|vw)\b|\b[0-9\. ]+%',
       END OF c_regex .
 
     CLASS-METHODS class_constructor .

--- a/src/syntax/zcl_abapgit_syntax_js.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_js.clas.abap
@@ -28,7 +28,7 @@ CLASS zcl_abapgit_syntax_js DEFINITION
         " comments /* ... */ or //
         comment TYPE string VALUE '\/\*.*\*\/|\/\*|\*\/|\/\/', "#EC NOTEXT
         " single or double quoted strings
-        text    TYPE string VALUE '"|''',                   "#EC NOTEXT
+        text    TYPE string VALUE '"|''|`',                   "#EC NOTEXT
         " in general keywords don't contain numbers (except -ms-scrollbar-3dlight-color)
         keyword TYPE string VALUE '\b[a-z-]+\b',            "#EC NOTEXT
       END OF c_regex .

--- a/src/syntax/zcl_abapgit_syntax_js.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_js.clas.abap
@@ -11,26 +11,26 @@ CLASS zcl_abapgit_syntax_js DEFINITION
       " 2) Variable types
       " 3) HTML Tags
       BEGIN OF c_css,
-        keyword   TYPE string VALUE 'keyword',              "#EC NOTEXT
-        text      TYPE string VALUE 'text',                 "#EC NOTEXT
-        comment   TYPE string VALUE 'comment',              "#EC NOTEXT
-        variables TYPE string VALUE 'variables',            "#EC NOTEXT
+        keyword   TYPE string VALUE 'keyword',
+        text      TYPE string VALUE 'text',
+        comment   TYPE string VALUE 'comment',
+        variables TYPE string VALUE 'variables',
       END OF c_css .
     CONSTANTS:
       BEGIN OF c_token,
-        keyword   TYPE c VALUE 'K',                         "#EC NOTEXT
-        text      TYPE c VALUE 'T',                         "#EC NOTEXT
-        comment   TYPE c VALUE 'C',                         "#EC NOTEXT
-        variables TYPE c VALUE 'V',                         "#EC NOTEXT
+        keyword   TYPE c VALUE 'K',
+        text      TYPE c VALUE 'T',
+        comment   TYPE c VALUE 'C',
+        variables TYPE c VALUE 'V',
       END OF c_token .
     CONSTANTS:
       BEGIN OF c_regex,
         " comments /* ... */ or //
-        comment TYPE string VALUE '\/\*.*\*\/|\/\*|\*\/|\/\/', "#EC NOTEXT
+        comment TYPE string VALUE '\/\*.*\*\/|\/\*|\*\/|\/\/',
         " single or double quoted strings
-        text    TYPE string VALUE '"|''|`',                   "#EC NOTEXT
+        text    TYPE string VALUE '"|''|`',
         " in general keywords don't contain numbers (except -ms-scrollbar-3dlight-color)
-        keyword TYPE string VALUE '\b[a-z-]+\b',            "#EC NOTEXT
+        keyword TYPE string VALUE '\b[a-z-]+\b',
       END OF c_regex .
 
     CLASS-METHODS class_constructor .

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.abap
@@ -7,27 +7,27 @@ CLASS zcl_abapgit_syntax_xml DEFINITION
 
     CONSTANTS:
       BEGIN OF c_css,
-        xml_tag  TYPE string VALUE 'xml_tag',               "#EC NOTEXT
-        attr     TYPE string VALUE 'attr',                  "#EC NOTEXT
-        attr_val TYPE string VALUE 'attr_val',              "#EC NOTEXT
-        comment  TYPE string VALUE 'comment',               "#EC NOTEXT
+        xml_tag  TYPE string VALUE 'xml_tag',
+        attr     TYPE string VALUE 'attr',
+        attr_val TYPE string VALUE 'attr_val',
+        comment  TYPE string VALUE 'comment',
       END OF c_css .
     CONSTANTS:
       BEGIN OF c_token,
-        xml_tag  TYPE c VALUE 'X',                          "#EC NOTEXT
-        attr     TYPE c VALUE 'A',                          "#EC NOTEXT
-        attr_val TYPE c VALUE 'V',                          "#EC NOTEXT
-        comment  TYPE c VALUE 'C',                          "#EC NOTEXT
+        xml_tag  TYPE c VALUE 'X',
+        attr     TYPE c VALUE 'A',
+        attr_val TYPE c VALUE 'V',
+        comment  TYPE c VALUE 'C',
       END OF c_token .
     CONSTANTS:
       BEGIN OF c_regex,
         "for XML tags, we will use a submatch
         " main pattern includes quoted strings so we can ignore < and > in attr values
-        xml_tag  TYPE string VALUE '(?:"[^"]*")|(?:''[^'']*'')|([<>])', "#EC NOTEXT
-        attr     TYPE string VALUE '(?:^|\s)[-a-z:_0-9]+\s*(?==\s*["|''])', "#EC NOTEXT
-        attr_val TYPE string VALUE '("[^"]*")|(''[^'']*'')', "#EC NOTEXT
+        xml_tag  TYPE string VALUE '(?:"[^"]*")|(?:''[^'']*'')|(?:`[^`]*`)|([<>])',
+        attr     TYPE string VALUE '(?:^|\s)[-a-z:_0-9]+\s*(?==\s*["|''|`])',
+        attr_val TYPE string VALUE '("[^"]*")|(''[^'']*'')|(`[^`]*`)',
         " comments <!-- ... -->
-        comment  TYPE string VALUE '[\<]!--.*--[\>]|[\<]!--|--[\>]', "#EC NOTEXT
+        comment  TYPE string VALUE '[\<]!--.*--[\>]|[\<]!--|--[\>]',
       END OF c_regex .
 
     METHODS constructor .

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
@@ -160,14 +160,15 @@ CLASS ltcl_syntax_cases DEFINITION FINAL FOR TESTING RISK LEVEL HARMLESS
                                 iv_offset   TYPE i
                                 iv_length   TYPE i
                                 iv_text_tag TYPE string,
-      test_xml_01  FOR TESTING,
-      test_xml_02  FOR TESTING,
-      test_xml_03  FOR TESTING,
-      test_xml_04  FOR TESTING,
-      test_xml_05  FOR TESTING,
-      test_xml_06  FOR TESTING,
-      test_xml_07  FOR TESTING,
-      test_xml_08  FOR TESTING.
+      test_xml_01 FOR TESTING,
+      test_xml_02 FOR TESTING,
+      test_xml_03 FOR TESTING,
+      test_xml_04 FOR TESTING,
+      test_xml_05 FOR TESTING,
+      test_xml_06 FOR TESTING,
+      test_xml_07 FOR TESTING,
+      test_xml_08 FOR TESTING,
+      test_xml_09 FOR TESTING.
 
 ENDCLASS.
 *----------------------------------------------------------------------*
@@ -689,7 +690,6 @@ CLASS ltcl_syntax_cases IMPLEMENTATION.
 
   ENDMETHOD.
 
-
   METHOD test_xml_08.
     "invalid XML characters in a string
     DATA lv_line TYPE string.
@@ -728,6 +728,70 @@ CLASS ltcl_syntax_cases IMPLEMENTATION.
                      iv_offset   = 10
                      iv_length   = 5
                      iv_text_tag = '' ).
+
+    do_test( lv_line ).
+
+  ENDMETHOD.
+
+  METHOD test_xml_09.
+    "back quotes used for attribute values (HTML)
+    DATA lv_line TYPE string.
+
+    lv_line = '<tag attribute=`value`/>'.
+
+    " Generate table with expected values after parsing
+    generate_parse( iv_token  = 'X'
+                    iv_offset = 0
+                    iv_length = 1 ).
+    generate_parse( iv_token  = 'A'
+                    iv_offset = 4
+                    iv_length = 10 ).
+    generate_parse( iv_token  = 'V'
+                    iv_offset = 15
+                    iv_length = 7 ).
+    generate_parse( iv_token  = 'X'
+                    iv_offset = 23
+                    iv_length = 1 ).
+
+    " Generate table with expected values after ordering
+    generate_order( iv_token    = 'X'
+                    iv_offset   = 0
+                    iv_length   = 4
+                    iv_text_tag = '<' ).
+    generate_order( iv_token    = 'A'
+                    iv_offset   = 4
+                    iv_length   = 10
+                    iv_text_tag = '' ).
+    generate_order( iv_token    = 'V'
+                    iv_offset   = 15
+                    iv_length   = 7
+                    iv_text_tag = '' ).
+    generate_order( iv_token    = 'X'
+                    iv_offset   = 22
+                    iv_length   = 2
+                    iv_text_tag = '>' ).
+
+    " Generate table with expected values after extending
+    generate_extend( iv_token    = 'X'
+                     iv_offset   = 0
+                     iv_length   = 4
+                     iv_text_tag = '<' ).
+    generate_extend( iv_token    = 'A'
+                     iv_offset   = 4
+                     iv_length   = 10
+                     iv_text_tag = '' ).
+    generate_extend( iv_token    = '.'
+                     iv_offset   = 14
+                     iv_length   = 1
+                     iv_text_tag = '' ).
+    generate_extend( iv_token    = 'V'
+                     iv_offset   = 15
+                     iv_length   = 7
+                     iv_text_tag = '' ).
+    generate_extend( iv_token    = 'X'
+                     iv_offset   = 22
+                     iv_length   = 2
+                     iv_text_tag = '>' ).
 
     do_test( lv_line ).
 


### PR DESCRIPTION
HTML, XML, or JS files might contain values in back quotes (although this is not syntactically correct for HTML and XML). These where not recognized properly by the syntax highlighter.

UT included for HTML/XML format.