### PR TITLE
JavaScript clean-up: Remove obsolete parts

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -217,14 +217,6 @@ function perfClear() {
 }
 
 /**********************************************************
- * TAG PAGE Logic
- **********************************************************/
-function onTagTypeChange(oSelectObject){
-  var sValue = oSelectObject.value;
-  submitSapeventForm({ type: sValue }, "change_tag_type", "post");
-}
-
-/**********************************************************
  * Repo Overview Logic
  **********************************************************/
 function findStyleSheetByName(name) {
@@ -2044,85 +2036,6 @@ function preparePatch(){
 function registerStagePatch(){
   var oPatch = new Patch();
   oPatch.registerStagePatch();
-}
-
-/**********************************************************
- * Page branch overview
- *
- * Hovering a commit node in the branch overview will show
- * a popup with the commit details. Single click on a node
- * will fix the popup, so that users can select text. The
- * fixation is removed when any node is hovered or the popup
- * is closed via 'X'.
- *
- **********************************************************/
-
-function BranchOverview() {
-  this.bFixed = false;
-  this.elCurrentCommit = {
-    style : {
-      display: "none"
-    }
-  };
-}
-
-BranchOverview.prototype.toggleCommit = function(sSha1, bFixPopup) {
-
-  // If the popup is fixed, we just remove the fixation.
-  // The popup will then be hidden by the next call of hideCommit
-  if (this.bFixed) {
-    this.bFixed = false;
-    return;
-  }
-
-  // We hide the previous shown commit popup
-  this.elCurrentCommit.style.display = "none";
-
-  // Display the new commit popup if sha1 is supplied
-  if (sSha1){
-    this.elCurrentCommit = document.getElementById(sSha1);
-    this.elCurrentCommit.style.display = "";
-
-    // and fix the popup so that the next hideCommit won't hide it.
-    this.bFixed = bFixPopup;
-
-  }
-
-};
-
-// called by onClick of commit nodes in branch overview
-BranchOverview.prototype.onCommitClick = function(commit){
-  this.toggleCommit(commit.sha1, true);
-};
-
-// Called by commit:mouseover
-BranchOverview.prototype.showCommit = function(event){
-  this.toggleCommit(event.data.sha1);
-};
-
-// Called by commit:mouseout
-BranchOverview.prototype.hideCommit = function (){
-  this.toggleCommit();
-};
-
-// Initialize Top Horizontal Scroller on GitGraph
-function setGitGraphScroller(){ // eslint-disable-line no-unused-vars
-
-  // Get gitGraph Element Canvas Width
-  var gitGraphEl = document.getElementById("gitGraph");
-  var gitGraphWidth = gitGraphEl.offsetWidth;
-
-  // Initialize gitGraph-HTopScroller Element width as gitGraph
-  var HTopScrollerEl = document.querySelector(".gitGraph-HTopScroller");
-  HTopScrollerEl.style.width = gitGraphWidth + "px";
-
-}
-
-// Setup Top Horizontal Scroller on GitGraph event
-function GitGraphScroller() { // eslint-disable-line no-unused-vars
-  var gitGraphWrapperEl = document.querySelector(".gitGraph-Wrapper");
-  var gitGraphscrollWrapperEl = document.querySelector(".gitGraph-scrollWrapper");
-  gitGraphWrapperEl.scrollLeft = gitGraphscrollWrapperEl.scrollLeft;
 }
 
 /**********************************************************


### PR DESCRIPTION
- Remove `onTagTypeChange` (usage removed in https://github.com/abapGit/abapGit/pull/5591)
- Remove `BranchOverview` (usage removed in https://github.com/abapGit/abapGit/pull/5503)