### PR TITLE
File status refactoring, sidetrack: show local state for offline repos

### DIFF
--- a/src/repo/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/repo/zcl_abapgit_repo_content_list.clas.abap
@@ -5,18 +5,25 @@ CLASS zcl_abapgit_repo_content_list DEFINITION
 
   PUBLIC SECTION.
     METHODS constructor
-      IMPORTING io_repo TYPE REF TO zcl_abapgit_repo.
+      IMPORTING
+        io_repo TYPE REF TO zcl_abapgit_repo.
 
     METHODS list
-      IMPORTING iv_path              TYPE string
-                iv_by_folders        TYPE abap_bool OPTIONAL
-                iv_changes_only      TYPE abap_bool OPTIONAL
-                iv_transports        TYPE abap_bool OPTIONAL
-      RETURNING VALUE(rt_repo_items) TYPE zif_abapgit_definitions=>ty_repo_item_tt
-      RAISING   zcx_abapgit_exception.
+      IMPORTING
+        iv_path              TYPE string
+        iv_by_folders        TYPE abap_bool DEFAULT abap_false
+        iv_changes_only      TYPE abap_bool DEFAULT abap_false
+        iv_transports        TYPE abap_bool DEFAULT abap_false
+        iv_show_local_state  TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(rt_repo_items) TYPE zif_abapgit_definitions=>ty_repo_item_tt
+      RAISING
+        zcx_abapgit_exception.
 
     METHODS get_log
-      RETURNING VALUE(ri_log) TYPE REF TO zif_abapgit_log.
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zif_abapgit_log.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
     CONSTANTS: BEGIN OF c_sortkey,
@@ -57,7 +64,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
 
   METHOD build_folders.
@@ -310,7 +317,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
     mi_log->clear( ).
 
-    IF mo_repo->has_remote_source( ) = abap_true.
+    IF mo_repo->has_remote_source( ) = abap_true OR iv_show_local_state = abap_true.
       rt_repo_items = build_repo_items_with_remote( ).
       check_repo_size( ).
     ELSE.

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -15,7 +15,6 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
     CONSTANTS:
       BEGIN OF c_actions,
         change_dir        TYPE string VALUE 'change_dir' ##NO_TEXT,
-        show_local_state  TYPE string VALUE 'show_local_state' ##NO_TEXT,
         toggle_hide_files TYPE string VALUE 'toggle_hide_files' ##NO_TEXT,
         toggle_folders    TYPE string VALUE 'toggle_folders' ##NO_TEXT,
         toggle_changes    TYPE string VALUE 'toggle_changes' ##NO_TEXT,
@@ -53,7 +52,6 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
     DATA mv_order_by TYPE string .
     DATA mv_order_descending TYPE abap_bool .
     DATA mv_diff_first TYPE abap_bool .
-    DATA mv_show_local_state TYPE abap_bool .
     DATA mv_key TYPE zif_abapgit_persistence=>ty_value .
     DATA mv_are_changes_recorded_in_tr TYPE abap_bool .
 
@@ -566,13 +564,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
       iv_chk = mv_show_folders
       iv_act = c_actions-toggle_folders ).
 
-    IF mo_repo->is_offline( ) = abap_true.
-      ro_toolbar->add(
-        iv_txt = 'Show Local State'
-        iv_chk = mv_show_local_state
-        iv_act = c_actions-show_local_state ).
-    ENDIF.
-
   ENDMETHOD.
 
 
@@ -907,9 +898,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
     " Command
     ri_html->add( '<td class="cmd">' ).
-    IF mo_repo->has_remote_source( ) = abap_true OR mv_show_local_state = abap_true.
-      ri_html->add( render_item_command( is_item ) ).
-    ENDIF.
+    ri_html->add( render_item_command( is_item ) ).
     ri_html->add( '</td>' ).
 
     ri_html->add( '</tr>' ).
@@ -1013,9 +1002,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
       " Command
       ri_html->add( '<td class="cmd">' ).
-      IF mo_repo->has_remote_source( ) = abap_true OR mv_show_local_state = abap_true.
-        ri_html->add( render_file_command( ls_file ) ).
-      ENDIF.
+      ri_html->add( render_file_command( ls_file ) ).
       ri_html->add( '</td>' ).
 
       ri_html->add( '</tr>' ).
@@ -1171,10 +1158,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
       WHEN c_actions-toggle_diff_first.
         mv_diff_first = zcl_abapgit_persistence_user=>get_instance( )->set_diff_first(
           boolc( mv_diff_first = abap_false ) ).
-        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
-
-      WHEN c_actions-show_local_state.    " Show local state for offline package
-        mv_show_local_state = boolc( mv_show_local_state = abap_false ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
       WHEN c_actions-display_more.      " Increase MAX lines limit
@@ -1344,7 +1327,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
           iv_path             = mv_cur_dir
           iv_by_folders       = mv_show_folders
           iv_changes_only     = mv_changes_only
-          iv_show_local_state = mv_show_local_state
+          iv_show_local_state = abap_true
           iv_transports       = mv_are_changes_recorded_in_tr ).
 
         apply_order_by( CHANGING ct_repo_items = lt_repo_items ).


### PR DESCRIPTION
A sidetrack from #6107 - a feature to show a change between actual serialized state and previously saved checksums. Sometimes useful. Although obviously functionality is limited as there are no diffs, just the fact that something was changed.

Not ready for review yet, waits for #6124 + need some adjustment in file_status logic

https://user-images.githubusercontent.com/15635498/222825035-ec62dcd2-27be-413e-a5f7-5eb22892f022.mp4

