### PR TITLE
Rename "Repository Overview" to "Repository List"

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -354,7 +354,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
         iv_only_favorites = iv_only_favorites.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
-      iv_page_title         = 'Repository Overview'
+      iv_page_title         = 'Repository List'
       ii_page_menu_provider = lo_component
       ii_child_component    = lo_component ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.xml
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.xml
@@ -5,7 +5,7 @@
    <VSEOCLASS>
     <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_REPO_OVER</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>abapGit - GUI Repository Overview</DESCRIPT>
+    <DESCRIPT>abapGit - GUI Repository List</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>


### PR DESCRIPTION
We call it "Repository List" in most places. This is making the description consistent across AG and in line with SAP lingo (It's a list view, like https://experience.sap.com/fiori-design-web/list-report-floorplan-sap-fiori-element/).

![image](https://user-images.githubusercontent.com/59966492/225120342-f9ee8375-9294-4f6b-86b3-2c823ba04050.png)

Closes https://github.com/abapGit/abapGit/issues/6142