### PR TITLE
Show performance metrics for long-running ops

### DIFF
--- a/src/inspect/zcl_abapgit_code_inspector.clas.abap
+++ b/src/inspect/zcl_abapgit_code_inspector.clas.abap
@@ -40,6 +40,7 @@ CLASS zcl_abapgit_code_inspector DEFINITION
   PRIVATE SECTION.
 
     DATA mv_success TYPE abap_bool .
+    DATA mv_summary TYPE string.
 
     TYPES: ty_run_mode TYPE c LENGTH 1.
 
@@ -333,6 +334,11 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_code_inspector~get_summary.
+    rv_summary = mv_summary.
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_code_inspector~is_successful.
 
     rv_success = mv_success.
@@ -344,16 +350,20 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
 
     DATA: lo_set     TYPE REF TO cl_ci_objectset,
           lo_variant TYPE REF TO cl_ci_checkvariant,
+          lv_count   TYPE i,
+          lo_timer   TYPE REF TO zcl_abapgit_timer,
           lx_error   TYPE REF TO zcx_abapgit_exception.
-
 
     TRY.
         lo_set = create_objectset( ).
 
-        IF lines( lo_set->iobjlst-objects ) = 0.
+        lv_count = lines( lo_set->iobjlst-objects ).
+        IF lv_count = 0.
           " no objects, nothing to check
           RETURN.
         ENDIF.
+
+        lo_timer = zcl_abapgit_timer=>create( iv_count = lv_count )->start( ).
 
         lo_variant = create_variant( iv_variant ).
 
@@ -377,6 +387,8 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
         zcx_abapgit_exception=>raise_with_text( lx_error ).
 
     ENDTRY.
+
+    mv_summary = lo_timer->end( ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/inspect/zif_abapgit_code_inspector.intf.abap
+++ b/src/inspect/zif_abapgit_code_inspector.intf.abap
@@ -10,7 +10,12 @@ INTERFACE zif_abapgit_code_inspector
       VALUE(rt_list) TYPE scit_alvlist
     RAISING
       zcx_abapgit_exception .
+
   METHODS is_successful
     RETURNING
       VALUE(rv_success) TYPE abap_bool .
+
+  METHODS get_summary
+    RETURNING
+      VALUE(rv_summary) TYPE string.
 ENDINTERFACE.

--- a/src/ui/pages/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page.clas.abap
@@ -37,8 +37,6 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         zcx_abapgit_exception .
   PRIVATE SECTION.
 
-    TYPES: ty_time TYPE p LENGTH 10 DECIMALS 2.
-
     DATA mo_settings TYPE REF TO zcl_abapgit_settings .
     DATA mx_error TYPE REF TO zcx_abapgit_exception .
     DATA mo_exception_viewer TYPE REF TO zcl_abapgit_exception_viewer .
@@ -59,7 +57,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         zcx_abapgit_exception .
     METHODS footer
       IMPORTING
-        !iv_time       TYPE ty_time
+        !iv_time       TYPE string
       RETURNING
         VALUE(ri_html) TYPE REF TO zif_abapgit_html .
     METHODS render_link_hints
@@ -91,7 +89,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -131,7 +129,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
                     iv_txt = ri_html->icon( 'git-alt' ) ).
     ri_html->add_a( iv_act = zif_abapgit_definitions=>c_action-homepage
                     iv_txt = ri_html->icon( iv_name = 'abapgit'
-                                            iv_hint = |{ iv_time } sec| ) ).
+                                            iv_hint = iv_time ) ).
     ri_html->add( '</div>' ).
     ri_html->add( |<div class="version">{ zif_abapgit_version=>c_abap_version }{ lv_version_detail }</div>| ).
     ri_html->add( '</td>' ).
@@ -347,13 +345,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
     DATA:
       li_script TYPE REF TO zif_abapgit_html,
-      lv_start  TYPE i,
-      lv_end    TYPE i,
-      lv_total  TYPE ty_time.
+      lo_timer  TYPE REF TO zcl_abapgit_timer.
 
     register_handlers( ).
 
-    GET RUN TIME FIELD lv_start.
+    lo_timer = zcl_abapgit_timer=>create( )->start( ).
 
     " Real page
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
@@ -376,10 +372,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
       ii_html          = ri_html
       iv_part_category = c_html_parts-hidden_forms ).
 
-    GET RUN TIME FIELD lv_end.
-    lv_total = ( lv_end - lv_start ) / 1000 / 1000.
-
-    ri_html->add( footer( lv_total ) ).
+    ri_html->add( footer( lo_timer->end( ) ) ).
 
     ri_html->add( '</div>' ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -64,7 +64,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
 
 
   METHOD ask_user_for_check_variant.
@@ -173,7 +173,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
 
     register_handlers( ).
 
-    ri_html->add( render_variant( mv_check_variant ) ).
+    ri_html->add( render_variant(
+      iv_variant = mv_check_variant
+      iv_summary = mv_summary ) ).
 
     IF lines( mt_result ) = 0.
       ri_html->add( '<div class="dummydiv success">' ).
@@ -198,6 +200,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
     mt_result = li_code_inspector->run(
       iv_variant = |{ mv_check_variant }|
       iv_save    = abap_true ).
+
+    mv_summary = li_code_inspector->get_summary( ).
 
     DELETE mt_result WHERE kind = 'N'.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -17,10 +17,12 @@ CLASS zcl_abapgit_gui_page_codi_base DEFINITION PUBLIC ABSTRACT INHERITING FROM 
       END OF c_actions .
     DATA mo_repo TYPE REF TO zcl_abapgit_repo .
     DATA mt_result TYPE scit_alvlist .
+    DATA mv_summary TYPE string.
 
     METHODS render_variant
       IMPORTING
         !iv_variant    TYPE sci_chkv
+        !iv_summary    TYPE string
       RETURNING
         VALUE(ri_html) TYPE REF TO zif_abapgit_html .
     METHODS render_result
@@ -277,7 +279,7 @@ CLASS zcl_abapgit_gui_page_codi_base IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->add( '<div class="ci-head">' ).
-    ri_html->add( |Code inspector check variant: <span class="ci-variant">{ iv_variant }</span>| ).
+    ri_html->add( |Code inspector check variant <span class="ci-variant">{ iv_variant }</span> completed ({ iv_summary })| ).
     ri_html->add( `</div>` ).
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_syntax.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_syntax.clas.abap
@@ -37,7 +37,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_syntax IMPLEMENTATION.
 
 
   METHOD build_menu.
@@ -66,7 +66,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
 
     ri_html->add( '<div class="toc">' ).
 
-    ri_html->add( render_variant( c_variant ) ).
+    ri_html->add( render_variant(
+      iv_variant = c_variant
+      iv_summary = mv_summary ) ).
 
     IF lines( mt_result ) = 0.
       ri_html->add( '<div class="dummydiv success">' ).
@@ -93,6 +95,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
         " Variant SYNTAX_CHECK does not exist in 702
         mt_result = li_syntax_check->run( 'VERI_' && c_variant ).
     ENDTRY.
+
+    mv_summary = li_syntax_check->get_summary( ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_timer.clas.abap
+++ b/src/utils/zcl_abapgit_timer.clas.abap
@@ -1,0 +1,102 @@
+CLASS zcl_abapgit_timer DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PRIVATE.
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS create
+      IMPORTING
+        !iv_text        TYPE string OPTIONAL
+        !iv_count       TYPE i OPTIONAL
+          PREFERRED PARAMETER iv_text
+      RETURNING
+        VALUE(ro_timer) TYPE REF TO zcl_abapgit_timer.
+
+    METHODS constructor
+      IMPORTING
+        !iv_text  TYPE string OPTIONAL
+        !iv_count TYPE i OPTIONAL.
+
+    METHODS start
+      RETURNING
+        VALUE(ro_timer) TYPE REF TO zcl_abapgit_timer.
+
+    METHODS end
+      IMPORTING
+        !iv_output_as_status_message TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(rv_result)             TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    DATA mv_text TYPE string.
+    DATA mv_count TYPE i.
+    DATA mv_timer TYPE timestampl.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_timer IMPLEMENTATION.
+
+
+  METHOD constructor.
+    mv_text  = iv_text.
+    mv_count = iv_count.
+  ENDMETHOD.
+
+
+  METHOD create.
+    CREATE OBJECT ro_timer
+      EXPORTING
+        iv_text  = iv_text
+        iv_count = iv_count.
+  ENDMETHOD.
+
+
+  METHOD end.
+
+    DATA:
+      lv_timestamp TYPE timestampl,
+      lv_runtime   TYPE timestampl,
+      lv_sec       TYPE p LENGTH 10 DECIMALS 2.
+
+    GET TIME STAMP FIELD lv_timestamp.
+
+    TRY.
+        lv_runtime = cl_abap_tstmp=>subtract(
+          tstmp1 = lv_timestamp
+          tstmp2 = mv_timer ).
+      CATCH cx_parameter_invalid.
+        rv_result = 'Error getting runtime measurement'.
+        RETURN.
+    ENDTRY.
+
+    lv_sec = lv_runtime. " round to 2 decimal places
+
+    IF mv_count = 1.
+      rv_result = |1 object, |.
+    ELSEIF mv_count > 1.
+      rv_result = |{ mv_count } objects, |.
+    ENDIF.
+
+    rv_result = rv_result && |{ lv_sec } seconds|.
+
+    IF iv_output_as_status_message = abap_true.
+      MESSAGE s000(oo) WITH mv_text rv_result.
+    ENDIF.
+
+    IF mv_text IS NOT INITIAL.
+      rv_result = |{ mv_text } { rv_result }|.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD start.
+    GET TIME STAMP FIELD mv_timer.
+    ro_timer = me.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/utils/zcl_abapgit_timer.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_timer.clas.testclasses.abap
@@ -1,0 +1,81 @@
+CLASS ltcl_test DEFINITION FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+
+    METHODS:
+      check_result
+        IMPORTING
+          iv_result TYPE string
+          iv_regex  TYPE string,
+
+      run_timer FOR TESTING,
+      run_timer_with_count FOR TESTING,
+      run_timer_with_text FOR TESTING.
+
+ENDCLASS.
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD check_result.
+
+    FIND REGEX iv_regex IN iv_result.
+
+    cl_aunit_assert=>assert_subrc(
+      act = sy-subrc
+      msg = 'Did not return right measurement' ).
+
+  ENDMETHOD.
+
+  METHOD run_timer.
+
+    DATA lo_timer TYPE REF TO zcl_abapgit_timer.
+
+    lo_timer = zcl_abapgit_timer=>create( )->start( ).
+
+    WAIT UP TO 1 SECONDS.
+
+    check_result(
+      iv_result = lo_timer->end( )
+      iv_regex  = '1.[0-9][0-9] seconds' ).
+
+  ENDMETHOD.
+
+  METHOD run_timer_with_count.
+
+    DATA lo_timer TYPE REF TO zcl_abapgit_timer.
+
+    lo_timer = zcl_abapgit_timer=>create( iv_count = 1 )->start( ).
+
+    WAIT UP TO 1 SECONDS.
+
+    check_result(
+      iv_result = lo_timer->end( )
+      iv_regex  = '1 object, 1.[0-9][0-9] seconds' ).
+
+    lo_timer = zcl_abapgit_timer=>create( iv_count = 1234 )->start( ).
+
+    WAIT UP TO 1 SECONDS.
+
+    check_result(
+      iv_result = lo_timer->end( )
+      iv_regex  = '1234 objects, 1.[0-9][0-9] seconds' ).
+
+  ENDMETHOD.
+
+  METHOD run_timer_with_text.
+
+    CONSTANTS lc_total TYPE string VALUE 'Total:'.
+
+    DATA lo_timer TYPE REF TO zcl_abapgit_timer.
+
+    lo_timer = zcl_abapgit_timer=>create( lc_total )->start( ).
+
+    WAIT UP TO 1 SECONDS.
+
+    check_result(
+      iv_result = lo_timer->end( )
+      iv_regex  = |{ lc_total } 1.[0-9][0-9] seconds| ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/utils/zcl_abapgit_timer.clas.xml
+++ b/src/utils/zcl_abapgit_timer.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_TIMER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>MBT Timer</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Ref https://github.com/abapGit/abapGit/issues/2727

Adds simple timer utility class which is used to measure runtime for code inspection and syntax check. 

Shows number of objects and runtime: