### PR TITLE
Gui component: Simplify handlers registration

### DIFF
--- a/src/ui/core/zcl_abapgit_gui_hotkey_ctl.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_hotkey_ctl.clas.abap
@@ -36,7 +36,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_hotkey_ctl IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_HOTKEY_CTL IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -146,7 +146,7 @@ CLASS zcl_abapgit_gui_hotkey_ctl IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_hotkey> LIKE LINE OF lt_registered_hotkeys.
 
-    zif_abapgit_gui_hotkey_ctl~register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/lib/zcl_abapgit_gui_component.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_component.clas.abap
@@ -23,14 +23,24 @@ CLASS zcl_abapgit_gui_component DEFINITION
         VALUE(ri_gui_services) TYPE REF TO zif_abapgit_gui_services
       RAISING
         zcx_abapgit_exception.
+    METHODS register_handlers
+      RAISING
+        zcx_abapgit_exception.
+
+  PRIVATE SECTION.
+    DATA mi_gui_services TYPE REF TO zif_abapgit_gui_services.
+
+    METHODS register_event_handler
+      IMPORTING
+        ii_event_handler TYPE REF TO zif_abapgit_gui_event_handler OPTIONAL
+      RAISING
+        zcx_abapgit_exception.
     METHODS register_hotkeys
       IMPORTING
         ii_hotkey_provider TYPE REF TO zif_abapgit_gui_hotkeys OPTIONAL
       RAISING
         zcx_abapgit_exception.
 
-  PRIVATE SECTION.
-    DATA mi_gui_services TYPE REF TO zif_abapgit_gui_services.
 ENDCLASS.
 
 
@@ -50,6 +60,31 @@ CLASS ZCL_ABAPGIT_GUI_COMPONENT IMPLEMENTATION.
     gui_services( )->get_html_parts( )->add_part(
       iv_collection = c_html_parts-scripts
       ii_part       = ii_part ).
+  ENDMETHOD.
+
+
+  METHOD register_event_handler.
+
+    DATA li_event_handler TYPE REF TO zif_abapgit_gui_event_handler.
+
+    IF ii_event_handler IS BOUND.
+      li_event_handler = ii_event_handler.
+    ELSE.
+      TRY.
+          li_event_handler ?= me.
+        CATCH cx_root.
+          RETURN.
+      ENDTRY.
+    ENDIF.
+
+    gui_services( )->register_event_handler( li_event_handler ).
+
+  ENDMETHOD.
+
+
+  METHOD register_handlers.
+    register_event_handler( ).
+    register_hotkeys( ).
   ENDMETHOD.
 
 

--- a/src/ui/lib/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.abap
@@ -1,6 +1,7 @@
 CLASS zcl_abapgit_html_form DEFINITION
   PUBLIC
   FINAL
+  INHERITING FROM zcl_abapgit_gui_component
   CREATE PRIVATE .
 
   PUBLIC SECTION.
@@ -188,7 +189,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_html_form IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
 
 
   METHOD checkbox.
@@ -443,9 +444,7 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
     ri_html->add( |</form>| ).
     ri_html->add( |</div>| ).
 
-    zcl_abapgit_ui_factory=>get_gui_services(
-      )->get_hotkeys_ctl(
-      )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
+    register_handlers( ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page.clas.abap
@@ -91,7 +91,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -351,7 +351,7 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
       lv_end    TYPE i,
       lv_total  TYPE ty_time.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     GET RUN TIME FIELD lv_start.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_addofflin.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_addofflin.clas.abap
@@ -66,7 +66,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_ADDOFFLIN IMPLEMENTATION.
 
 
   METHOD choose_labels.
@@ -266,7 +266,7 @@ CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_addonline.clas.abap
@@ -69,7 +69,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
 
   METHOD choose_labels.
@@ -325,7 +325,7 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -64,7 +64,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
 
 
   METHOD ask_user_for_check_variant.
@@ -171,7 +171,7 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    gui_services( )->get_hotkeys_ctl( )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
+    register_handlers( ).
 
     ri_html->add( render_variant( mv_check_variant ) ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_commit.clas.abap
@@ -114,7 +114,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
 
   METHOD branch_name_to_internal.
@@ -519,7 +519,7 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     IF mo_form_util->is_empty( mo_form_data ) = abap_true.
       get_defaults( ).

--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -68,7 +68,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_DEBUGINFO IMPLEMENTATION.
 
 
   METHOD build_toolbar.
@@ -438,7 +438,7 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
@@ -270,7 +270,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
 
 
   METHOD add_filter_sub_menu.
@@ -874,7 +874,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
     li_progress->off( ).
 
-    gui_services( )->get_hotkeys_ctl( )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
+    register_handlers( ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_ex_object.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_ex_object.clas.abap
@@ -164,7 +164,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_EX_OBJECT IMPLEMENTATION.
 
 
   METHOD zif_abapgit_gui_renderable~render.
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_ex_pckage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_ex_pckage.clas.abap
@@ -50,7 +50,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_ex_pckage IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_EX_PCKAGE IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -160,7 +160,7 @@ CLASS zcl_abapgit_gui_page_ex_pckage IMPLEMENTATION.
 
 
   METHOD zif_abapgit_gui_renderable~render.
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_merge_sel.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_merge_sel.clas.abap
@@ -57,7 +57,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_merge_sel IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_SEL IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -182,7 +182,7 @@ CLASS zcl_abapgit_gui_page_merge_sel IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_patch.clas.abap
@@ -134,7 +134,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_patch IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
 
 
   METHOD add_menu_begin.
@@ -457,7 +457,7 @@ CLASS zcl_abapgit_gui_page_patch IMPLEMENTATION.
       CLEAR: mv_pushed.
     ENDIF.
 
-    gui_services( )->get_hotkeys_ctl( )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
+    register_handlers( ).
 
     ri_html = super->render_content( ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -167,7 +167,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
 
 
   METHOD apply_filter.
@@ -1028,10 +1028,9 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       it_overview = lt_overview ).
     ri_html->add( |</div>| ).
 
-    gui_services( )->register_event_handler( me ).
     register_deferred_script( render_scripts( ) ).
     register_deferred_script( zcl_abapgit_gui_chunk_lib=>render_repo_palette( c_action-select ) ).
-    register_hotkeys( ).
+    register_handlers( ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -38,7 +38,7 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-protected section.
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     DATA mo_repo TYPE REF TO zcl_abapgit_repo .

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -38,6 +38,7 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+protected section.
   PRIVATE SECTION.
 
     DATA mo_repo TYPE REF TO zcl_abapgit_repo .
@@ -197,7 +198,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -1281,7 +1282,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_item> LIKE LINE OF lt_repo_items.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT mo_repo_aggregated_state.
 
@@ -1423,7 +1424,6 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     ENDTRY.
 
     register_deferred_script( render_scripts( ) ).
-    register_hotkeys( ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/zcl_abapgit_gui_page_run_bckg.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_run_bckg.clas.abap
@@ -26,7 +26,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_run_bckg IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_RUN_BCKG IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -84,7 +84,7 @@ CLASS zcl_abapgit_gui_page_run_bckg IMPLEMENTATION.
 
     DATA: lv_text LIKE LINE OF mt_text.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     run( ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_bckg.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_bckg.clas.abap
@@ -65,7 +65,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_BCKG IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -327,7 +327,7 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     read_settings( ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_glob.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_glob.clas.abap
@@ -77,7 +77,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_glob IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_GLOB IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -359,7 +359,7 @@ CLASS zcl_abapgit_gui_page_sett_glob IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     IF mo_form_util->is_empty( mo_form_data ) = abap_true.
       read_settings( ).

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_info.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_info.clas.abap
@@ -117,7 +117,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_INFO IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -590,7 +590,7 @@ CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     read_settings( ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -87,7 +87,54 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_LOCL IMPLEMENTATION.
+
+
+  METHOD choose_check_variant.
+
+    DATA: lv_check_variant TYPE sci_chkv.
+
+    lv_check_variant = zcl_abapgit_ui_factory=>get_popups( )->choose_code_insp_check_variant( ).
+
+    IF lv_check_variant IS NOT INITIAL.
+      mo_form_data->set(
+        iv_key = c_id-code_inspector_check_variant
+        iv_val = lv_check_variant ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD choose_labels.
+
+    DATA:
+      lv_old_labels TYPE string,
+      lv_new_labels TYPE string.
+
+    lv_old_labels = mo_form_data->get( c_id-labels ).
+
+    lv_new_labels = zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_labels( lv_old_labels ).
+
+    mo_form_data->set(
+      iv_key = c_id-labels
+      iv_val = lv_new_labels ).
+
+  ENDMETHOD.
+
+
+  METHOD choose_transport_request.
+
+    DATA: lv_transport_request TYPE trkorr.
+
+    lv_transport_request = zcl_abapgit_ui_factory=>get_popups( )->popup_transport_request( ).
+
+    IF lv_transport_request IS NOT INITIAL.
+      mo_form_data->set(
+          iv_key = c_id-transport_request
+          iv_val = lv_transport_request ).
+    ENDIF.
+
+  ENDMETHOD.
 
 
   METHOD constructor.
@@ -346,7 +393,7 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     IF mo_form_util->is_empty( mo_form_data ) = abap_true.
       read_settings( ).
@@ -368,52 +415,4 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
     ri_html->add( `</div>` ).
 
   ENDMETHOD.
-
-
-  METHOD choose_labels.
-
-    DATA:
-      lv_old_labels TYPE string,
-      lv_new_labels TYPE string.
-
-    lv_old_labels = mo_form_data->get( c_id-labels ).
-
-    lv_new_labels = zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_labels( lv_old_labels ).
-
-    mo_form_data->set(
-      iv_key = c_id-labels
-      iv_val = lv_new_labels ).
-
-  ENDMETHOD.
-
-
-  METHOD choose_check_variant.
-
-    DATA: lv_check_variant TYPE sci_chkv.
-
-    lv_check_variant = zcl_abapgit_ui_factory=>get_popups( )->choose_code_insp_check_variant( ).
-
-    IF lv_check_variant IS NOT INITIAL.
-      mo_form_data->set(
-        iv_key = c_id-code_inspector_check_variant
-        iv_val = lv_check_variant ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD choose_transport_request.
-
-    DATA: lv_transport_request TYPE trkorr.
-
-    lv_transport_request = zcl_abapgit_ui_factory=>get_popups( )->popup_transport_request( ).
-
-    IF lv_transport_request IS NOT INITIAL.
-      mo_form_data->set(
-          iv_key = c_id-transport_request
-          iv_val = lv_transport_request ).
-    ENDIF.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_pers.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_pers.clas.abap
@@ -397,7 +397,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_PERS IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     IF mo_form_util->is_empty( mo_form_data ) = abap_true.
       read_settings( ).

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -183,7 +183,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REMO IMPLEMENTATION.
 
 
   METHOD check_protection.
@@ -1074,7 +1074,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
@@ -1090,8 +1090,6 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       io_validation_log = mo_validation_log ) ).
 
     ri_html->add( `</div>` ).
-
-    gui_services( )->get_hotkeys_ctl( )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -73,7 +73,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -426,7 +426,7 @@ CLASS zcl_abapgit_gui_page_sett_repo IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     IF mo_form_util->is_empty( mo_form_data ) = abap_true.
       read_settings( ).

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -124,7 +124,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
 
   METHOD build_menu.
@@ -442,7 +442,7 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
     ri_html->add( '</div>' ).
 
-    gui_services( )->get_hotkeys_ctl( )->register_hotkeys( zif_abapgit_gui_hotkeys~get_hotkey_actions( ) ).
+    register_handlers( ).
     gui_services( )->get_html_parts( )->add_part(
       iv_collection = zcl_abapgit_gui_component=>c_html_parts-hidden_forms
       ii_part       = render_deferred_hidden_events( ) ).

--- a/src/ui/pages/zcl_abapgit_gui_page_tags.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_tags.clas.abap
@@ -99,7 +99,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_tags IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_TAGS IMPLEMENTATION.
 
 
   METHOD choose_commit.
@@ -396,7 +396,7 @@ CLASS zcl_abapgit_gui_page_tags IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
-    gui_services( )->register_event_handler( me ).
+    register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 


### PR DESCRIPTION
To #6049
Not that I'm super excited but definitely less code to call. Complete automation seems not possible to me, unless there is a gui helper method to render components

So instead
```abap
  ii_html->add( <div> )
  ii_html->add( some_component->render( ) )
```

It should be
```abap
  ii_html->add( <div> )
  ii_html->add( gui_services->render_component( some_component ) )
```

Then `render_component` will call all the automatic stuff. But seems like one clutter for another (maybe I'm wrong here)

Welcome to review.