### PR TITLE
USE_LXE settings and serialization of selected languages (in old format)

### DIFF
--- a/src/objects/core/zabapgit_parallel.fugr.xml
+++ b/src/objects/core/zabapgit_parallel.fugr.xml
@@ -116,6 +116,10 @@
        <PARAMETER>IT_TRANSLATION_LANGS</PARAMETER>
        <TYP>TFPLAISO</TYP>
       </RSIMP>
+      <RSIMP>
+       <PARAMETER>IV_USE_LXE</PARAMETER>
+       <TYP>CHAR1</TYP>
+      </RSIMP>
      </IMPORT>
      <EXPORT>
       <RSEXP>
@@ -171,6 +175,11 @@
        <PARAMETER>IT_TRANSLATION_LANGS</PARAMETER>
        <KIND>P</KIND>
        <STEXT>Language Table in ISO Format</STEXT>
+      </RSFDO>
+      <RSFDO>
+       <PARAMETER>IV_USE_LXE</PARAMETER>
+       <KIND>P</KIND>
+       <STEXT>Single-Character Flag</STEXT>
       </RSFDO>
       <RSFDO>
        <PARAMETER>EV_RESULT</PARAMETER>

--- a/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
+++ b/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
@@ -10,6 +10,7 @@ FUNCTION z_abapgit_serialize_parallel.
 *"     VALUE(IV_PATH) TYPE  STRING
 *"     VALUE(IV_MAIN_LANGUAGE_ONLY) TYPE  CHAR1
 *"     VALUE(IT_TRANSLATION_LANGS) TYPE  TFPLAISO
+*"     VALUE(IV_USE_LXE) TYPE  CHAR1
 *"  EXPORTING
 *"     VALUE(EV_RESULT) TYPE  XSTRING
 *"     VALUE(EV_PATH) TYPE  STRING
@@ -31,6 +32,7 @@ FUNCTION z_abapgit_serialize_parallel.
       ls_files = zcl_abapgit_objects=>serialize(
         is_item               = ls_item
         iv_main_language_only = iv_main_language_only
+        iv_use_lxe            = iv_use_lxe
         iv_language           = iv_language
         it_translation_langs  = it_translation_langs ).
 

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
@@ -53,8 +53,16 @@ CLASS zcl_abapgit_lxe_texts DEFINITION
       IMPORTING
         it_iso_filter TYPE zif_abapgit_definitions=>ty_languages
         iv_lang_field_name TYPE abap_compname
+        iv_keep_master_lang TYPE sy-langu OPTIONAL
       CHANGING
         ct_tab TYPE STANDARD TABLE
+      RAISING
+        zcx_abapgit_exception.
+    CLASS-METHODS apply_iso_langs_to_lang_filter
+      IMPORTING
+        it_iso_filter TYPE zif_abapgit_definitions=>ty_languages
+      CHANGING
+        ct_language_filter TYPE zif_abapgit_environment=>ty_system_language_filter
       RAISING
         zcx_abapgit_exception.
 
@@ -136,6 +144,37 @@ ENDCLASS.
 
 
 CLASS ZCL_ABAPGIT_LXE_TEXTS IMPLEMENTATION.
+
+
+  METHOD apply_iso_langs_to_lang_filter.
+
+    DATA lv_laiso LIKE LINE OF it_iso_filter.
+    DATA lv_langu TYPE sy-langu.
+    DATA ls_range LIKE LINE OF ct_language_filter.
+
+    ls_range-sign = 'I'.
+    ls_range-option = 'EQ'.
+
+    LOOP AT it_iso_filter INTO lv_laiso.
+
+      cl_i18n_languages=>sap2_to_sap1(
+        EXPORTING
+          im_lang_sap2  = lv_laiso
+        RECEIVING
+          re_lang_sap1  = lv_langu
+        EXCEPTIONS
+          no_assignment = 1
+          OTHERS        = 2 ).
+      IF sy-subrc <> 0.
+        CONTINUE.
+      ENDIF.
+
+      ls_range-low = lv_langu.
+      APPEND ls_range TO ct_language_filter.
+
+    ENDLOOP.
+
+  ENDMETHOD.
 
 
   METHOD check_langs_versus_installed.
@@ -458,6 +497,10 @@ CLASS ZCL_ABAPGIT_LXE_TEXTS IMPLEMENTATION.
       lv_index = sy-tabix.
       ASSIGN COMPONENT iv_lang_field_name OF STRUCTURE <ls_i> TO <lv_langu>.
       ASSERT sy-subrc = 0.
+
+      IF <lv_langu> = iv_keep_master_lang.
+        CONTINUE. " Just keep it
+      ENDIF.
 
       cl_i18n_languages=>sap1_to_sap2(
         EXPORTING

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
@@ -42,6 +42,14 @@ CLASS zcl_abapgit_lxe_texts DEFINITION
         VALUE(rt_unsupported_languages) TYPE zif_abapgit_definitions=>ty_languages
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS trim_saplangu_by_iso
+      IMPORTING
+        it_iso_filter TYPE zif_abapgit_definitions=>ty_languages
+        it_sap_langs TYPE zif_abapgit_definitions=>ty_sap_langu_tab
+      RETURNING
+        VALUE(rt_filtered_sap_langs) TYPE zif_abapgit_definitions=>ty_sap_langu_tab
+      RAISING
+        zcx_abapgit_exception.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -387,6 +395,38 @@ CLASS ZCL_ABAPGIT_LXE_TEXTS IMPLEMENTATION.
             lt_pcx_s1 = rt_text_pairs_tmp.
 
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD trim_saplangu_by_iso.
+
+    DATA lv_langu TYPE sy-langu.
+    DATA lv_laiso TYPE laiso.
+
+    IF it_iso_filter IS INITIAL.
+      rt_filtered_sap_langs = it_sap_langs.
+      RETURN.
+    ENDIF.
+
+    LOOP AT it_sap_langs INTO lv_langu.
+      cl_i18n_languages=>sap1_to_sap2(
+        EXPORTING
+          im_lang_sap1  = lv_langu
+        RECEIVING
+          re_lang_sap2  = lv_laiso
+        EXCEPTIONS
+          no_assignment = 1
+          OTHERS        = 2 ).
+      IF sy-subrc <> 0.
+        CONTINUE.
+      ENDIF.
+
+      READ TABLE it_iso_filter TRANSPORTING NO FIELDS WITH KEY table_line = lv_laiso.
+      IF sy-subrc = 0.
+        APPEND lv_langu TO rt_filtered_sap_langs.
+      ENDIF.
+    ENDLOOP.
 
   ENDMETHOD.
 

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
@@ -58,7 +58,7 @@ CLASS zcl_abapgit_lxe_texts DEFINITION
         ct_tab TYPE STANDARD TABLE
       RAISING
         zcx_abapgit_exception.
-    CLASS-METHODS apply_iso_langs_to_lang_filter
+    CLASS-METHODS add_iso_langs_to_lang_filter
       IMPORTING
         it_iso_filter TYPE zif_abapgit_definitions=>ty_languages
       CHANGING
@@ -146,7 +146,7 @@ ENDCLASS.
 CLASS ZCL_ABAPGIT_LXE_TEXTS IMPLEMENTATION.
 
 
-  METHOD apply_iso_langs_to_lang_filter.
+  METHOD add_iso_langs_to_lang_filter.
 
     DATA lv_laiso LIKE LINE OF it_iso_filter.
     DATA lv_langu TYPE sy-langu.

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.testclasses.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.testclasses.abap
@@ -2,6 +2,7 @@ CLASS ltcl_lxe_texts DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 
   PRIVATE SECTION.
     METHODS:
+      filter_sap_langs FOR TESTING RAISING zcx_abapgit_exception,
       check_langs_versus_installed FOR TESTING RAISING zcx_abapgit_exception,
       lang_string_to_table FOR TESTING,
       table_to_lang_string FOR TESTING.
@@ -126,6 +127,47 @@ CLASS ltcl_lxe_texts IMPLEMENTATION.
       CATCH zcx_abapgit_exception.
         cl_abap_unit_assert=>fail( ).
     ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD filter_sap_langs.
+
+    DATA lt_act TYPE zif_abapgit_definitions=>ty_sap_langu_tab.
+    DATA lt_exp TYPE zif_abapgit_definitions=>ty_sap_langu_tab.
+    DATA lt_filter TYPE zif_abapgit_definitions=>ty_languages.
+
+    APPEND 'E' TO lt_act.
+    APPEND 'D' TO lt_act.
+    APPEND 'S' TO lt_act.
+
+    APPEND 'DE' TO lt_filter.
+    APPEND 'EN' TO lt_filter.
+
+    APPEND 'E' TO lt_exp.
+    APPEND 'D' TO lt_exp.
+
+    lt_act = zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      it_iso_filter = lt_filter
+      it_sap_langs  = lt_act ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lt_exp ).
+
+    CLEAR: lt_act, lt_exp, lt_filter. " Empty filter
+    APPEND 'E' TO lt_act.
+    APPEND 'D' TO lt_act.
+
+    APPEND 'E' TO lt_exp.
+    APPEND 'D' TO lt_exp.
+
+    lt_act = zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      it_iso_filter = lt_filter
+      it_sap_langs  = lt_act ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lt_exp ).
 
   ENDMETHOD.
 

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.testclasses.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.testclasses.abap
@@ -3,6 +3,7 @@ CLASS ltcl_lxe_texts DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
     METHODS:
       filter_sap_langs FOR TESTING RAISING zcx_abapgit_exception,
+      filter_sap_langs_tab FOR TESTING RAISING zcx_abapgit_exception,
       check_langs_versus_installed FOR TESTING RAISING zcx_abapgit_exception,
       lang_string_to_table FOR TESTING,
       table_to_lang_string FOR TESTING.
@@ -136,19 +137,21 @@ CLASS ltcl_lxe_texts IMPLEMENTATION.
     DATA lt_exp TYPE zif_abapgit_definitions=>ty_sap_langu_tab.
     DATA lt_filter TYPE zif_abapgit_definitions=>ty_languages.
 
+    APPEND 'DE' TO lt_filter.
+    APPEND 'EN' TO lt_filter.
+
     APPEND 'E' TO lt_act.
     APPEND 'D' TO lt_act.
     APPEND 'S' TO lt_act.
 
-    APPEND 'DE' TO lt_filter.
-    APPEND 'EN' TO lt_filter.
-
     APPEND 'E' TO lt_exp.
     APPEND 'D' TO lt_exp.
 
-    lt_act = zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      it_iso_filter = lt_filter
-      it_sap_langs  = lt_act ).
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = lt_filter
+      CHANGING
+        ct_sap_langs  = lt_act ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lt_act
@@ -161,9 +164,75 @@ CLASS ltcl_lxe_texts IMPLEMENTATION.
     APPEND 'E' TO lt_exp.
     APPEND 'D' TO lt_exp.
 
-    lt_act = zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      it_iso_filter = lt_filter
-      it_sap_langs  = lt_act ).
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = lt_filter
+      CHANGING
+        ct_sap_langs  = lt_act ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lt_exp ).
+
+  ENDMETHOD.
+
+  METHOD filter_sap_langs_tab.
+
+    DATA:
+      BEGIN OF ls_i,
+        spras TYPE sy-langu,
+        stuff TYPE string,
+      END OF ls_i.
+
+    DATA lt_act LIKE TABLE OF ls_i.
+    DATA lt_exp LIKE TABLE OF ls_i.
+    DATA lt_filter TYPE zif_abapgit_definitions=>ty_languages.
+
+    APPEND 'DE' TO lt_filter.
+    APPEND 'EN' TO lt_filter.
+
+    ls_i-spras = 'E'.
+    APPEND ls_i TO lt_act.
+    ls_i-spras = 'D'.
+    APPEND ls_i TO lt_act.
+    ls_i-spras = 'S'.
+    APPEND ls_i TO lt_act.
+
+    ls_i-spras = 'E'.
+    APPEND ls_i TO lt_exp.
+    ls_i-spras = 'D'.
+    APPEND ls_i TO lt_exp.
+
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = lt_filter
+        iv_lang_field_name = 'SPRAS'
+      CHANGING
+        ct_tab = lt_act ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lt_exp ).
+
+    CLEAR: lt_act, lt_exp, lt_filter. " Empty filter
+    ls_i-spras = 'E'.
+    APPEND ls_i TO lt_act.
+    ls_i-spras = 'D'.
+    APPEND ls_i TO lt_act.
+    ls_i-spras = 'S'.
+    APPEND ls_i TO lt_act.
+
+    ls_i-spras = 'E'.
+    APPEND ls_i TO lt_exp.
+    ls_i-spras = 'D'.
+    APPEND ls_i TO lt_exp.
+
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = lt_filter
+        iv_lang_field_name = 'SPRAS'
+      CHANGING
+        ct_tab = lt_act ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lt_act

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.testclasses.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.testclasses.abap
@@ -280,7 +280,7 @@ CLASS ltcl_lxe_texts IMPLEMENTATION.
     ls_range-low    = 'D'.
     APPEND ls_range TO lt_exp.
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING
         it_iso_filter = lt_filter
       CHANGING

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -689,7 +689,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
       ii_xml     = ii_xml
       iv_clsname = ls_clskey-clsname ).
 
-    IF ii_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF ii_xml->i18n_params( )-translation_languages IS INITIAL OR ii_xml->i18n_params( )-use_lxe = abap_false.
       serialize_tpool_i18n(
         ii_xml              = ii_xml
         it_langu_additional = lt_langu_additional
@@ -807,7 +807,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
       deserialize_tpool( io_xml ).
 
-      IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
         deserialize_tpool_i18n( io_xml ).
       ELSE.
         deserialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -674,6 +674,11 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
     " Select all active translations of program texts
     " Skip main language - it was already serialized
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT language
       INTO TABLE lt_langu_additional
       FROM d010tinf

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -353,6 +353,13 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'I18N_TPOOL'
                   CHANGING  cg_data = lt_i18n_tpool ).
 
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'LANGUAGE'
+      CHANGING
+        ct_tab = lt_i18n_tpool ).
+
     LOOP AT lt_i18n_tpool INTO ls_i18n_tpool.
       lt_tpool = read_tpool( ls_i18n_tpool-textpool ).
       mi_object_oriented_object_fct->insert_text_pool(

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -243,9 +243,11 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
     SORT lt_i18n_langs.
     DELETE ADJACENT DUPLICATES FROM lt_i18n_langs.
 
-    lt_i18n_langs = zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      it_sap_langs = lt_i18n_langs
-      it_iso_filter = ii_xml->i18n_params( )-translation_languages ).
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING
+        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -243,6 +243,10 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
     SORT lt_i18n_langs.
     DELETE ADJACENT DUPLICATES FROM lt_i18n_langs.
 
+    lt_i18n_langs = zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      it_sap_langs = lt_i18n_langs
+      it_iso_filter = ii_xml->i18n_params( )-translation_languages ).
+
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.
 

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -386,7 +386,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       deserialize_texts(
         ii_xml   = io_xml
         is_dd01v = ls_dd01v
@@ -509,7 +509,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
     io_xml->add( iv_name = 'DD07V_TAB'
                  ig_data = lt_dd07v ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       serialize_texts(
         ii_xml   = io_xml
         it_dd07v = lt_dd07v ).

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -229,7 +229,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
       CHANGING  ct_language_filter = lt_language_filter ).
 

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -228,6 +228,11 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
 
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT ddlanguage AS langu INTO TABLE lt_i18n_langs
       FROM dd01v
       WHERE domname = lv_name
@@ -242,12 +247,6 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
 
     SORT lt_i18n_langs.
     DELETE ADJACENT DUPLICATES FROM lt_i18n_langs.
-
-    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      EXPORTING
-        it_iso_filter = ii_xml->i18n_params( )-translation_languages
-      CHANGING
-        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -130,6 +130,10 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'DD07_TEXTS'
                   CHANGING  cg_data = lt_dd07_texts ).
 
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING ct_sap_langs   = lt_i18n_langs ).
+
     SORT lt_i18n_langs.
     SORT lt_dd07_texts BY ddlanguage. " Optimization
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -109,7 +109,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
       CHANGING  ct_language_filter = lt_language_filter ).
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -204,7 +204,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       deserialize_texts(
         ii_xml   = io_xml
         is_dd04v = ls_dd04v ).
@@ -331,7 +331,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
     io_xml->add( iv_name = 'DD04V'
                  ig_data = ls_dd04v ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       serialize_texts( io_xml ).
     ELSE.
       serialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -108,17 +108,16 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
 
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT ddlanguage AS langu INTO TABLE lt_i18n_langs
       FROM dd04v
       WHERE rollname = lv_name
       AND ddlanguage IN lt_language_filter
       AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
-
-    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      EXPORTING
-        it_iso_filter = ii_xml->i18n_params( )-translation_languages
-      CHANGING
-        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -114,6 +114,12 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
       AND ddlanguage IN lt_language_filter
       AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
 
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING
+        ct_sap_langs = lt_i18n_langs ).
+
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.
       CALL FUNCTION 'DDIF_DTEL_GET'

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -57,6 +57,10 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'DD04_TEXTS'
                   CHANGING  cg_data = lt_dd04_texts ).
 
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING ct_sap_langs   = lt_i18n_langs ).
+
     SORT lt_i18n_langs.
     SORT lt_dd04_texts BY ddlanguage. " Optimization
 

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -161,7 +161,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
 
   METHOD check_rfc_parameters.
@@ -1305,7 +1305,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     lv_program_name = main_name( ).
     ls_progdir = read_progdir( lv_program_name ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       " Old I18N option
       serialize_texts( iv_prog_name = lv_program_name
                        ii_xml       = io_xml ).

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -983,6 +983,13 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
       AND prog = iv_prog_name
       AND language <> mv_language ##TOO_MANY_ITAB_FIELDS.
 
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'LANGUAGE'
+      CHANGING
+        ct_tab = lt_tpool_i18n ).
+
     SORT lt_tpool_i18n BY language ASCENDING.
     LOOP AT lt_tpool_i18n ASSIGNING <ls_tpool>.
       READ TEXTPOOL iv_prog_name
@@ -1306,11 +1313,10 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
     ls_progdir = read_progdir( lv_program_name ).
 
     IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
-      " Old I18N option
-      serialize_texts( iv_prog_name = lv_program_name
-                       ii_xml       = io_xml ).
+      serialize_texts(
+        iv_prog_name = lv_program_name
+        ii_xml       = io_xml ).
     ELSE.
-      " New LXE option
       serialize_lxe_texts( io_xml ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -130,6 +130,19 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'T100T'
                   CHANGING  cg_data = lt_t100t ).
 
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRSL'
+      CHANGING
+        ct_tab = lt_t100_texts ).
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRSL'
+      CHANGING
+        ct_tab = lt_t100t ).
+
     MODIFY t100t FROM TABLE lt_t100t.                     "#EC CI_SUBRC
 
     LOOP AT lt_t100_texts ASSIGNING <ls_t100_text>.

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -235,10 +235,17 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
 
     SORT lt_i18n_langs ASCENDING.
 
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING
+        ct_sap_langs = lt_i18n_langs ).
+
     IF lines( lt_i18n_langs ) > 0.
 
       SELECT * FROM t100t INTO CORRESPONDING FIELDS OF TABLE lt_t100t
-        WHERE sprsl <> mv_language
+        FOR ALL ENTRIES IN lt_i18n_langs
+        WHERE sprsl = lt_i18n_langs-table_line
         AND arbgb = lv_msg_id.                          "#EC CI_GENBUFF
 
       SELECT * FROM t100 INTO CORRESPONDING FIELDS OF TABLE lt_t100_texts

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -407,7 +407,7 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_msag ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       deserialize_texts( io_xml ).
     ELSE.
       deserialize_lxe_texts( io_xml ).
@@ -500,7 +500,7 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
     serialize_longtexts_msag( it_t100 = lt_source
                               ii_xml  = io_xml ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       serialize_texts( io_xml ).
     ELSE.
       serialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -228,7 +228,7 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
     " Skip main lang - it has been already serialized and also technical languages
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
       CHANGING  ct_language_filter = lt_language_filter ).
 

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -227,6 +227,11 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
     " Collect additional languages
     " Skip main lang - it has been already serialized and also technical languages
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT sprsl AS langu INTO TABLE lt_i18n_langs
       FROM t100t
       WHERE arbgb = lv_msg_id
@@ -235,22 +240,16 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
 
     SORT lt_i18n_langs ASCENDING.
 
-    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      EXPORTING
-        it_iso_filter = ii_xml->i18n_params( )-translation_languages
-      CHANGING
-        ct_sap_langs = lt_i18n_langs ).
-
     IF lines( lt_i18n_langs ) > 0.
 
       SELECT * FROM t100t INTO CORRESPONDING FIELDS OF TABLE lt_t100t
-        FOR ALL ENTRIES IN lt_i18n_langs
-        WHERE sprsl = lt_i18n_langs-table_line
+*        FOR ALL ENTRIES IN lt_i18n_langs
+        WHERE sprsl IN lt_language_filter " = lt_i18n_langs-table_line
         AND arbgb = lv_msg_id.                          "#EC CI_GENBUFF
 
       SELECT * FROM t100 INTO CORRESPONDING FIELDS OF TABLE lt_t100_texts
-        FOR ALL ENTRIES IN lt_i18n_langs
-        WHERE sprsl = lt_i18n_langs-table_line
+*        FOR ALL ENTRIES IN lt_i18n_langs
+        WHERE sprsl IN lt_language_filter " = lt_i18n_langs-table_line
         AND arbgb = lv_msg_id
         ORDER BY PRIMARY KEY.             "#EC CI_SUBRC "#EC CI_GENBUFF
 

--- a/src/objects/zcl_abapgit_object_para.clas.abap
+++ b/src/objects/zcl_abapgit_object_para.clas.abap
@@ -160,7 +160,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PARA IMPLEMENTATION.
     MODIFY tparat FROM ls_tparat.                         "#EC CI_SUBRC
     ASSERT sy-subrc = 0.
 
-    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL AND io_xml->i18n_params( )-use_lxe = abap_true.
       deserialize_lxe_texts( io_xml ).
     ENDIF.
 
@@ -242,7 +242,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PARA IMPLEMENTATION.
     " Here only the original language is serialized,
     " so it should be present for the moment. LXEs are just translations
 
-    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL AND io_xml->i18n_params( )-use_lxe = abap_true.
       serialize_lxe_texts( io_xml ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -125,7 +125,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
     " Skip main language - it was already serialized
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
       CHANGING  ct_language_filter = lt_language_filter ).
 

--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -124,6 +124,11 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
     " Select all active translations of program texts
     " Skip main language - it was already serialized
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT language
       INTO CORRESPONDING FIELDS OF TABLE lt_tpool_i18n
       FROM d010tinf
@@ -332,10 +337,8 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
 
     " Texts serializing (translations)
     IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
-      " Old I18N option
       serialize_texts( io_xml ).
     ELSE.
-      " New LXE option
       serialize_lxe_texts( io_xml ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -40,7 +40,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_prog IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -331,7 +331,7 @@ CLASS zcl_abapgit_object_prog IMPLEMENTATION.
                        io_files = zif_abapgit_object~mo_files ).
 
     " Texts serializing (translations)
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       " Old I18N option
       serialize_texts( io_xml ).
     ELSE.

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -315,7 +315,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
       MODIFY ttree FROM ls_ttree.
     ENDIF.
 
-    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL AND io_xml->i18n_params( )-use_lxe = abap_true.
       deserialize_lxe_texts( io_xml ).
     ENDIF.
 
@@ -418,7 +418,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
 
 
     IF io_xml->i18n_params( )-main_language_only = abap_true
-      OR io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+      OR io_xml->i18n_params( )-translation_languages IS NOT INITIAL AND io_xml->i18n_params( )-use_lxe = abap_true.
       lv_all_languages = abap_false.
       DELETE lt_titles WHERE spras <> mv_language.
     ELSE.
@@ -458,7 +458,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
     io_xml->add( iv_name = 'TREE_TEXTS'
                  ig_data = lt_texts ).
 
-    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS NOT INITIAL AND io_xml->i18n_params( )-use_lxe = abap_true.
       serialize_lxe_texts( io_xml ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -416,13 +416,19 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
       TABLES
         description      = lt_titles.
 
-
     IF io_xml->i18n_params( )-main_language_only = abap_true
       OR io_xml->i18n_params( )-translation_languages IS NOT INITIAL AND io_xml->i18n_params( )-use_lxe = abap_true.
       lv_all_languages = abap_false.
       DELETE lt_titles WHERE spras <> mv_language.
     ELSE.
       lv_all_languages = abap_true.
+      zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+        EXPORTING
+          it_iso_filter = io_xml->i18n_params( )-translation_languages
+          iv_lang_field_name = 'SPRAS'
+          iv_keep_master_lang = mv_language
+        CHANGING
+          ct_tab = lt_titles ).
     ENDIF.
 
     CALL FUNCTION 'STREE_HIERARCHY_READ'
@@ -446,6 +452,14 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
 
     SORT lt_texts BY spras.
     DELETE ADJACENT DUPLICATES FROM lt_texts COMPARING spras node_id.
+
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = io_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRAS'
+        iv_keep_master_lang = mv_language
+      CHANGING
+        ct_tab = lt_texts ).
 
     io_xml->add( iv_name = 'TREE_HEAD'
                  ig_data = ls_head ).

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -275,6 +275,19 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'TREE_TEXTS'
                   CHANGING  cg_data = lt_texts ).
 
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = io_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRAS'
+      CHANGING
+        ct_tab = lt_titles ).
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = io_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRAS'
+      CHANGING
+        ct_tab = lt_texts ).
+
     IF zif_abapgit_object~exists( ) = abap_true.
       delete_tree_structure( mv_tree_id ).
     ENDIF.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -555,17 +555,16 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT ddlanguage AS langu INTO TABLE lt_i18n_langs
       FROM dd02v
       WHERE tabname = lv_name
       AND ddlanguage IN lt_language_filter
       AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
-
-    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      EXPORTING
-        it_iso_filter = ii_xml->i18n_params( )-translation_languages
-      CHANGING
-        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -821,7 +821,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
       deserialize_indexes( io_xml ).
 
-      IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+      IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
         deserialize_texts(
           io_xml   = io_xml
           is_dd02v = ls_dd02v ).
@@ -1056,7 +1056,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     io_xml->add( iv_name = 'DD36M'
                  ig_data = lt_dd36m ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       serialize_texts( io_xml ).
     ELSE.
       serialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -556,7 +556,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
       CHANGING  ct_language_filter = lt_language_filter ).
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -99,7 +99,7 @@ CLASS zcl_abapgit_object_tabl DEFINITION
         zcx_abapgit_exception .
     METHODS deserialize_texts
       IMPORTING
-        !io_xml   TYPE REF TO zif_abapgit_xml_input
+        !ii_xml   TYPE REF TO zif_abapgit_xml_input
         !is_dd02v TYPE dd02v
       RAISING
         zcx_abapgit_exception .
@@ -402,11 +402,15 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
     lv_name = ms_item-obj_name.
 
-    io_xml->read( EXPORTING iv_name = 'I18N_LANGS'
+    ii_xml->read( EXPORTING iv_name = 'I18N_LANGS'
                   CHANGING  cg_data = lt_i18n_langs ).
 
-    io_xml->read( EXPORTING iv_name = 'DD02_TEXTS'
+    ii_xml->read( EXPORTING iv_name = 'DD02_TEXTS'
                   CHANGING  cg_data = lt_dd02_texts ).
+
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING ct_sap_langs   = lt_i18n_langs ).
 
     SORT lt_i18n_langs.
     SORT lt_dd02_texts BY ddlanguage. " Optimization
@@ -828,7 +832,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
       IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
         deserialize_texts(
-          io_xml   = io_xml
+          ii_xml   = io_xml
           is_dd02v = ls_dd02v ).
       ELSE.
         deserialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -94,7 +94,7 @@ CLASS zcl_abapgit_object_tabl DEFINITION
         !cs_dd03p TYPE dd03p .
     METHODS serialize_texts
       IMPORTING
-        !io_xml TYPE REF TO zif_abapgit_xml_output
+        !ii_xml TYPE REF TO zif_abapgit_xml_output
       RAISING
         zcx_abapgit_exception .
     METHODS deserialize_texts
@@ -547,7 +547,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     FIELD-SYMBOLS: <lv_lang>      LIKE LINE OF lt_i18n_langs,
                    <ls_dd02_text> LIKE LINE OF lt_dd02_texts.
 
-    IF io_xml->i18n_params( )-main_language_only = abap_true.
+    IF ii_xml->i18n_params( )-main_language_only = abap_true.
       RETURN.
     ENDIF.
 
@@ -560,6 +560,12 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       WHERE tabname = lv_name
       AND ddlanguage IN lt_language_filter
       AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
+
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING
+        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.
@@ -586,10 +592,10 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     SORT lt_dd02_texts BY ddlanguage ASCENDING.
 
     IF lines( lt_i18n_langs ) > 0.
-      io_xml->add( iv_name = 'I18N_LANGS'
+      ii_xml->add( iv_name = 'I18N_LANGS'
                    ig_data = lt_i18n_langs ).
 
-      io_xml->add( iv_name = 'DD02_TEXTS'
+      ii_xml->add( iv_name = 'DD02_TEXTS'
                    ig_data = lt_dd02_texts ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -765,7 +765,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
                            it_authorizations = lt_tstca ).
     ENDIF.
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       deserialize_texts( io_xml ).
     ELSE.
       deserialize_lxe_texts( io_xml ).
@@ -895,7 +895,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
     io_xml->add( iv_name = 'AUTHORIZATIONS'
                  ig_data = lt_tstca ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       serialize_texts( io_xml ).
     ELSE.
       serialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -81,7 +81,7 @@ CLASS zcl_abapgit_object_tran DEFINITION
         zcx_abapgit_exception .
     METHODS deserialize_texts
       IMPORTING
-        !io_xml TYPE REF TO zif_abapgit_xml_input
+        !ii_xml TYPE REF TO zif_abapgit_xml_input
       RAISING
         zcx_abapgit_exception .
     METHODS deserialize_oo_transaction
@@ -346,10 +346,16 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_tpool> LIKE LINE OF lt_tpool_i18n.
 
-
     " Read XML-files data
-    io_xml->read( EXPORTING iv_name = 'I18N_TPOOL'
+    ii_xml->read( EXPORTING iv_name = 'I18N_TPOOL'
                   CHANGING  cg_data = lt_tpool_i18n ).
+
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRSL'
+      CHANGING
+        ct_tab = lt_tpool_i18n ).
 
     " Force t-code name (security reasons)
     LOOP AT lt_tpool_i18n ASSIGNING <ls_tpool>.

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -76,7 +76,7 @@ CLASS zcl_abapgit_object_tran DEFINITION
         !cg_value TYPE any .
     METHODS serialize_texts
       IMPORTING
-        !io_xml TYPE REF TO zif_abapgit_xml_output
+        !ii_xml TYPE REF TO zif_abapgit_xml_output
       RAISING
         zcx_abapgit_exception .
     METHODS deserialize_texts
@@ -396,7 +396,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
 
     DATA lt_tpool_i18n TYPE TABLE OF tstct.
 
-    IF io_xml->i18n_params( )-main_language_only = abap_true.
+    IF ii_xml->i18n_params( )-main_language_only = abap_true.
       RETURN.
     ENDIF.
 
@@ -408,9 +408,16 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
       WHERE sprsl <> mv_language
       AND   tcode = ms_item-obj_name ##TOO_MANY_ITAB_FIELDS. "#EC CI_GENBUFF
 
+    zcl_abapgit_lxe_texts=>trim_tab_w_saplang_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+        iv_lang_field_name = 'SPRSL'
+      CHANGING
+        ct_tab = lt_tpool_i18n ).
+
     IF lines( lt_tpool_i18n ) > 0.
       SORT lt_tpool_i18n BY sprsl ASCENDING.
-      io_xml->add( iv_name = 'I18N_TPOOL'
+      ii_xml->add( iv_name = 'I18N_TPOOL'
                    ig_data = lt_tpool_i18n ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -54,7 +54,7 @@ CLASS zcl_abapgit_object_view DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
       deserialize_texts
         IMPORTING
-          io_xml   TYPE REF TO zif_abapgit_xml_input
+          ii_xml   TYPE REF TO zif_abapgit_xml_input
           is_dd25v TYPE dd25v
         RAISING
           zcx_abapgit_exception.
@@ -80,11 +80,15 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
 
     lv_name = ms_item-obj_name.
 
-    io_xml->read( EXPORTING iv_name = 'I18N_LANGS'
+    ii_xml->read( EXPORTING iv_name = 'I18N_LANGS'
                   CHANGING  cg_data = lt_i18n_langs ).
 
-    io_xml->read( EXPORTING iv_name = 'DD25_TEXTS'
+    ii_xml->read( EXPORTING iv_name = 'DD25_TEXTS'
                   CHANGING  cg_data = lt_dd25_texts ).
+
+   zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING ct_sap_langs   = lt_i18n_langs ).
 
     SORT lt_i18n_langs.
     SORT lt_dd25_texts BY ddlanguage.
@@ -306,7 +310,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
 
     IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       deserialize_texts(
-        io_xml   = io_xml
+        ii_xml   = io_xml
         is_dd25v = ls_dd25v ).
     ELSE.
       deserialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -168,7 +168,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
 
-    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+    zcl_abapgit_lxe_texts=>add_iso_langs_to_lang_filter(
       EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
       CHANGING  ct_language_filter = lt_language_filter ).
 

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -86,7 +86,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
     ii_xml->read( EXPORTING iv_name = 'DD25_TEXTS'
                   CHANGING  cg_data = lt_dd25_texts ).
 
-   zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
       EXPORTING it_iso_filter = ii_xml->i18n_params( )-translation_languages
       CHANGING ct_sap_langs   = lt_i18n_langs ).
 

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -167,17 +167,16 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
 
     " Collect additional languages, skip main lang - it was serialized already
     lt_language_filter = zcl_abapgit_factory=>get_environment( )->get_system_language_filter( ).
+
+    zcl_abapgit_lxe_texts=>apply_iso_langs_to_lang_filter(
+      EXPORTING it_iso_filter      = ii_xml->i18n_params( )-translation_languages
+      CHANGING  ct_language_filter = lt_language_filter ).
+
     SELECT DISTINCT ddlanguage AS langu INTO TABLE lt_i18n_langs
       FROM dd25v
       WHERE viewname = ms_item-obj_name
       AND ddlanguage IN lt_language_filter
       AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
-
-    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
-      EXPORTING
-        it_iso_filter = ii_xml->i18n_params( )-translation_languages
-      CHANGING
-        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -48,7 +48,7 @@ CLASS zcl_abapgit_object_view DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
       serialize_texts
         IMPORTING
-          io_xml TYPE REF TO zif_abapgit_xml_output
+          ii_xml TYPE REF TO zif_abapgit_xml_output
         RAISING
           zcx_abapgit_exception,
 
@@ -161,7 +161,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
       <lv_lang>      LIKE LINE OF lt_i18n_langs,
       <ls_dd25_text> LIKE LINE OF lt_dd25_texts.
 
-    IF io_xml->i18n_params( )-main_language_only = abap_true.
+    IF ii_xml->i18n_params( )-main_language_only = abap_true.
       RETURN.
     ENDIF.
 
@@ -172,6 +172,12 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
       WHERE viewname = ms_item-obj_name
       AND ddlanguage IN lt_language_filter
       AND ddlanguage <> mv_language.                      "#EC CI_SUBRC
+
+    zcl_abapgit_lxe_texts=>trim_saplangu_by_iso(
+      EXPORTING
+        it_iso_filter = ii_xml->i18n_params( )-translation_languages
+      CHANGING
+        ct_sap_langs = lt_i18n_langs ).
 
     LOOP AT lt_i18n_langs ASSIGNING <lv_lang>.
       lv_index = sy-tabix.
@@ -202,10 +208,10 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
     SORT lt_dd25_texts BY ddlanguage ASCENDING.
 
     IF lines( lt_i18n_langs ) > 0.
-      io_xml->add( iv_name = 'I18N_LANGS'
+      ii_xml->add( iv_name = 'I18N_LANGS'
                    ig_data = lt_i18n_langs ).
 
-      io_xml->add( iv_name = 'DD25_TEXTS'
+      ii_xml->add( iv_name = 'DD25_TEXTS'
                    ig_data = lt_dd25_texts ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -299,7 +299,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       deserialize_texts(
         io_xml   = io_xml
         is_dd25v = ls_dd25v ).
@@ -452,7 +452,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VIEW IMPLEMENTATION.
     io_xml->add( ig_data = lt_dd28v
                  iv_name = 'DD28V_TABLE' ).
 
-    IF io_xml->i18n_params( )-translation_languages IS INITIAL.
+    IF io_xml->i18n_params( )-translation_languages IS INITIAL OR io_xml->i18n_params( )-use_lxe = abap_false.
       serialize_texts( io_xml ).
     ELSE.
       serialize_lxe_texts( io_xml ).

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -18,6 +18,7 @@ CLASS zcl_abapgit_objects DEFINITION
         !iv_language             TYPE spras
         !iv_main_language_only   TYPE abap_bool DEFAULT abap_false
         !it_translation_langs    TYPE zif_abapgit_definitions=>ty_languages OPTIONAL
+        !iv_use_lxe              TYPE abap_bool DEFAULT abap_false
       RETURNING
         VALUE(rs_files_and_item) TYPE ty_serialization
       RAISING
@@ -196,7 +197,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
 
   METHOD changed_by.
@@ -867,8 +868,11 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
   METHOD determine_i18n_params.
 
+    " TODO: unify with ZCL_ABAPGIT_SERIALIZE=>DETERMINE_I18N_PARAMS, same code
+
     IF io_dot IS BOUND.
       rs_i18n_params-main_language         = io_dot->get_main_language( ).
+      rs_i18n_params-use_lxe               = io_dot->use_lxe( ).
       rs_i18n_params-main_language_only    = iv_main_language_only.
       rs_i18n_params-translation_languages = zcl_abapgit_lxe_texts=>get_translation_languages(
         iv_main_language  = io_dot->get_main_language( )
@@ -1116,6 +1120,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     ls_i18n_params-main_language         = iv_language.
     ls_i18n_params-main_language_only    = iv_main_language_only.
     ls_i18n_params-translation_languages = it_translation_langs.
+    ls_i18n_params-use_lxe               = iv_use_lxe.
 
     li_xml->i18n_params( ls_i18n_params ).
 

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -94,7 +94,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects_super IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -303,6 +303,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
   METHOD serialize_lxe_texts.
 
     IF ii_xml->i18n_params( )-main_language_only = abap_true OR
+       ii_xml->i18n_params( )-use_lxe = abap_false OR
        ii_xml->i18n_params( )-translation_languages IS INITIAL.
       RETURN.
     ENDIF.

--- a/src/repo/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/repo/zcl_abapgit_dot_abapgit.clas.abap
@@ -74,6 +74,11 @@ CLASS zcl_abapgit_dot_abapgit DEFINITION
         VALUE(rs_signature) TYPE zif_abapgit_git_definitions=>ty_file_signature
       RAISING
         zcx_abapgit_exception .
+    METHODS use_lxe
+      IMPORTING
+        iv_yes TYPE abap_bool DEFAULT abap_undefined
+      RETURNING
+        VALUE(rv_yes) TYPE abap_bool.
     METHODS get_requirements
       RETURNING
         VALUE(rt_requirements) TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt .
@@ -101,7 +106,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
 
 
   METHOD add_ignore.
@@ -337,6 +342,17 @@ CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
       IN rv_xml
       WITH '<?xml version="1.0" encoding="utf-8"?>'.
     ASSERT sy-subrc = 0.
+
+  ENDMETHOD.
+
+
+  METHOD use_lxe.
+
+    IF iv_yes <> abap_undefined.
+      ms_data-use_lxe = iv_yes.
+    ENDIF.
+
+    rv_yes = ms_data-use_lxe.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/repo/zif_abapgit_dot_abapgit.intf.abap
+++ b/src/repo/zif_abapgit_dot_abapgit.intf.abap
@@ -13,6 +13,7 @@ INTERFACE zif_abapgit_dot_abapgit PUBLIC.
     BEGIN OF ty_dot_abapgit,
       master_language              TYPE spras,
       i18n_languages               TYPE zif_abapgit_definitions=>ty_languages,
+      use_lxe                      TYPE abap_bool,
       starting_folder              TYPE string,
       folder_logic                 TYPE string,
       ignore                       TYPE STANDARD TABLE OF string WITH DEFAULT KEY,

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -30,6 +30,7 @@ CLASS zcl_abapgit_gui_page_sett_repo DEFINITION
         dot              TYPE string VALUE 'dot',
         main_language    TYPE string VALUE 'main_language',
         i18n_langs       TYPE string VALUE 'i18n_langs',
+        use_lxe          TYPE string VALUE 'use_lxe',
         starting_folder  TYPE string VALUE 'starting_folder',
         folder_logic     TYPE string VALUE 'folder_logic',
         ignore           TYPE string VALUE 'ignore',
@@ -125,8 +126,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       iv_readonly    = abap_true
     )->text(
       iv_name        = c_id-i18n_langs
-      iv_label       = 'Serialize Translations (experimental LXE approach)'
+      iv_label       = 'Serialize Translations for these languages'
       iv_hint        = 'Comma-separate 2-letter ISO language codes e.g. "DE,ES,..." - should not include main language'
+    )->checkbox(
+      iv_name        = c_id-use_lxe
+      iv_label       = 'Use experimental LXE approach for translations'
     )->radio(
       iv_name        = c_id-folder_logic
       iv_default_value = zif_abapgit_dot_abapgit=>c_folder_logic-prefix
@@ -212,6 +216,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       iv_key = c_id-i18n_langs
       iv_val = zcl_abapgit_lxe_texts=>convert_table_to_lang_string( lo_dot->get_i18n_languages( ) ) ).
     mo_form_data->set(
+      iv_key = c_id-use_lxe
+      iv_val = lo_dot->use_lxe( ) ).
+    mo_form_data->set(
       iv_key = c_id-folder_logic
       iv_val = ls_dot-folder_logic ).
     mo_form_data->set(
@@ -295,6 +302,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       zcl_abapgit_lxe_texts=>convert_lang_string_to_table(
         iv_langs              = mo_form_data->get( c_id-i18n_langs )
         iv_skip_main_language = lo_dot->get_main_language( ) ) ).
+    lo_dot->use_lxe( boolc( mo_form_data->get( c_id-use_lxe ) is not initial ) ).
 
     " Remove all ignores
     lt_ignore = lo_dot->get_data( )-ignore.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -126,7 +126,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       iv_readonly    = abap_true
     )->text(
       iv_name        = c_id-i18n_langs
-      iv_label       = 'Serialize Translations for these languages (Experimental)'
+      iv_label       = 'Serialize Translations for These Languages'
       iv_hint        = 'Comma-separate 2-letter ISO language codes e.g. "DE,ES,..." - should not include main language'
     )->checkbox(
       iv_name        = c_id-use_lxe
@@ -411,7 +411,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
     IF io_form_data->get( c_id-use_lxe ) = abap_true AND lt_lang_list IS INITIAL.
       ro_validation_log->set(
         iv_key = c_id-i18n_langs
-        iv_val = 'The LXE approach supposes a non-empty list of languages to save' ).
+        iv_val = 'LXE approach requires a non-empy list of languages' ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -302,7 +302,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       zcl_abapgit_lxe_texts=>convert_lang_string_to_table(
         iv_langs              = mo_form_data->get( c_id-i18n_langs )
         iv_skip_main_language = lo_dot->get_main_language( ) ) ).
-    lo_dot->use_lxe( boolc( mo_form_data->get( c_id-use_lxe ) is not initial ) ).
+    lo_dot->use_lxe( boolc( mo_form_data->get( c_id-use_lxe ) = 'X' ) ).
 
     " Remove all ignores
     lt_ignore = lo_dot->get_data( )-ignore.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -131,6 +131,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
     )->checkbox(
       iv_name        = c_id-use_lxe
       iv_label       = 'Use experimental LXE approach for translations'
+      iv_hint        = 'It''s mandatory to specify the list of languages above in addition to this setting'
     )->radio(
       iv_name        = c_id-folder_logic
       iv_default_value = zif_abapgit_dot_abapgit=>c_folder_logic-prefix
@@ -350,6 +351,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
   METHOD validate_form.
 
     DATA:
+      lt_lang_list        TYPE zif_abapgit_definitions=>ty_languages,
       lv_folder           TYPE string,
       lv_len              TYPE i,
       lv_component        TYPE zif_abapgit_dot_abapgit=>ty_requirement-component,
@@ -402,6 +404,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
           iv_key = c_id-version_constant
           iv_val = lx_exception->get_text( ) ).
     ENDTRY.
+
+    lt_lang_list = zcl_abapgit_lxe_texts=>convert_lang_string_to_table(
+      iv_langs              = io_form_data->get( c_id-i18n_langs )
+      iv_skip_main_language = mo_repo->get_dot_abapgit( )->get_main_language( ) ).
+    IF io_form_data->get( c_id-use_lxe ) = abap_true AND lt_lang_list IS INITIAL.
+      ro_validation_log->set(
+        iv_key = c_id-i18n_langs
+        iv_val = 'The LXE approach supposes a non-empty list of languages to save' ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -126,7 +126,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       iv_readonly    = abap_true
     )->text(
       iv_name        = c_id-i18n_langs
-      iv_label       = 'Serialize Translations for these languages'
+      iv_label       = 'Serialize Translations for these languages (Experimental)'
       iv_hint        = 'Comma-separate 2-letter ISO language codes e.g. "DE,ES,..." - should not include main language'
     )->checkbox(
       iv_name        = c_id-use_lxe

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -455,6 +455,8 @@ INTERFACE zif_abapgit_definitions
     END OF c_method .
 
   TYPES:
+    ty_sap_langu_tab TYPE STANDARD TABLE OF langu WITH DEFAULT KEY.
+  TYPES:
     ty_languages TYPE STANDARD TABLE OF laiso WITH DEFAULT KEY.
   TYPES:
     BEGIN OF ty_i18n_params,

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -461,6 +461,7 @@ INTERFACE zif_abapgit_definitions
       main_language         TYPE sy-langu,
       main_language_only    TYPE abap_bool,
       translation_languages TYPE ty_languages,
+      use_lxe               TYPE abap_bool,
     END OF ty_i18n_params .
   TYPES ty_trrngtrkor_tt TYPE RANGE OF trkorr.
 ENDINTERFACE.

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -90,6 +90,7 @@
       {"object": "ZCL_ABAPGIT_SERIALIZE", "class": "ltcl_serialize", "method": "unsupported", "note": "Void type: KO100"},
       {"object": "ZCL_ABAPGIT_SERIALIZE", "class": "ltcl_serialize", "method": "ignored",     "note": "Void type: KO100"},
       {"object": "ZCL_ABAPGIT_SERIALIZE", "class": "ltcl_i18n", "method": "test",             "note": "Void type: DD02V"},
+      {"object": "ZCL_ABAPGIT_SERIALIZE", "class": "ltcl_determine_max_threads", "method": "determine_max_threads",             "note": "??"},
 
       {"object": "ZCL_ABAPGIT_FILE_STATUS", "class": "ltcl_calculate_status", "method": "deleted_remote", "note": "READ TABLE subrc 4 vs subrc 8"},
       {"object": "ZCL_ABAPGIT_FILE_STATUS", "class": "ltcl_calculate_status", "method": "complete", "note": "READ TABLE subrc 4 vs subrc 8"},


### PR DESCRIPTION
Working on #2539. But in the meantime here is one intermediary feature.

**Main problem**: sometimes a deployed product gets extra translations in a client system. For technical reasons. E.g. a new language is installed in the system and somehow it is applied (copied from master??) to our tool as well. The new language obviously is not maintained in the repo (and there is no intention to do it) and thus it create unnecessary diffs. Which greatly complicates further deployments and adds chaos. Pulling does not delete the new language texts (which, by the way, can be another or additional approach to the solution of this problem)

![image](https://user-images.githubusercontent.com/15635498/227553836-4c7020da-d213-4e02-918e-5ff880d3477a.png)


**The current state**: currently all the found translations are serialized. Which is actually contra intuitive and not quite correct.

**The solution**: ... so the solution is extra filtering of serialized translations. So that only explicitly defined languages are serialized. Settings-wise we already have a list-of-languages config. It works just fine. I added another setting which defines if the translation should use LXE. So now we have 3 "modes":
- no LXE, empty language list - the default - serialize all found, as before
- LXE + language list - use LXE, works as before (for the moment ... will improve soon ;)
- no LXE + language list - this is new. It serializes texts in the "old" way but limits them to the given list

**UI**
![image](https://user-images.githubusercontent.com/15635498/227543472-b5e505b8-7635-4e68-abf0-dfb88f29d10d.png)

**Technical stuff**
- i18n_params now have a new flag - `use_lxe`
- all the logic forks, based on presence of translation_languages (so the LXE approach) now check both TLs and `use_lxe = true`
- respective changes in all passing params ... e.g. parallel FUGR ... by the I think it makes sense to pass the whole structure - now these are separate 4 (!) params ... but in future refactorings ...
- **question by the way** - both serialization and deserialization now have `determine_i18n_params` method. Which are identical. Any ideas where to move it to a single place ? (can be done later)
- `zcl_abapgit_lxe_texts` has now a little zoo of helper methods to filter out unnecessary languages. Probably makes sense to unify it all. In future. (Not now to minimize code impact) Covered by UTs
- the rest are more or less trivial changes to objects (doma, dtel, tabl, view, msag, prog, figr, clas, tran)

The feature **would benefit from some unbiased testing** ... ;) as it touches the basics

**One issue (and question)**
There is one conceptual issue. Which is potentially solved in LXE approach relatively easily, but not so in the old XML approach. What if I want to deserialize specific languages within the officially maintained ones ? E.g. EN,DE,ES are maintained, the client wants just EN and DE ? In theory, I can create a package, link it in AG, set the needed languages and deserialize ! And I even added the code for this in the objects. But !!! There are 2 catches:
1) the language settings are in dotfile (as it should be). And the dot file is deserialized first and **replaces** the manual config. After which happily deploys all the languages. Well, maybe not that big deal - let's pre filter dotfile languages to the local ones (although it has some logical contraversion), but !
2) ... then after the deployment there will be diffs between local and remote languages in another direction. So ones that are officially maintained but not deployed.

I don't see a normal way to resolve it. Also I think that maybe it does not matter. Because the goal (see the "Main problem" section above) is to avoid serialization of unmaintained languages. Thus the dotfile list must always be deployed. And then after we can use the local settings to trim unmaintained languages. So my current opinion is to do nothing about it. But I'm open to ideas. Again to emphasize that in LXE approach it will be solved differently and effectively.



