### PR TITLE
Prevent dump if too many requests are selected

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -973,6 +973,10 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'No Request Found' ).
     ENDIF.
 
+    IF lines( lt_request ) > 10000.
+      zcx_abapgit_exception=>raise( 'Too many requests selected (max 10000)' ).
+    ENDIF.
+
     LOOP AT lt_request REFERENCE INTO lr_request.
       ls_r_trkorr-sign = 'I'.
       ls_r_trkorr-option = 'EQ'.


### PR DESCRIPTION
Selection in "Stage by Transport" can result in dump:

![image](https://user-images.githubusercontent.com/59966492/218159065-f88c35ba-fd6c-40b5-8a62-283e7bb6ee61.png)

Fix dump DBSQL_STMNT_TOO_LARGE by checking for max 10000 transports.