### PR TITLE
Refactor popup_to_select_from_list

### DIFF
--- a/src/apack/zcl_abapgit_apack_helper.clas.abap
+++ b/src/apack/zcl_abapgit_apack_helper.clas.abap
@@ -80,7 +80,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_apack_helper IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_APACK_HELPER IMPLEMENTATION.
 
 
   METHOD are_dependencies_met.
@@ -275,7 +275,7 @@ CLASS zcl_abapgit_apack_helper IMPLEMENTATION.
           lt_columns      TYPE salv_t_column_ref,
           ls_column       LIKE LINE OF lt_columns,
           lt_color_table  TYPE ty_color_tab,
-          ls_position     TYPE zcl_abapgit_popups=>ty_popup_position,
+          ls_position     TYPE zif_abapgit_popups=>ty_popup_position,
           lx_ex           TYPE REF TO cx_root.
 
     IF it_dependencies IS INITIAL.

--- a/src/ui/lib/zcl_abapgit_exception_viewer.clas.abap
+++ b/src/ui/lib/zcl_abapgit_exception_viewer.clas.abap
@@ -74,7 +74,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_exception_viewer IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_EXCEPTION_VIEWER IMPLEMENTATION.
 
 
   METHOD add_row.
@@ -283,7 +283,7 @@ CLASS zcl_abapgit_exception_viewer IMPLEMENTATION.
           lo_event   TYPE REF TO cl_salv_events_table,
           lo_columns TYPE REF TO cl_salv_columns_table,
           lo_alv     TYPE REF TO cl_salv_table.
-    DATA  ls_position TYPE zcl_abapgit_popups=>ty_popup_position.
+    DATA  ls_position TYPE zif_abapgit_popups=>ty_popup_position.
 
     TRY.
         cl_salv_table=>factory(

--- a/src/ui/lib/zcl_abapgit_log_viewer.clas.abap
+++ b/src/ui/lib/zcl_abapgit_log_viewer.clas.abap
@@ -91,7 +91,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_log_viewer IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_LOG_VIEWER IMPLEMENTATION.
 
 
   METHOD calculate_cell_type.
@@ -289,7 +289,7 @@ CLASS zcl_abapgit_log_viewer IMPLEMENTATION.
           lo_columns     TYPE REF TO cl_salv_columns_table,
           lo_column      TYPE REF TO cl_salv_column,
           lo_functions   TYPE REF TO cl_salv_functions_list,
-          ls_position    TYPE zcl_abapgit_popups=>ty_popup_position,
+          ls_position    TYPE zif_abapgit_popups=>ty_popup_position,
           lv_add_obj_col TYPE abap_bool,
           lo_event       TYPE REF TO cl_salv_events_table.
 

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -100,7 +100,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD activate_objects.
@@ -395,6 +395,8 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     <ls_column>-name = 'OBJ_TYPE'.
     APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
     <ls_column>-name = 'OBJ_NAME'.
+    APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
+    <ls_column>-name = 'DEVCLASS'.
     APPEND INITIAL LINE TO lt_columns ASSIGNING <ls_column>.
     <ls_column>-name = 'ICON'.
     <ls_column>-text = 'Action'.

--- a/src/ui/zcl_abapgit_free_sel_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_free_sel_dialog.clas.abap
@@ -57,7 +57,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_free_sel_dialog IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_FREE_SEL_DIALOG IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -135,7 +135,7 @@ CLASS zcl_abapgit_free_sel_dialog IMPLEMENTATION.
 
   METHOD free_selections_dialog.
 
-    DATA ls_position TYPE zcl_abapgit_popups=>ty_popup_position.
+    DATA ls_position TYPE zif_abapgit_popups=>ty_popup_position.
 
     ls_position = zcl_abapgit_popups=>center(
       iv_width  = 60

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -8,24 +8,15 @@ CLASS zcl_abapgit_popups DEFINITION
 
     INTERFACES zif_abapgit_popups .
 
-    TYPES:
-      BEGIN OF ty_popup_position,
-        start_column LIKE  sy-cucol,
-        start_row    LIKE  sy-curow,
-        end_column   LIKE  sy-cucol,
-        end_row      LIKE  sy-curow,
-      END OF ty_popup_position.
-
     CLASS-METHODS center
       IMPORTING
         !iv_width          TYPE i
         !iv_height         TYPE i
       RETURNING
-        VALUE(rs_position) TYPE ty_popup_position.
+        VALUE(rs_position) TYPE zif_abapgit_popups=>ty_popup_position.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS c_default_column TYPE abap_componentdescr-name VALUE `DEFAULT_COLUMN` ##NO_TEXT.
 
     TYPES:
       ty_lt_fields TYPE STANDARD TABLE OF sval WITH DEFAULT KEY .
@@ -39,15 +30,9 @@ CLASS zcl_abapgit_popups DEFINITION
     TYPES:
       ty_commit_value_tab_tt TYPE STANDARD TABLE OF ty_commit_value_tab WITH DEFAULT KEY.
 
-    CONSTANTS c_fieldname_selected TYPE abap_componentdescr-name VALUE `SELECTED` ##NO_TEXT.
-    CONSTANTS c_fieldname_obj_type TYPE abap_componentdescr-name VALUE `OBJ_TYPE` ##NO_TEXT.
     CONSTANTS c_answer_cancel      TYPE c LENGTH 1 VALUE 'A' ##NO_TEXT.
 
-    DATA mo_select_list_popup TYPE REF TO cl_salv_table .
-    DATA mr_table TYPE REF TO data .
-    DATA mv_cancel TYPE abap_bool VALUE abap_false.
-    DATA mo_table_descr TYPE REF TO cl_abap_tabledescr .
-    DATA ms_position TYPE ty_popup_position.
+    DATA ms_position TYPE zif_abapgit_popups=>ty_popup_position.
 
     METHODS add_field
       IMPORTING
@@ -59,26 +44,6 @@ CLASS zcl_abapgit_popups DEFINITION
         !iv_obligatory TYPE spo_obl OPTIONAL
       CHANGING
         !ct_fields     TYPE zif_abapgit_popups=>ty_sval_tt .
-    METHODS create_new_table
-      IMPORTING
-        !it_list TYPE STANDARD TABLE .
-    METHODS get_selected_rows
-      EXPORTING
-        !et_list TYPE INDEX TABLE .
-    METHODS on_select_list_link_click
-      FOR EVENT link_click OF cl_salv_events_table
-      IMPORTING
-        !row
-        !column .
-    METHODS on_select_list_function_click
-      FOR EVENT added_function OF cl_salv_events_table
-      IMPORTING
-        !e_salv_function .
-    METHODS on_double_click
-      FOR EVENT double_click OF cl_salv_events_table
-      IMPORTING
-        !row
-        !column .
     METHODS _popup_3_get_values
       IMPORTING
         !iv_popup_title    TYPE string
@@ -100,18 +65,11 @@ CLASS zcl_abapgit_popups DEFINITION
         !et_commits     TYPE zif_abapgit_definitions=>ty_commit_tt
       RAISING
         zcx_abapgit_exception.
-    METHODS get_pfstatus
-      IMPORTING
-        !iv_selection_mode TYPE salv_de_constant
-        !iv_object_list    TYPE abap_bool
-      EXPORTING
-        !ev_report         TYPE sy-repid
-        !ev_pfstatus       TYPE sy-pfkey.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_popups IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_POPUPS IMPLEMENTATION.
 
 
   METHOD add_field.
@@ -202,349 +160,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
                                 |{ lv_time_string }|.
 
     ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD create_new_table.
-
-    " create and populate a table on the fly derived from
-    " it_data with a select column
-
-    DATA: lr_struct        TYPE REF TO data,
-          lt_components    TYPE cl_abap_structdescr=>component_table,
-          lo_data_descr    TYPE REF TO cl_abap_datadescr,
-          lo_elem_descr    TYPE REF TO cl_abap_elemdescr,
-          lo_struct_descr  TYPE REF TO cl_abap_structdescr,
-          lo_struct_descr2 TYPE REF TO cl_abap_structdescr.
-
-    FIELD-SYMBOLS: <lt_table>     TYPE STANDARD TABLE,
-                   <ls_component> TYPE abap_componentdescr,
-                   <lg_line>      TYPE data,
-                   <lg_data>      TYPE any,
-                   <lg_value>     TYPE any.
-
-    mo_table_descr ?= cl_abap_tabledescr=>describe_by_data( it_list ).
-    lo_data_descr = mo_table_descr->get_table_line_type( ).
-
-    CASE lo_data_descr->kind.
-      WHEN cl_abap_elemdescr=>kind_elem.
-        lo_elem_descr ?= mo_table_descr->get_table_line_type( ).
-        INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
-        <ls_component>-name = c_default_column.
-        <ls_component>-type = lo_elem_descr.
-
-      WHEN cl_abap_elemdescr=>kind_struct.
-        lo_struct_descr ?= mo_table_descr->get_table_line_type( ).
-        lt_components = lo_struct_descr->get_components( ).
-
-    ENDCASE.
-
-    IF lt_components IS INITIAL.
-      RETURN.
-    ENDIF.
-
-    INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
-    <ls_component>-name = c_fieldname_selected.
-    <ls_component>-type ?= cl_abap_datadescr=>describe_by_name( 'FLAG' ).
-
-    lo_struct_descr2 = cl_abap_structdescr=>create( lt_components ).
-    mo_table_descr = cl_abap_tabledescr=>create( lo_struct_descr2 ).
-
-    CREATE DATA mr_table TYPE HANDLE mo_table_descr.
-    ASSIGN mr_table->* TO <lt_table>.
-    ASSERT sy-subrc = 0.
-
-    CREATE DATA lr_struct TYPE HANDLE lo_struct_descr2.
-    ASSIGN lr_struct->* TO <lg_line>.
-    ASSERT sy-subrc = 0.
-
-    LOOP AT it_list ASSIGNING <lg_data>.
-      CLEAR <lg_line>.
-      CASE lo_data_descr->kind.
-        WHEN cl_abap_elemdescr=>kind_elem.
-          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_data> TO <lg_value>.
-          ASSERT <lg_value> IS ASSIGNED.
-          <lg_line> = <lg_value>.
-
-        WHEN OTHERS.
-          MOVE-CORRESPONDING <lg_data> TO <lg_line>.
-
-      ENDCASE.
-      INSERT <lg_line> INTO TABLE <lt_table>.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD get_pfstatus.
-
-    ev_report  = 'SAPMSVIM'.
-
-    IF iv_selection_mode = if_salv_c_selection_mode=>single.
-      ev_pfstatus = '110'.
-    ELSE.
-      ev_pfstatus = '102'.
-
-      IF iv_object_list = abap_true.
-        " For object lists with multiple selections, try to use a PFSTATUS that includes
-        " an additional button to show other selection options
-        CALL FUNCTION 'RS_CUA_STATUS_CHECK'
-          EXPORTING
-            objectname       = 'SELECT_MULTI_WK'
-            program          = 'SAPLSEDI_POPUPS'
-          EXCEPTIONS
-            object_not_found = 1
-            OTHERS           = 2.
-        IF sy-subrc = 0.
-          ev_report   = 'SAPLSEDI_POPUPS'.
-          ev_pfstatus = 'SELECT_MULTI_WK'.
-        ENDIF.
-      ENDIF.
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD get_selected_rows.
-
-    DATA: lv_condition TYPE string,
-          lr_exporting TYPE REF TO data.
-
-    FIELD-SYMBOLS: <lg_exporting>    TYPE any,
-                   <lt_table>        TYPE STANDARD TABLE,
-                   <lg_line>         TYPE any,
-                   <lg_value>        TYPE any,
-                   <lv_selected>     TYPE abap_bool,
-                   <lv_selected_row> TYPE LINE OF salv_t_row.
-
-    DATA: lo_data_descr    TYPE REF TO cl_abap_datadescr,
-          lo_selections    TYPE REF TO cl_salv_selections,
-          lt_selected_rows TYPE salv_t_row.
-
-    ASSIGN mr_table->* TO <lt_table>.
-    ASSERT sy-subrc = 0.
-
-    lo_selections = mo_select_list_popup->get_selections( ).
-
-    IF lo_selections->get_selection_mode( ) = if_salv_c_selection_mode=>single.
-
-      lt_selected_rows = lo_selections->get_selected_rows( ).
-
-      LOOP AT lt_selected_rows ASSIGNING <lv_selected_row>.
-
-        READ TABLE <lt_table>
-          ASSIGNING <lg_line>
-          INDEX <lv_selected_row>.
-        CHECK <lg_line> IS ASSIGNED.
-
-        ASSIGN COMPONENT c_fieldname_selected
-           OF STRUCTURE <lg_line>
-           TO <lv_selected>.
-        CHECK <lv_selected> IS ASSIGNED.
-
-        <lv_selected> = abap_true.
-
-      ENDLOOP.
-
-    ENDIF.
-
-    lv_condition = |{ c_fieldname_selected } = ABAP_TRUE|.
-
-    CREATE DATA lr_exporting LIKE LINE OF et_list.
-    ASSIGN lr_exporting->* TO <lg_exporting>.
-
-    mo_table_descr ?= cl_abap_tabledescr=>describe_by_data( et_list ).
-    lo_data_descr = mo_table_descr->get_table_line_type( ).
-
-    LOOP AT <lt_table> ASSIGNING <lg_line> WHERE (lv_condition).
-      CLEAR <lg_exporting>.
-
-      CASE lo_data_descr->kind.
-        WHEN cl_abap_elemdescr=>kind_elem.
-          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_line> TO <lg_value>.
-          ASSERT <lg_value> IS ASSIGNED.
-          <lg_exporting> = <lg_value>.
-
-        WHEN OTHERS.
-          MOVE-CORRESPONDING <lg_line> TO <lg_exporting>.
-
-      ENDCASE.
-      APPEND <lg_exporting> TO et_list.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD on_double_click.
-
-    DATA: lo_selections    TYPE REF TO cl_salv_selections.
-
-    lo_selections = mo_select_list_popup->get_selections( ).
-
-    IF lo_selections->get_selection_mode( ) = if_salv_c_selection_mode=>single.
-      mo_select_list_popup->close_screen( ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD on_select_list_function_click.
-
-    DATA: lv_answer    TYPE c LENGTH 1,
-          ls_position  LIKE ms_position,
-          ls_selection TYPE spopli,
-          lt_selection TYPE TABLE OF spopli.
-
-    FIELD-SYMBOLS: <lt_table>    TYPE STANDARD TABLE,
-                   <lg_line>     TYPE any,
-                   <lv_object>   TYPE tadir-object,
-                   <lv_selected> TYPE abap_bool.
-
-    ASSIGN mr_table->* TO <lt_table>.
-    ASSERT sy-subrc = 0.
-
-    " Work for functions of SAPMSVIM and SAPLSEDI_POPUPS
-    CASE e_salv_function.
-      WHEN 'O.K.' OR 'OK'.
-        mv_cancel = abap_false.
-        mo_select_list_popup->close_screen( ).
-
-      WHEN 'ABR' OR 'CANCEL'.
-        "Canceled: clear list to overwrite nothing
-        CLEAR <lt_table>.
-        mv_cancel = abap_true.
-        mo_select_list_popup->close_screen( ).
-
-      WHEN 'SALL' OR 'SEL_ALL'.
-        LOOP AT <lt_table> ASSIGNING <lg_line>.
-
-          ASSIGN COMPONENT c_fieldname_selected
-                 OF STRUCTURE <lg_line>
-                 TO <lv_selected>.
-          ASSERT sy-subrc = 0.
-
-          <lv_selected> = abap_true.
-
-        ENDLOOP.
-
-        mo_select_list_popup->refresh( ).
-
-      WHEN 'DSEL' OR 'SEL_DEL'.
-        LOOP AT <lt_table> ASSIGNING <lg_line>.
-
-          ASSIGN COMPONENT c_fieldname_selected
-                 OF STRUCTURE <lg_line>
-                 TO <lv_selected>.
-          ASSERT sy-subrc = 0.
-
-          <lv_selected> = abap_false.
-
-        ENDLOOP.
-
-        mo_select_list_popup->refresh( ).
-
-      WHEN 'SEL_KEY'.
-        ls_selection-varoption = 'All objects'.
-        APPEND ls_selection TO lt_selection.
-        ls_selection-varoption = 'Packages'.
-        APPEND ls_selection TO lt_selection.
-        ls_selection-varoption = 'DDIC objects'.
-        APPEND ls_selection TO lt_selection.
-        ls_selection-varoption = 'Source code'.
-        APPEND ls_selection TO lt_selection.
-        ls_selection-varoption = 'Enhancements'.
-        APPEND ls_selection TO lt_selection.
-
-        ls_position-start_column = ms_position-start_column + 20.
-        ls_position-start_row    = ms_position-start_row + 5.
-
-        CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
-          EXPORTING
-            titel      = 'Selection'
-            textline1  = 'Which objects should be selected?'
-            start_col  = ls_position-start_column
-            start_row  = ls_position-start_row
-            cursorline = 1
-          IMPORTING
-            answer     = lv_answer
-          TABLES
-            t_spopli   = lt_selection
-          EXCEPTIONS
-            OTHERS     = 1.
-        IF sy-subrc <> 0 OR lv_answer = c_answer_cancel.
-          RETURN.
-        ENDIF.
-
-        LOOP AT <lt_table> ASSIGNING <lg_line>.
-
-          ASSIGN COMPONENT c_fieldname_obj_type OF STRUCTURE <lg_line> TO <lv_object>.
-          ASSERT sy-subrc = 0.
-
-          CASE lv_answer.
-            WHEN '2'. " Packages
-              IF 'DEVC' <> <lv_object>.
-                CONTINUE.
-              ENDIF.
-            WHEN '3'. " DDIC
-              IF zcl_abapgit_objects_activation=>is_ddic_type( <lv_object> ) = abap_false.
-                CONTINUE.
-              ENDIF.
-            WHEN '4'. " Source Code
-              IF 'CLAS,FUGR,INTF,PROG,TYPE' NS <lv_object>.
-                CONTINUE.
-              ENDIF.
-            WHEN '5'. " Enhancements
-              IF 'ENHO,ENHS,ENHC,ENSC' NS <lv_object>.
-                CONTINUE.
-              ENDIF.
-          ENDCASE.
-
-          ASSIGN COMPONENT c_fieldname_selected
-                 OF STRUCTURE <lg_line>
-                 TO <lv_selected>.
-          ASSERT sy-subrc = 0.
-
-          <lv_selected> = abap_true.
-
-        ENDLOOP.
-
-        mo_select_list_popup->refresh( ).
-
-      WHEN OTHERS.
-        CLEAR <lt_table>.
-        mo_select_list_popup->close_screen( ).
-    ENDCASE.
-
-  ENDMETHOD.
-
-
-  METHOD on_select_list_link_click.
-
-    FIELD-SYMBOLS: <lt_table>    TYPE STANDARD TABLE,
-                   <lg_line>     TYPE any,
-                   <lv_selected> TYPE abap_bool.
-
-    ASSIGN mr_table->* TO <lt_table>.
-    ASSERT sy-subrc = 0.
-
-    READ TABLE <lt_table> ASSIGNING <lg_line> INDEX row.
-    IF sy-subrc = 0.
-
-      ASSIGN COMPONENT c_fieldname_selected
-             OF STRUCTURE <lg_line>
-             TO <lv_selected>.
-      ASSERT sy-subrc = 0.
-
-      IF <lv_selected> = abap_true.
-        <lv_selected> = abap_false.
-      ELSE.
-        <lv_selected> = abap_true.
-      ENDIF.
-
-    ENDIF.
-
-    mo_select_list_popup->refresh( ).
 
   ENDMETHOD.
 
@@ -1113,156 +728,29 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
   METHOD zif_abapgit_popups~popup_to_select_from_list.
 
-    DATA: lv_pfstatus     TYPE sy-pfkey,
-          lv_report       TYPE sy-repid,
-          lv_object_list  TYPE abap_bool,
-          lo_events       TYPE REF TO cl_salv_events_table,
-          lo_columns      TYPE REF TO cl_salv_columns_table,
-          lt_columns      TYPE salv_t_column_ref,
-          ls_column       TYPE salv_s_column_ref,
-          lo_column       TYPE REF TO cl_salv_column_list,
-          lo_table_header TYPE REF TO cl_salv_form_text.
+    DATA lo_popup TYPE REF TO lcl_object_descision_list.
 
-    FIELD-SYMBOLS: <lt_table>             TYPE STANDARD TABLE,
-                   <ls_column_to_display> TYPE zif_abapgit_popups=>ty_alv_column,
-                   <lv_row>               TYPE i,
-                   <ls_line>              TYPE any,
-                   <lv_selected>          TYPE data.
-
-    CLEAR: et_list.
-
-    create_new_table( it_list ).
-
-    ASSIGN mr_table->* TO <lt_table>.
-    ASSERT sy-subrc = 0.
-
-    LOOP AT it_preselected_rows ASSIGNING <lv_row>.
-
-      READ TABLE <lt_table> INDEX <lv_row> ASSIGNING <ls_line>.
-      IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |Preselected row { <lv_row> } doesn't exist| ).
-      ENDIF.
-
-      ASSIGN
-        COMPONENT c_fieldname_selected
-        OF STRUCTURE <ls_line>
-        TO <lv_selected>.
-      ASSERT sy-subrc = 0.
-
-      <lv_selected> = abap_true.
-
-    ENDLOOP.
+    CLEAR et_list.
 
     ms_position = center(
       iv_width  = iv_end_column - iv_start_column
       iv_height = iv_end_line - iv_start_line ).
 
-    TRY.
-        cl_salv_table=>factory( IMPORTING r_salv_table = mo_select_list_popup
-                                CHANGING  t_table      = <lt_table> ).
+    CREATE OBJECT lo_popup
+      EXPORTING
+        it_list               = it_list
+        iv_title              = iv_title
+        iv_header_text        = iv_header_text
+        is_position           = ms_position
+        iv_striped_pattern    = iv_striped_pattern
+        iv_optimize_col_width = iv_optimize_col_width
+        iv_selection_mode     = iv_selection_mode
+        iv_select_column_text = iv_select_column_text
+        it_columns_to_display = it_columns_to_display
+        it_preselected_rows   = it_preselected_rows.
 
-        mo_select_list_popup->set_screen_popup( start_column = ms_position-start_column
-                                                end_column   = ms_position-end_column
-                                                start_line   = ms_position-start_row
-                                                end_line     = ms_position-end_row ).
-
-        lo_events = mo_select_list_popup->get_event( ).
-
-        SET HANDLER on_select_list_link_click FOR lo_events.
-        SET HANDLER on_select_list_function_click FOR lo_events.
-        SET HANDLER on_double_click FOR lo_events.
-
-        IF iv_title CN ' _0'.
-          mo_select_list_popup->get_display_settings( )->set_list_header( iv_title ).
-        ENDIF.
-
-        IF iv_header_text CN ' _0'.
-          CREATE OBJECT lo_table_header
-            EXPORTING
-              text = iv_header_text.
-          mo_select_list_popup->set_top_of_list( lo_table_header ).
-        ENDIF.
-
-        mo_select_list_popup->get_display_settings( )->set_striped_pattern( iv_striped_pattern ).
-        mo_select_list_popup->get_selections( )->set_selection_mode( iv_selection_mode ).
-
-        lo_columns = mo_select_list_popup->get_columns( ).
-        lt_columns = lo_columns->get( ).
-        lo_columns->set_optimize( iv_optimize_col_width ).
-
-        LOOP AT lt_columns INTO ls_column.
-
-          lo_column ?= ls_column-r_column.
-
-          IF    iv_selection_mode    = if_salv_c_selection_mode=>multiple
-            AND ls_column-columnname = c_fieldname_selected.
-            lo_column->set_cell_type( if_salv_c_cell_type=>checkbox_hotspot ).
-            lo_column->set_output_length( 20 ).
-            lo_column->set_short_text( |{ iv_select_column_text }| ).
-            lo_column->set_medium_text( |{ iv_select_column_text }| ).
-            lo_column->set_long_text( |{ iv_select_column_text }| ).
-            CONTINUE.
-          ENDIF.
-
-          READ TABLE it_columns_to_display
-            ASSIGNING <ls_column_to_display>
-            WITH KEY name = ls_column-columnname.
-
-          CASE sy-subrc.
-            WHEN 0.
-              IF <ls_column_to_display>-text CN ' _0'.
-                lo_column->set_short_text( |{ <ls_column_to_display>-text }| ).
-                lo_column->set_medium_text( |{ <ls_column_to_display>-text }| ).
-                lo_column->set_long_text( |{ <ls_column_to_display>-text }| ).
-              ENDIF.
-
-              IF <ls_column_to_display>-length > 0.
-                lo_column->set_output_length( <ls_column_to_display>-length ).
-              ENDIF.
-
-              IF <ls_column_to_display>-show_icon = abap_true.
-                lo_column->set_icon( abap_true ).
-              ENDIF.
-
-            WHEN OTHERS.
-              " Hide column
-              lo_column->set_technical( abap_true ).
-
-          ENDCASE.
-
-          IF ls_column-columnname = c_fieldname_obj_type.
-            lv_object_list = abap_true.
-          ENDIF.
-
-        ENDLOOP.
-
-        get_pfstatus(
-          EXPORTING
-            iv_selection_mode = iv_selection_mode
-            iv_object_list    = lv_object_list
-          IMPORTING
-            ev_report         = lv_report
-            ev_pfstatus       = lv_pfstatus ).
-
-        mo_select_list_popup->set_screen_status( pfstatus = lv_pfstatus
-                                                 report   = lv_report ).
-
-        mo_select_list_popup->display( ).
-
-      CATCH cx_salv_msg.
-        zcx_abapgit_exception=>raise( 'Error from POPUP_TO_SELECT_FROM_LIST' ).
-    ENDTRY.
-
-    IF mv_cancel = abap_true.
-      mv_cancel = abap_false.
-      RAISE EXCEPTION TYPE zcx_abapgit_cancel.
-    ENDIF.
-
-    get_selected_rows( IMPORTING et_list = et_list ).
-
-    CLEAR: mo_select_list_popup,
-           mr_table,
-           mo_table_descr.
+    lo_popup->display( ).
+    lo_popup->get_selected( IMPORTING et_list = et_list ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -1,10 +1,10 @@
 CLASS lcl_object_descision_list DEFINITION FINAL.
   PUBLIC SECTION.
 
-    CONSTANTS c_default_column TYPE abap_componentdescr-name VALUE `DEFAULT_COLUMN` ##NO_TEXT.
-    CONSTANTS c_fieldname_selected TYPE abap_componentdescr-name VALUE `SELECTED` ##NO_TEXT.
-    CONSTANTS c_answer_cancel      TYPE c LENGTH 1 VALUE 'A' ##NO_TEXT.
-    CONSTANTS c_fieldname_obj_type TYPE abap_componentdescr-name VALUE `OBJ_TYPE` ##NO_TEXT.
+    CONSTANTS c_default_column TYPE abap_componentdescr-name VALUE `DEFAULT_COLUMN`.
+    CONSTANTS c_fieldname_selected TYPE abap_componentdescr-name VALUE `SELECTED`.
+    CONSTANTS c_answer_cancel      TYPE c LENGTH 1 VALUE 'A'.
+    CONSTANTS c_fieldname_obj_type TYPE abap_componentdescr-name VALUE `OBJ_TYPE`.
 
     METHODS constructor
       IMPORTING
@@ -104,8 +104,6 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
 
   METHOD get_selected.
 
-    CLEAR et_list.
-
     DATA:
       lv_condition     TYPE string,
       lr_exporting     TYPE REF TO data,
@@ -120,6 +118,8 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
       <lg_value>        TYPE any,
       <lv_selected>     TYPE abap_bool,
       <lv_selected_row> TYPE LINE OF salv_t_row.
+
+    CLEAR et_list.
 
     ASSIGN mr_table->* TO <lt_table>.
     ASSERT sy-subrc = 0.
@@ -229,7 +229,7 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
         TRY.
             lo_columns->get_column( |{ c_fieldname_obj_type }| ).
             lv_object_list = abap_true.
-          CATCH CX_SALV_NOT_FOUND.
+          CATCH cx_salv_not_found.
         ENDTRY.
 
         setup_columns(
@@ -237,10 +237,6 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
           iv_selection_mode     = iv_selection_mode
           iv_select_column_text = iv_select_column_text
           it_columns_to_display = it_columns_to_display ).
-
-*        data lo_functions type ref to cl_salv_functions_list.
-*        lo_functions = mo_alv->get_functions( ).
-*        lo_functions->set_all( abap_true ).
 
         set_pfstatus(
           iv_object_list    = lv_object_list

--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -437,7 +437,7 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
     CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
       EXPORTING
         titel      = 'Selection'
-        textline1  = 'Which objects should be selected?'
+        textline1  = 'Which objects should be added to the selection?'
         start_col  = ls_position-start_column
         start_row  = ls_position-start_row
         cursorline = 1
@@ -480,8 +480,6 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
 
       ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
       ASSERT sy-subrc = 0.
-
-      <lv_selected> = abap_false. " Reset
 
       CASE iv_category.
         WHEN 'All objects'.

--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -1,0 +1,633 @@
+CLASS lcl_object_descision_list DEFINITION FINAL.
+  PUBLIC SECTION.
+
+    CONSTANTS c_default_column TYPE abap_componentdescr-name VALUE `DEFAULT_COLUMN` ##NO_TEXT.
+    CONSTANTS c_fieldname_selected TYPE abap_componentdescr-name VALUE `SELECTED` ##NO_TEXT.
+    CONSTANTS c_answer_cancel      TYPE c LENGTH 1 VALUE 'A' ##NO_TEXT.
+    CONSTANTS c_fieldname_obj_type TYPE abap_componentdescr-name VALUE `OBJ_TYPE` ##NO_TEXT.
+
+    METHODS constructor
+      IMPORTING
+        !it_list               TYPE STANDARD TABLE
+        !iv_title              TYPE lvc_title DEFAULT space
+        !iv_header_text        TYPE csequence DEFAULT space
+        !is_position           TYPE zif_abapgit_popups=>ty_popup_position
+        !iv_striped_pattern    TYPE abap_bool DEFAULT abap_false
+        !iv_optimize_col_width TYPE abap_bool DEFAULT abap_true
+        !iv_selection_mode     TYPE salv_de_constant DEFAULT if_salv_c_selection_mode=>multiple
+        !iv_select_column_text TYPE csequence DEFAULT space
+        !it_columns_to_display TYPE zif_abapgit_popups=>ty_alv_column_tt
+        !it_preselected_rows   TYPE zif_abapgit_popups=>ty_rows OPTIONAL
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS display
+      RAISING
+        zcx_abapgit_exception.
+    METHODS get_selected
+      EXPORTING
+        VALUE(et_list) TYPE STANDARD TABLE.
+
+  PRIVATE SECTION.
+
+    DATA mr_table TYPE REF TO data.
+    DATA mo_table_descr TYPE REF TO cl_abap_tabledescr.
+    DATA mo_alv TYPE REF TO cl_salv_table.
+    DATA mv_cancel TYPE abap_bool.
+    DATA ms_position TYPE zif_abapgit_popups=>ty_popup_position.
+
+    " Events
+    METHODS on_select_list_link_click
+      FOR EVENT link_click OF cl_salv_events_table
+      IMPORTING
+        !row
+        !column.
+    METHODS on_select_list_function_click
+      FOR EVENT added_function OF cl_salv_events_table
+      IMPORTING
+        !e_salv_function.
+    METHODS on_double_click
+      FOR EVENT double_click OF cl_salv_events_table
+      IMPORTING
+        !row
+        !column.
+
+    " Methods
+    METHODS create_new_selectable_table
+      IMPORTING
+        it_list TYPE STANDARD TABLE.
+    METHODS preselect
+      IMPORTING
+        it_preselected_rows TYPE zif_abapgit_popups=>ty_rows OPTIONAL
+      RAISING
+        zcx_abapgit_exception.
+    METHODS create_alv
+      RETURNING
+        VALUE(ro_alv) TYPE REF TO cl_salv_table
+      RAISING
+        cx_salv_msg.
+    METHODS setup_columns
+      IMPORTING
+        io_columns TYPE REF TO cl_salv_columns_table
+        iv_selection_mode     TYPE salv_de_constant
+        iv_select_column_text TYPE csequence
+        it_columns_to_display TYPE zif_abapgit_popups=>ty_alv_column_tt
+      RAISING
+        cx_salv_msg.
+    METHODS set_pfstatus
+      IMPORTING
+        !iv_selection_mode TYPE salv_de_constant
+        !iv_object_list    TYPE abap_bool.
+    METHODS ask_user_for_obj_category
+      RETURNING
+        VALUE(rv_category) TYPE string.
+    METHODS mark_category
+      IMPORTING
+        iv_category TYPE string.
+    METHODS mark_all_to
+      IMPORTING
+        iv_selected TYPE abap_bool.
+
+ENDCLASS.
+
+CLASS lcl_object_descision_list IMPLEMENTATION.
+
+  METHOD display.
+
+    mo_alv->display( ).
+
+    IF mv_cancel = abap_true.
+      RAISE EXCEPTION TYPE zcx_abapgit_cancel.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD get_selected.
+
+    CLEAR et_list.
+
+    DATA:
+      lv_condition     TYPE string,
+      lr_exporting     TYPE REF TO data,
+      lo_data_descr    TYPE REF TO cl_abap_datadescr,
+      lo_selections    TYPE REF TO cl_salv_selections,
+      lt_selected_rows TYPE salv_t_row.
+
+    FIELD-SYMBOLS:
+      <lg_exporting>    TYPE any,
+      <lt_table>        TYPE STANDARD TABLE,
+      <ls_line>         TYPE any,
+      <lg_value>        TYPE any,
+      <lv_selected>     TYPE abap_bool,
+      <lv_selected_row> TYPE LINE OF salv_t_row.
+
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    lo_selections = mo_alv->get_selections( ).
+
+    IF lo_selections->get_selection_mode( ) = if_salv_c_selection_mode=>single.
+
+      lt_selected_rows = lo_selections->get_selected_rows( ).
+
+      LOOP AT lt_selected_rows ASSIGNING <lv_selected_row>.
+
+        READ TABLE <lt_table> ASSIGNING <ls_line> INDEX <lv_selected_row>.
+        CHECK <ls_line> IS ASSIGNED.
+
+        ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
+        CHECK <lv_selected> IS ASSIGNED.
+
+        <lv_selected> = abap_true.
+
+      ENDLOOP.
+
+    ENDIF.
+
+    lv_condition = |{ c_fieldname_selected } = ABAP_TRUE|.
+
+    CREATE DATA lr_exporting LIKE LINE OF et_list.
+    ASSIGN lr_exporting->* TO <lg_exporting>.
+
+*    mo_table_descr ?= cl_abap_tabledescr=>describe_by_data( et_list ). " different export structure ?
+    lo_data_descr = mo_table_descr->get_table_line_type( ).
+
+    LOOP AT <lt_table> ASSIGNING <ls_line> WHERE (lv_condition).
+      CLEAR <lg_exporting>.
+
+      CASE lo_data_descr->kind.
+        WHEN cl_abap_elemdescr=>kind_elem.
+          ASSIGN COMPONENT c_default_column OF STRUCTURE <ls_line> TO <lg_value>.
+          ASSERT <lg_value> IS ASSIGNED.
+          <lg_exporting> = <lg_value>.
+
+        WHEN OTHERS.
+          MOVE-CORRESPONDING <ls_line> TO <lg_exporting>.
+
+      ENDCASE.
+      APPEND <lg_exporting> TO et_list.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD create_alv.
+
+    FIELD-SYMBOLS <lt_table> TYPE STANDARD TABLE.
+
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    cl_salv_table=>factory(
+      IMPORTING
+        r_salv_table = ro_alv
+      CHANGING
+        t_table      = <lt_table> ).
+
+  ENDMETHOD.
+
+  METHOD constructor.
+
+    DATA:
+      lv_object_list  TYPE abap_bool,
+      lo_events       TYPE REF TO cl_salv_events_table,
+      lo_columns      TYPE REF TO cl_salv_columns_table,
+      lo_table_header TYPE REF TO cl_salv_form_text.
+
+    create_new_selectable_table( it_list ).
+    preselect( it_preselected_rows ).
+
+    TRY.
+        mo_alv = create_alv( ).
+        mo_alv->set_screen_popup(
+          start_column = is_position-start_column
+          end_column   = is_position-end_column
+          start_line   = is_position-start_row
+          end_line     = is_position-end_row ).
+        ms_position = is_position.
+
+        lo_events = mo_alv->get_event( ).
+
+        SET HANDLER on_select_list_link_click FOR lo_events.
+        SET HANDLER on_select_list_function_click FOR lo_events.
+        SET HANDLER on_double_click FOR lo_events.
+
+        IF iv_title CN ' _0'.
+          mo_alv->get_display_settings( )->set_list_header( iv_title ).
+        ENDIF.
+
+        IF iv_header_text CN ' _0'.
+          CREATE OBJECT lo_table_header EXPORTING text = iv_header_text.
+          mo_alv->set_top_of_list( lo_table_header ).
+        ENDIF.
+
+        mo_alv->get_display_settings( )->set_striped_pattern( iv_striped_pattern ).
+        mo_alv->get_selections( )->set_selection_mode( iv_selection_mode ).
+
+        lo_columns = mo_alv->get_columns( ).
+        lo_columns->set_optimize( iv_optimize_col_width ).
+
+        TRY.
+            lo_columns->get_column( |{ c_fieldname_obj_type }| ).
+            lv_object_list = abap_true.
+          CATCH CX_SALV_NOT_FOUND.
+        ENDTRY.
+
+        setup_columns(
+          io_columns            = lo_columns
+          iv_selection_mode     = iv_selection_mode
+          iv_select_column_text = iv_select_column_text
+          it_columns_to_display = it_columns_to_display ).
+
+*        data lo_functions type ref to cl_salv_functions_list.
+*        lo_functions = mo_alv->get_functions( ).
+*        lo_functions->set_all( abap_true ).
+
+        set_pfstatus(
+          iv_object_list    = lv_object_list
+          iv_selection_mode = iv_selection_mode ).
+
+      CATCH cx_salv_msg.
+        zcx_abapgit_exception=>raise( 'ALV error from object decision list' ).
+    ENDTRY.
+
+
+  ENDMETHOD.
+
+  METHOD create_new_selectable_table.
+
+    " create and populate a table on the fly derived from
+    " it_data with a select column
+
+    DATA:
+      lr_struct        TYPE REF TO data,
+      lt_components    TYPE cl_abap_structdescr=>component_table,
+      lo_data_descr    TYPE REF TO cl_abap_datadescr,
+      lo_elem_descr    TYPE REF TO cl_abap_elemdescr,
+      lo_struct_descr  TYPE REF TO cl_abap_structdescr,
+      lo_struct_descr2 TYPE REF TO cl_abap_structdescr.
+
+    FIELD-SYMBOLS:
+      <lt_table>     TYPE STANDARD TABLE,
+      <ls_component> TYPE abap_componentdescr,
+      <ls_line>      TYPE data,
+      <lg_data>      TYPE any,
+      <lg_value>     TYPE any.
+
+    mo_table_descr ?= cl_abap_tabledescr=>describe_by_data( it_list ).
+    lo_data_descr = mo_table_descr->get_table_line_type( ).
+
+    CASE lo_data_descr->kind.
+      WHEN cl_abap_elemdescr=>kind_elem.
+        lo_elem_descr ?= mo_table_descr->get_table_line_type( ).
+        INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
+        <ls_component>-name = c_default_column.
+        <ls_component>-type = lo_elem_descr.
+
+      WHEN cl_abap_elemdescr=>kind_struct.
+        lo_struct_descr ?= mo_table_descr->get_table_line_type( ).
+        lt_components = lo_struct_descr->get_components( ).
+
+    ENDCASE.
+
+    IF lt_components IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
+    <ls_component>-name = c_fieldname_selected.
+    <ls_component>-type ?= cl_abap_datadescr=>describe_by_name( 'FLAG' ).
+
+    lo_struct_descr2 = cl_abap_structdescr=>create( lt_components ).
+    mo_table_descr = cl_abap_tabledescr=>create( lo_struct_descr2 ).
+
+    CREATE DATA mr_table TYPE HANDLE mo_table_descr.
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    CREATE DATA lr_struct TYPE HANDLE lo_struct_descr2.
+    ASSIGN lr_struct->* TO <ls_line>.
+    ASSERT sy-subrc = 0.
+
+    LOOP AT it_list ASSIGNING <lg_data>.
+      CLEAR <ls_line>.
+      CASE lo_data_descr->kind.
+        WHEN cl_abap_elemdescr=>kind_elem.
+          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_data> TO <lg_value>.
+          ASSERT <lg_value> IS ASSIGNED.
+          <ls_line> = <lg_value>.
+
+        WHEN OTHERS.
+          MOVE-CORRESPONDING <lg_data> TO <ls_line>.
+
+      ENDCASE.
+      INSERT <ls_line> INTO TABLE <lt_table>.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD preselect.
+
+    FIELD-SYMBOLS:
+      <lt_table>    TYPE STANDARD TABLE,
+      <lv_row>      LIKE LINE OF it_preselected_rows,
+      <ls_line>     TYPE any,
+      <lv_selected> TYPE data.
+
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    LOOP AT it_preselected_rows ASSIGNING <lv_row>.
+
+      READ TABLE <lt_table> INDEX <lv_row> ASSIGNING <ls_line>.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |Preselected row { <lv_row> } doesn't exist| ).
+      ENDIF.
+
+      ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
+      ASSERT sy-subrc = 0.
+      <lv_selected> = abap_true.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD on_double_click.
+
+    DATA lo_selections TYPE REF TO cl_salv_selections.
+
+    lo_selections = mo_alv->get_selections( ).
+
+    IF lo_selections->get_selection_mode( ) = if_salv_c_selection_mode=>single.
+      mo_alv->close_screen( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD on_select_list_function_click.
+
+    " Work for functions of SAPMSVIM and SAPLSEDI_POPUPS
+    CASE e_salv_function.
+      WHEN 'O.K.' OR 'OK'.
+        mv_cancel = abap_false.
+        mo_alv->close_screen( ).
+
+      WHEN 'ABR' OR 'CANCEL'.
+        " Canceled: clear list to overwrite nothing
+        mv_cancel = abap_true.
+        mo_alv->close_screen( ).
+
+      WHEN 'SALL' OR 'SEL_ALL'.
+        mark_all_to( abap_true ).
+        mo_alv->refresh( ).
+
+      WHEN 'DSEL' OR 'SEL_DEL'.
+        mark_all_to( abap_false ).
+        mo_alv->refresh( ).
+
+      WHEN 'SEL_KEY'.
+        mark_category( ask_user_for_obj_category( ) ).
+        mo_alv->refresh( ).
+
+      WHEN OTHERS.
+        mv_cancel = abap_true.
+        mo_alv->close_screen( ).
+
+    ENDCASE.
+
+  ENDMETHOD.
+
+  METHOD mark_all_to.
+
+    FIELD-SYMBOLS:
+      <lt_table>    TYPE STANDARD TABLE,
+      <ls_line>     TYPE any,
+      <lv_selected> TYPE abap_bool.
+
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    LOOP AT <lt_table> ASSIGNING <ls_line>.
+
+      ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
+      ASSERT sy-subrc = 0.
+      <lv_selected> = iv_selected.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD ask_user_for_obj_category.
+
+    DATA:
+      lv_answer    TYPE c LENGTH 1,
+      ls_position  TYPE zif_abapgit_popups=>ty_popup_position,
+      ls_selection TYPE spopli,
+      lt_selection TYPE TABLE OF spopli.
+
+    ls_selection-varoption = 'All objects'.
+    APPEND ls_selection TO lt_selection.
+    ls_selection-varoption = 'Packages'.
+    APPEND ls_selection TO lt_selection.
+    ls_selection-varoption = 'DDIC objects'.
+    APPEND ls_selection TO lt_selection.
+    ls_selection-varoption = 'Source code'.
+    APPEND ls_selection TO lt_selection.
+    ls_selection-varoption = 'Enhancements'.
+    APPEND ls_selection TO lt_selection.
+
+    ls_position-start_column = ms_position-start_column + 20.
+    ls_position-start_row    = ms_position-start_row + 5.
+
+    CALL FUNCTION 'POPUP_TO_DECIDE_LIST'
+      EXPORTING
+        titel      = 'Selection'
+        textline1  = 'Which objects should be selected?'
+        start_col  = ls_position-start_column
+        start_row  = ls_position-start_row
+        cursorline = 1
+      IMPORTING
+        answer     = lv_answer
+      TABLES
+        t_spopli   = lt_selection
+      EXCEPTIONS
+        OTHERS     = 1.
+    IF sy-subrc <> 0 OR lv_answer = c_answer_cancel.
+      RETURN.
+    ENDIF.
+
+    READ TABLE lt_selection INDEX lv_answer INTO ls_selection.
+    IF sy-subrc = 0.
+      rv_category = ls_selection-varoption.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD mark_category.
+
+    FIELD-SYMBOLS:
+      <lt_table>    TYPE STANDARD TABLE,
+      <lv_obj_type> TYPE tadir-object,
+      <ls_line>     TYPE any,
+      <lv_selected> TYPE abap_bool.
+
+    IF iv_category IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    LOOP AT <lt_table> ASSIGNING <ls_line>.
+
+      ASSIGN COMPONENT c_fieldname_obj_type OF STRUCTURE <ls_line> TO <lv_obj_type>.
+      ASSERT sy-subrc = 0.
+
+      ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
+      ASSERT sy-subrc = 0.
+
+      <lv_selected> = abap_false. " Reset
+
+      CASE iv_category.
+        WHEN 'All objects'.
+          " Just mark
+        WHEN 'Packages'.
+          IF <lv_obj_type> <> 'DEVC'.
+            CONTINUE.
+          ENDIF.
+        WHEN 'DDIC objects'.
+          IF zcl_abapgit_objects_activation=>is_ddic_type( <lv_obj_type> ) = abap_false.
+            CONTINUE.
+          ENDIF.
+        WHEN 'Source code'.
+          IF 'CLAS,FUGR,INTF,PROG,TYPE' NS <lv_obj_type>.
+            CONTINUE.
+          ENDIF.
+        WHEN 'Enhancements'.
+          IF 'ENHO,ENHS,ENHC,ENSC' NS <lv_obj_type>.
+            CONTINUE.
+          ENDIF.
+        WHEN OTHERS.
+          RETURN. " Unexpected category
+      ENDCASE.
+
+      <lv_selected> = abap_true.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD on_select_list_link_click.
+
+    FIELD-SYMBOLS:
+      <lt_table>    TYPE STANDARD TABLE,
+      <ls_line>     TYPE any,
+      <lv_selected> TYPE abap_bool.
+
+    ASSIGN mr_table->* TO <lt_table>.
+    ASSERT sy-subrc = 0.
+
+    READ TABLE <lt_table> ASSIGNING <ls_line> INDEX row.
+    IF sy-subrc = 0.
+
+      ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
+      ASSERT sy-subrc = 0.
+      <lv_selected> = boolc( <lv_selected> = abap_false ).
+
+    ENDIF.
+
+    mo_alv->refresh( ).
+
+  ENDMETHOD.
+
+  METHOD setup_columns.
+
+    DATA:
+      lt_columns      TYPE salv_t_column_ref,
+      ls_column       TYPE salv_s_column_ref,
+      lo_column       TYPE REF TO cl_salv_column_list.
+
+    FIELD-SYMBOLS <ls_column_to_display> TYPE zif_abapgit_popups=>ty_alv_column.
+
+    lt_columns = io_columns->get( ).
+
+    LOOP AT lt_columns INTO ls_column.
+
+      lo_column ?= ls_column-r_column.
+
+      IF    iv_selection_mode    = if_salv_c_selection_mode=>multiple
+        AND ls_column-columnname = c_fieldname_selected.
+        lo_column->set_cell_type( if_salv_c_cell_type=>checkbox_hotspot ).
+        lo_column->set_output_length( 20 ).
+        lo_column->set_short_text( |{ iv_select_column_text }| ).
+        lo_column->set_medium_text( |{ iv_select_column_text }| ).
+        lo_column->set_long_text( |{ iv_select_column_text }| ).
+        CONTINUE.
+      ENDIF.
+
+      READ TABLE it_columns_to_display
+        ASSIGNING <ls_column_to_display>
+        WITH KEY name = ls_column-columnname.
+
+      CASE sy-subrc.
+        WHEN 0.
+          IF <ls_column_to_display>-text CN ' _0'.
+            lo_column->set_short_text( |{ <ls_column_to_display>-text }| ).
+            lo_column->set_medium_text( |{ <ls_column_to_display>-text }| ).
+            lo_column->set_long_text( |{ <ls_column_to_display>-text }| ).
+          ENDIF.
+
+          IF <ls_column_to_display>-length > 0.
+            lo_column->set_output_length( <ls_column_to_display>-length ).
+          ENDIF.
+
+          IF <ls_column_to_display>-show_icon = abap_true.
+            lo_column->set_icon( abap_true ).
+          ENDIF.
+
+        WHEN OTHERS.
+          " Hide column
+          lo_column->set_technical( abap_true ).
+
+      ENDCASE.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD set_pfstatus.
+
+    DATA:
+      lv_report         TYPE sy-repid,
+      lv_pfstatus       TYPE sy-pfkey.
+
+    lv_report  = 'SAPMSVIM'.
+
+    IF iv_selection_mode = if_salv_c_selection_mode=>single.
+      lv_pfstatus = '110'.
+    ELSE.
+      lv_pfstatus = '102'.
+
+      IF iv_object_list = abap_true.
+        " For object lists with multiple selections, try to use a PFSTATUS that includes
+        " an additional button to show other selection options
+        CALL FUNCTION 'RS_CUA_STATUS_CHECK'
+          EXPORTING
+            objectname       = 'SELECT_MULTI_WK'
+            program          = 'SAPLSEDI_POPUPS'
+          EXCEPTIONS
+            object_not_found = 1
+            OTHERS           = 2.
+        IF sy-subrc = 0.
+          lv_report   = 'SAPLSEDI_POPUPS'.
+          lv_pfstatus = 'SELECT_MULTI_WK'.
+        ENDIF.
+      ENDIF.
+    ENDIF.
+
+    mo_alv->set_screen_status(
+      pfstatus = lv_pfstatus
+      report   = lv_report ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -420,8 +420,6 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
       ls_selection TYPE spopli,
       lt_selection TYPE TABLE OF spopli.
 
-    ls_selection-varoption = 'All objects'.
-    APPEND ls_selection TO lt_selection.
     ls_selection-varoption = 'Packages'.
     APPEND ls_selection TO lt_selection.
     ls_selection-varoption = 'DDIC objects'.
@@ -482,8 +480,6 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
       ASSERT sy-subrc = 0.
 
       CASE iv_category.
-        WHEN 'All objects'.
-          " Just mark
         WHEN 'Packages'.
           IF <lv_obj_type> <> 'DEVC'.
             CONTINUE.

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -109,7 +109,7 @@ INTERFACE zif_abapgit_popups
       !iv_title              TYPE lvc_title DEFAULT space
       !iv_header_text        TYPE csequence DEFAULT space
       !iv_start_column       TYPE i DEFAULT 10
-      !iv_end_column         TYPE i DEFAULT 90
+      !iv_end_column         TYPE i DEFAULT 110
       !iv_start_line         TYPE i DEFAULT 8
       !iv_end_line           TYPE i DEFAULT 25
       !iv_striped_pattern    TYPE abap_bool DEFAULT abap_false

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -15,6 +15,14 @@ INTERFACE zif_abapgit_popups
     END OF ty_alv_column,
     ty_alv_column_tt TYPE TABLE OF ty_alv_column WITH DEFAULT KEY.
 
+  TYPES:
+    BEGIN OF ty_popup_position,
+      start_column LIKE  sy-cucol,
+      start_row    LIKE  sy-curow,
+      end_column   LIKE  sy-cucol,
+      end_row      LIKE  sy-curow,
+    END OF ty_popup_position.
+
   CONSTANTS c_new_branch_label TYPE string VALUE '+ create new ...' ##NO_TEXT.
 
   METHODS popup_search_help

--- a/src/utils/zcl_abapgit_requirement_helper.clas.abap
+++ b/src/utils/zcl_abapgit_requirement_helper.clas.abap
@@ -54,7 +54,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_requirement_helper IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REQUIREMENT_HELPER IMPLEMENTATION.
 
 
   METHOD get_requirement_met_status.
@@ -188,7 +188,7 @@ CLASS zcl_abapgit_requirement_helper IMPLEMENTATION.
           lt_color_negative TYPE lvc_t_scol,
           lt_color_positive TYPE lvc_t_scol,
           ls_color          TYPE lvc_s_scol,
-          ls_position       TYPE zcl_abapgit_popups=>ty_popup_position,
+          ls_position       TYPE zif_abapgit_popups=>ty_popup_position,
           lx_ex             TYPE REF TO cx_root.
 
     FIELD-SYMBOLS: <ls_line>        TYPE ty_color_line,

--- a/src/zabapgit_password_dialog.prog.abap
+++ b/src/zabapgit_password_dialog.prog.abap
@@ -63,7 +63,7 @@ CLASS lcl_password_dialog IMPLEMENTATION.
 
   METHOD popup.
 
-    DATA ls_position TYPE zcl_abapgit_popups=>ty_popup_position.
+    DATA ls_position TYPE zif_abapgit_popups=>ty_popup_position.
 
     CLEAR p_pass.
     p_url      = iv_repo_url.


### PR DESCRIPTION
It appeared, that `popup_to_select_from_list` holds 30% of `zcl_popup`, most of private methods and most of attributes ... which are kind of global vars in this way. So it is a class in class. And I separated it into a local class for decoupling and better code structure. Would be nice to merge it soon, cause I have other plans to improve this dialog. It's just this refactoring is already huge and not to mix it with the feature.

It is mostly move and restructure the code. Changes are:
- the dialog does not support different structures on in and out anymore (why should it ?! )
- the object category button is now exclusive, deselects all "other" objects before marking the selected category. I think it was a bug at the first place.

The rest is the same just in better structure