### PR TITLE
XML: unit test render()

### DIFF
--- a/src/xml/zcl_abapgit_xml.clas.testclasses.abap
+++ b/src/xml/zcl_abapgit_xml.clas.testclasses.abap
@@ -67,33 +67,37 @@ CLASS ltcl_xml IMPLEMENTATION.
 
     lv_to_xml = render_xml( 'FOO' ).
 
-    cl_abap_unit_assert=>assert_equals(
+    cl_abap_unit_assert=>assert_char_cp(
       act = lv_to_xml
-      exp = lv_from_xml ).
+      exp = |*{ lv_from_xml }*| ).
 
   ENDMETHOD.
 
   METHOD render_xml.
 
-    DATA: li_element       TYPE REF TO if_ixml_element,
-          li_ostream       TYPE REF TO if_ixml_ostream,
-          li_streamfactory TYPE REF TO if_ixml_stream_factory.
+* this code replicates the functionality in ZCL_ABAPGIT_XML_OUTPUT,
 
-    li_element = mo_xml->mi_xml_doc->find_from_path( |/{ mo_xml->c_abapgit_tag }/{ iv_name }| ).
+    DATA: li_ostream       TYPE REF TO if_ixml_ostream,
+          li_renderer      TYPE REF TO if_ixml_renderer,
+          li_streamfactory TYPE REF TO if_ixml_stream_factory.
 
     li_streamfactory = mo_xml->mi_ixml->create_stream_factory( ).
 
     li_ostream = li_streamfactory->create_ostream_cstring( rv_xml ).
 
-    li_element->render( ostream = li_ostream ).
+    li_renderer = mo_xml->mi_ixml->create_renderer(
+      ostream  = li_ostream
+      document = mo_xml->mi_xml_doc ).
+
+    li_renderer->render( ).
 
   ENDMETHOD.
 
   METHOD bad_version_raises_exc.
 
-    DATA: lv_xml TYPE string,
+    DATA: lv_xml   TYPE string,
           lo_error TYPE REF TO zcx_abapgit_exception,
-          lv_text TYPE string.
+          lv_text  TYPE string.
 
     lv_xml = |<?xml version="1.0"?>|
           && |<{ mo_xml->c_abapgit_tag } { mo_xml->c_attr_version }="v9.8.7">|
@@ -115,9 +119,9 @@ CLASS ltcl_xml IMPLEMENTATION.
 
   METHOD bad_xml_raises_exc.
 
-    DATA: lv_xml TYPE string,
+    DATA: lv_xml   TYPE string,
           lo_error TYPE REF TO zcx_abapgit_exception,
-          lv_text TYPE string.
+          lv_text  TYPE string.
 
     lv_xml = |<?xml version="1.0"?>|
           && |<{ mo_xml->c_abapgit_tag } { mo_xml->c_attr_version }="{ zif_abapgit_version=>c_xml_version }">|

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -128,7 +128,7 @@
       {"object": "ZCL_ABAPGIT_GUI_ASSET_MANAGER", "class": "ltcl_abapgit_gui_asset_manager", "method": "get_mime_asset", "note": "todo in open-abap fm WWWPARAMS_READ"},
       {"object": "ZCL_ABAPGIT_GUI_CSS_PROCESSOR", "class": "ltcl_multiple_files",            "method": "test_overwrite", "note": "??"},
 
-      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "space_leading_trailing", "note": "todo in if_ixml_document$find_from_path, https://github.com/open-abap/open-abap/issues/226 "},
+      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "space_leading_trailing", "note": "close to working"},
       {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "bad_xml_raises_exc", "note": "handling of xml parser errors, cl_ixml, test method parse_negative"},
       {"object": "ZCL_ABAPGIT_XML_OUTPUT", "class": "ltcl_xml_output", "method": "render_xml_string", "note": "kernel_call_transformation.mi_writer.get(...).if_sxml_writer$open_element is not a function"},
       {"object": "ZCL_ABAPGIT_XML_OUTPUT", "class": "ltcl_xml_output", "method": "add_simple_object", "note": "kernel_call_transformation.mi_writer.get(...).if_sxml_writer$open_element is not a function"},

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -128,7 +128,7 @@
       {"object": "ZCL_ABAPGIT_GUI_ASSET_MANAGER", "class": "ltcl_abapgit_gui_asset_manager", "method": "get_mime_asset", "note": "todo in open-abap fm WWWPARAMS_READ"},
       {"object": "ZCL_ABAPGIT_GUI_CSS_PROCESSOR", "class": "ltcl_multiple_files",            "method": "test_overwrite", "note": "??"},
 
-      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "space_leading_trailing", "note": "close to working"},
+      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "space_leading_trailing", "note": "close to working, https://github.com/open-abap/open-abap-core/pull/557 "},
       {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "bad_xml_raises_exc", "note": "handling of xml parser errors, cl_ixml, test method parse_negative"},
       {"object": "ZCL_ABAPGIT_XML_OUTPUT", "class": "ltcl_xml_output", "method": "render_xml_string", "note": "kernel_call_transformation.mi_writer.get(...).if_sxml_writer$open_element is not a function"},
       {"object": "ZCL_ABAPGIT_XML_OUTPUT", "class": "ltcl_xml_output", "method": "add_simple_object", "note": "kernel_call_transformation.mi_writer.get(...).if_sxml_writer$open_element is not a function"},


### PR DESCRIPTION
refactor XML unit test to use the same methods as in ZCL_XML_OUTPUT class