### PR TITLE
Fix zip diff command visibility

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -446,7 +446,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
     ELSE.
       " offline repo
 
-      IF mo_repo->has_remote_source( ) = abap_true AND mo_repo_aggregated_state->remote( ) IS NOT INITIAL.
+      IF mo_repo->has_remote_source( ) = abap_true AND mo_repo_aggregated_state->is_unchanged( ) = abap_false.
         ro_toolbar->add( iv_txt = 'Pull <sup>zip</sup>'
                          iv_act = |{ zif_abapgit_definitions=>c_action-git_pull }?key={ mv_key }|
                          iv_opt = zif_abapgit_html=>c_html_opt-strong ).


### PR DESCRIPTION
When importing from ZIP it happens that only local changes are available. I could not easily recreate it, but it was connected to extra translations in local systems. The below screenshot is simulated. In this case Diff (and also Pull) command is not visible, though it is very important to control what's wrong with the marked objects. Just had an issue with it yesterday when deploying our product.
![image](https://user-images.githubusercontent.com/15635498/221191611-7f6c3f69-bc25-4b69-9e4a-2132a0f5f783.png)

So the fix just shows Diff/Pull for any `unchanged` status
![2023-02-24_15h29_33](https://user-images.githubusercontent.com/15635498/221191731-03b98546-8ac1-46ea-a3ff-750fd603f27a.png)

