### PR TITLE
LXE: more objects

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -313,7 +313,7 @@
     "max_one_statement": true,
     "message_exists": false,
     "method_length": {
-      "statements": 100,
+      "statements": 105,
       "checkForms": true,
       "ignoreTestClasses": false,
       "errorWhenEmpty": false

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -62,7 +62,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_doma IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
 
 
   METHOD adjust_exit.
@@ -386,9 +386,14 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    deserialize_texts( ii_xml   = io_xml
-                       is_dd01v = ls_dd01v
-                       it_dd07v = lt_dd07v ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      deserialize_texts(
+        ii_xml   = io_xml
+        is_dd01v = ls_dd01v
+        it_dd07v = lt_dd07v ).
+    ELSE.
+      deserialize_lxe_texts( io_xml ).
+    ENDIF.
 
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_doma ).
@@ -504,8 +509,13 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
     io_xml->add( iv_name = 'DD07V_TAB'
                  ig_data = lt_dd07v ).
 
-    serialize_texts( ii_xml   = io_xml
-                     it_dd07v = lt_dd07v ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      serialize_texts(
+        ii_xml   = io_xml
+        it_dd07v = lt_dd07v ).
+    ELSE.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
     serialize_longtexts( ii_xml         = io_xml
                          iv_longtext_id = c_longtext_id_doma ).

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -35,7 +35,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -204,8 +204,13 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    deserialize_texts( ii_xml   = io_xml
-                       is_dd04v = ls_dd04v ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      deserialize_texts(
+        ii_xml   = io_xml
+        is_dd04v = ls_dd04v ).
+    ELSE.
+      deserialize_lxe_texts( io_xml ).
+    ENDIF.
 
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_dtel ).
@@ -326,7 +331,11 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
     io_xml->add( iv_name = 'DD04V'
                  ig_data = ls_dd04v ).
 
-    serialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      serialize_texts( io_xml ).
+    ELSE.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
     serialize_longtexts( ii_xml         = io_xml
                          iv_longtext_id = c_longtext_id_dtel ).

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -48,7 +48,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_msag IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
 
 
   METHOD delete_documentation.
@@ -407,7 +407,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_msag ).
 
-    deserialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      deserialize_texts( io_xml ).
+    ELSE.
+      deserialize_lxe_texts( io_xml ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -496,7 +500,11 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
     serialize_longtexts_msag( it_t100 = lt_source
                               ii_xml  = io_xml ).
 
-    serialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      serialize_texts( io_xml ).
+    ELSE.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -47,7 +47,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
 
 
   METHOD clear_fields.
@@ -315,6 +315,10 @@ CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
       MODIFY ttree FROM ls_ttree.
     ENDIF.
 
+    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+      deserialize_lxe_texts( io_xml ).
+    ENDIF.
+
     IF zcl_abapgit_factory=>get_sap_package( iv_package )->are_changes_recorded_in_tr_req( ) = abap_true.
       " Add necessary SHI6, SHI7, and TABU entries to transport (SAP Note 455542)
       insert_transport( iv_transport ).
@@ -412,12 +416,13 @@ CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
       TABLES
         description      = lt_titles.
 
-    lv_all_languages = abap_false.
 
-    IF io_xml->i18n_params( )-main_language_only = abap_false.
-      lv_all_languages = abap_true.
-    ELSE.
+    IF io_xml->i18n_params( )-main_language_only = abap_true
+      OR io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+      lv_all_languages = abap_false.
       DELETE lt_titles WHERE spras <> mv_language.
+    ELSE.
+      lv_all_languages = abap_true.
     ENDIF.
 
     CALL FUNCTION 'STREE_HIERARCHY_READ'
@@ -452,6 +457,10 @@ CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
                  ig_data = lt_refs ).
     io_xml->add( iv_name = 'TREE_TEXTS'
                  ig_data = lt_texts ).
+
+    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -968,9 +968,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CLEAR: ls_dd02v-as4user,
-           ls_dd02v-as4date,
-           ls_dd02v-as4time.
+    CLEAR: ls_dd02v-as4user, ls_dd02v-as4date, ls_dd02v-as4time.
 
 * reset numeric field, so XML does not crash
     IF ls_dd02v-prozpuff = ''.
@@ -986,9 +984,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       CLEAR ls_dd02v-datavg.
     ENDIF.
 
-    CLEAR: ls_dd09l-as4user,
-           ls_dd09l-as4date,
-           ls_dd09l-as4time.
+    CLEAR: ls_dd09l-as4user, ls_dd09l-as4date, ls_dd09l-as4time.
 
     ASSIGN COMPONENT 'ROWORCOLST' OF STRUCTURE ls_dd09l TO <lg_roworcolst>.
     IF sy-subrc = 0 AND <lg_roworcolst> = 'C'.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -968,7 +968,9 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CLEAR: ls_dd02v-as4user, ls_dd02v-as4date, ls_dd02v-as4time.
+    CLEAR: ls_dd02v-as4user,
+           ls_dd02v-as4date,
+           ls_dd02v-as4time.
 
 * reset numeric field, so XML does not crash
     IF ls_dd02v-prozpuff = ''.
@@ -984,7 +986,9 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       CLEAR ls_dd02v-datavg.
     ENDIF.
 
-    CLEAR: ls_dd09l-as4user, ls_dd09l-as4date, ls_dd09l-as4time.
+    CLEAR: ls_dd09l-as4user,
+           ls_dd09l-as4date,
+           ls_dd09l-as4time.
 
     ASSIGN COMPONENT 'ROWORCOLST' OF STRUCTURE ls_dd09l TO <lg_roworcolst>.
     IF sy-subrc = 0 AND <lg_roworcolst> = 'C'.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -112,7 +112,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
 
   METHOD clear_dd03p_fields.
@@ -821,8 +821,13 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
       deserialize_indexes( io_xml ).
 
-      deserialize_texts( io_xml   = io_xml
-                         is_dd02v = ls_dd02v ).
+      IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+        deserialize_texts(
+          io_xml   = io_xml
+          is_dd02v = ls_dd02v ).
+      ELSE.
+        deserialize_lxe_texts( io_xml ).
+      ENDIF.
 
       deserialize_longtexts( ii_xml         = io_xml
                              iv_longtext_id = c_longtext_id_tabl ).
@@ -1051,7 +1056,11 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
     io_xml->add( iv_name = 'DD36M'
                  ig_data = lt_dd36m ).
 
-    serialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      serialize_texts( io_xml ).
+    ELSE.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
     serialize_longtexts( ii_xml         = io_xml
                          iv_longtext_id = c_longtext_id_tabl ).

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -106,7 +106,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_tran IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
 
 
   METHOD add_data.
@@ -765,8 +765,11 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
                            it_authorizations = lt_tstca ).
     ENDIF.
 
-    " Texts deserializing (translations)
-    deserialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      deserialize_texts( io_xml ).
+    ELSE.
+      deserialize_lxe_texts( io_xml ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -892,8 +895,11 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
     io_xml->add( iv_name = 'AUTHORIZATIONS'
                  ig_data = lt_tstca ).
 
-    " Texts serializing (translations)
-    serialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      serialize_texts( io_xml ).
+    ELSE.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -63,7 +63,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -299,8 +299,13 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    deserialize_texts( io_xml   = io_xml
-                       is_dd25v = ls_dd25v ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      deserialize_texts(
+        io_xml   = io_xml
+        is_dd25v = ls_dd25v ).
+    ELSE.
+      deserialize_lxe_texts( io_xml ).
+    ENDIF.
 
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_view ).
@@ -447,7 +452,11 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
     io_xml->add( ig_data = lt_dd28v
                  iv_name = 'DD28V_TABLE' ).
 
-    serialize_texts( io_xml ).
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      serialize_texts( io_xml ).
+    ELSE.
+      serialize_lxe_texts( io_xml ).
+    ENDIF.
 
     serialize_longtexts( ii_xml         = io_xml
                          iv_longtext_id = c_longtext_id_view ).

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -188,7 +188,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
 
   METHOD changed_by.
@@ -595,7 +595,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
           lt_steps_id TYPE zif_abapgit_definitions=>ty_deserialization_step_tt,
           lt_steps    TYPE zif_abapgit_objects=>ty_step_data_tt,
           lx_exc      TYPE REF TO zcx_abapgit_exception.
-    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
+    DATA lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
+    DATA ls_i18n_params TYPE zif_abapgit_definitions=>ty_i18n_params.
 
     FIELD-SYMBOLS: <ls_result>  TYPE zif_abapgit_definitions=>ty_result,
                    <lv_step_id> TYPE LINE OF zif_abapgit_definitions=>ty_deserialization_step_tt,
@@ -635,6 +636,19 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     check_objects_locked( iv_language = io_repo->get_dot_abapgit( )->get_main_language( )
                           it_items    = lt_items ).
+
+    " Determine I18N parameters
+    IF io_repo->get_dot_abapgit( ) IS BOUND.
+      ls_i18n_params-main_language         = io_repo->get_dot_abapgit( )->get_main_language( ).
+      ls_i18n_params-main_language_only    = io_repo->get_local_settings( )-main_language_only.
+      ls_i18n_params-translation_languages = zcl_abapgit_lxe_texts=>get_translation_languages(
+        iv_main_language  = io_repo->get_dot_abapgit( )->get_main_language( )
+        it_i18n_languages = io_repo->get_dot_abapgit( )->get_i18n_languages( ) ).
+    ENDIF.
+
+    IF ls_i18n_params-main_language IS INITIAL.
+      ls_i18n_params-main_language = sy-langu.
+    ENDIF.
 
     IF lines( lt_items ) = 1.
       ii_log->add_info( |>>> Deserializing 1 object| ).
@@ -690,6 +704,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
           IF lo_files->is_json_metadata( ) = abap_false.
             "analyze XML in order to instantiate the proper serializer
             lo_xml = lo_files->read_xml( ).
+            lo_xml->i18n_params( ls_i18n_params ).
             ls_metadata = lo_xml->get_metadata( ).
           ELSE.
             " there's no XML and metadata for JSON format

--- a/src/xml/zcl_abapgit_xml_input.clas.abap
+++ b/src/xml/zcl_abapgit_xml_input.clas.abap
@@ -14,14 +14,18 @@ CLASS zcl_abapgit_xml_input DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
-    METHODS: fix_xml.
+
+    DATA ms_i18n_params TYPE zif_abapgit_definitions=>ty_i18n_params.
+
+    METHODS fix_xml.
 
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_xml_input IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_XML_INPUT IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -56,6 +60,17 @@ CLASS zcl_abapgit_xml_input IMPLEMENTATION.
 
   METHOD zif_abapgit_xml_input~get_raw.
     ri_raw = mi_xml_doc.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_xml_input~i18n_params.
+
+    IF is_i18n_params IS SUPPLIED.
+      ms_i18n_params = is_i18n_params.
+    ENDIF.
+
+    rs_i18n_params = ms_i18n_params.
+
   ENDMETHOD.
 
 

--- a/src/xml/zif_abapgit_xml_input.intf.abap
+++ b/src/xml/zif_abapgit_xml_input.intf.abap
@@ -10,6 +10,12 @@ INTERFACE zif_abapgit_xml_input
   METHODS get_raw
     RETURNING
       VALUE(ri_raw) TYPE REF TO if_ixml_document .
+  METHODS i18n_params
+    IMPORTING
+      !is_i18n_params       TYPE zif_abapgit_definitions=>ty_i18n_params OPTIONAL
+    RETURNING
+      VALUE(rs_i18n_params) TYPE zif_abapgit_definitions=>ty_i18n_params .
+
 * todo, add read_xml to match add_xml in lcl_xml_output
   METHODS get_metadata
     RETURNING


### PR DESCRIPTION
ref: #4415, #4470, #4494, #2539

Extending the work of #4415 to more objects to increase the testing surface for future improvements in this direction.
PARA, TRAN, MSAG, CLAS, TABL, VIEW, SHI3, DTEL, DOMA

Generally should be safe changes, but CLAS could benefit from some testing as the code change there was a bit less trivial. And also a review may be useful for `ZCL_ABAPGIT_OBJECTS->deserialize` - it was certainly a "make it work" piece of code.

`zif_abapgit_xml_input~i18n_params` has the same logic as his `output` counterpart.

Known issue (it was there before) - LXE is not applied to new objects from the first time. This is in plans. This PR is to add support for the feature to more objects only and to find patterns