### PR TITLE
DEVC: Fix error handling

### DIFF
--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -31,6 +31,11 @@ CLASS zcl_abapgit_object_devc DEFINITION PUBLIC
         !iv_lock    TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
+    METHODS unlock_and_raise_error
+      IMPORTING
+        !ii_package TYPE REF TO if_package
+      RAISING
+        zcx_abapgit_exception .
     METHODS is_empty
       IMPORTING
         !iv_package_name   TYPE devclass
@@ -270,6 +275,27 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD unlock_and_raise_error.
+
+    DATA ls_msg TYPE bal_s_msg.
+
+    " Remember message since unlock overwrites it (for example with XT465)
+    MOVE-CORRESPONDING syst TO ls_msg.
+
+    set_lock( ii_package = ii_package
+              iv_lock    = abap_false ).
+
+    zcx_abapgit_exception=>raise_t100(
+      iv_msgid = ls_msg-msgid
+      iv_msgno = ls_msg-msgno
+      iv_msgv1 = ls_msg-msgv1
+      iv_msgv2 = ls_msg-msgv2
+      iv_msgv3 = ls_msg-msgv3
+      iv_msgv4 = ls_msg-msgv4 ).
+
+  ENDMETHOD.
+
+
   METHOD update_pinf_usages.
     DATA: lt_current_permissions TYPE tpak_permission_to_use_list,
           li_usage               TYPE REF TO if_package_permission_to_use,
@@ -429,9 +455,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       ENDTRY.
 
       IF sy-subrc <> 0.
-        set_lock( ii_package = li_package
-                  iv_lock    = abap_false ).
-        zcx_abapgit_exception=>raise_t100( ).
+        unlock_and_raise_error( li_package ).
       ENDIF.
 
       TRY.
@@ -460,10 +484,9 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
               OTHERS                = 7 ).
 
       ENDTRY.
+
       IF sy-subrc <> 0.
-        set_lock( ii_package = li_package
-                  iv_lock    = abap_false ).
-        zcx_abapgit_exception=>raise_t100( ).
+        unlock_and_raise_error( li_package ).
       ENDIF.
 
     ENDIF.
@@ -473,6 +496,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
   METHOD zif_abapgit_object~deserialize.
     DATA: li_package      TYPE REF TO if_package,
+          ls_msg          TYPE bal_s_msg,
           ls_package_data TYPE scompkdtln,
           ls_data_sign    TYPE scompksign,
           lt_usage_data   TYPE scomppdata,
@@ -576,9 +600,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 *          superpackage_invalid       = 17  downport, does not exist in 7.30
           OTHERS                     = 18 ).
       IF sy-subrc <> 0.
-        set_lock( ii_package = li_package
-                  iv_lock    = abap_false ).
-        zcx_abapgit_exception=>raise_t100( ).
+        unlock_and_raise_error( li_package ).
       ENDIF.
 
     ELSE.
@@ -651,9 +673,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
         object_invalid        = 4
         OTHERS                = 5 ).
     IF sy-subrc <> 0.
-      set_lock( ii_package = li_package
-                iv_lock    = abap_false ).
-      zcx_abapgit_exception=>raise_t100( ).
+      unlock_and_raise_error( li_package ).
     ENDIF.
 
     set_lock( ii_package = li_package

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -280,7 +280,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
     DATA ls_msg TYPE bal_s_msg.
 
     " Remember message since unlock overwrites it (for example with XT465)
-    MOVE-CORRESPONDING syst TO ls_msg.
+    MOVE-CORRESPONDING sy TO ls_msg.
 
     set_lock( ii_package = ii_package
               iv_lock    = abap_false ).

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -496,7 +496,6 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
   METHOD zif_abapgit_object~deserialize.
     DATA: li_package      TYPE REF TO if_package,
-          ls_msg          TYPE bal_s_msg,
           ls_package_data TYPE scompkdtln,
           ls_data_sign    TYPE scompksign,
           lt_usage_data   TYPE scomppdata,


### PR DESCRIPTION
Incorrect error messages are displayed during deserialize or delete since unlocking the package overwrites `syst`. 

Most likely the error message is "Parameter ... not in version ... of tp configuration" (XT465):

![image](https://user-images.githubusercontent.com/59966492/224086381-173782e0-a83c-4386-beb6-ee34e8bb9240.png)

Fix saves message parameters, unlocks, and then raises correct error.