### PR TITLE
Improve pull dialog button logic

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -95,6 +95,7 @@ CLASS lcl_object_descision_list DEFINITION FINAL.
     METHODS mark_indexed
       IMPORTING
         iv_selected TYPE abap_bool DEFAULT abap_true
+        iv_invert TYPE abap_bool DEFAULT abap_false
         it_scope TYPE lvc_t_fidx.
 
 ENDCLASS.
@@ -432,7 +433,9 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
     lt_scope = mo_alv->get_selections( )->get_selected_rows( ).
 
     IF lines( lt_scope ) > 0.
-      mark_indexed( lt_scope ).
+      mark_indexed(
+        it_scope  = lt_scope
+        iv_invert = abap_true ).
       mo_alv->get_selections( )->set_selected_rows( lt_clear ).
     ELSE.
       MESSAGE 'Select rows first to mark them' TYPE 'S'.
@@ -490,7 +493,12 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
 
       ASSIGN COMPONENT c_fieldname_selected OF STRUCTURE <ls_line> TO <lv_selected>.
       ASSERT sy-subrc = 0.
-      <lv_selected> = iv_selected.
+
+      IF iv_invert = abap_true.
+        <lv_selected> = boolc( <lv_selected> = abap_false ).
+      ELSE.
+        <lv_selected> = iv_selected.
+      ENDIF.
 
     ENDLOOP.
 

--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -1,11 +1,11 @@
 CLASS lcl_object_descision_list DEFINITION FINAL.
   PUBLIC SECTION.
 
-    CONSTANTS c_default_column TYPE abap_componentdescr-name VALUE 'DEFAULT_COLUMN'.
+    CONSTANTS c_default_column     TYPE abap_componentdescr-name VALUE 'DEFAULT_COLUMN'.
     CONSTANTS c_fieldname_selected TYPE abap_componentdescr-name VALUE 'SELECTED'.
     CONSTANTS c_answer_cancel      TYPE c LENGTH 1 VALUE 'A'.
     CONSTANTS c_fieldname_obj_type TYPE abap_componentdescr-name VALUE 'OBJ_TYPE'.
-    CONSTANTS c_own_pfstatus TYPE sy-pfkey VALUE 'DECIDE_DIALOG'.
+    CONSTANTS c_own_pfstatus       TYPE sy-pfkey VALUE 'DECIDE_DIALOG'.
 
     METHODS constructor
       IMPORTING
@@ -69,7 +69,7 @@ CLASS lcl_object_descision_list DEFINITION FINAL.
         cx_salv_msg.
     METHODS setup_columns
       IMPORTING
-        io_columns TYPE REF TO cl_salv_columns_table
+        io_columns            TYPE REF TO cl_salv_columns_table
         iv_selection_mode     TYPE salv_de_constant
         iv_select_column_text TYPE csequence
         it_columns_to_display TYPE zif_abapgit_popups=>ty_alv_column_tt
@@ -95,11 +95,11 @@ CLASS lcl_object_descision_list DEFINITION FINAL.
     METHODS mark_indexed
       IMPORTING
         iv_selected TYPE abap_bool DEFAULT abap_true
-        iv_invert TYPE abap_bool DEFAULT abap_false
-        it_scope TYPE lvc_t_fidx.
+        iv_invert   TYPE abap_bool DEFAULT abap_false
+        it_scope    TYPE lvc_t_fidx.
     METHODS are_all_marked
       IMPORTING
-        it_scope TYPE lvc_t_fidx
+        it_scope      TYPE lvc_t_fidx
       RETURNING
         VALUE(rv_yes) TYPE abap_bool.
 
@@ -498,11 +498,11 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
 
     CALL FUNCTION 'LVC_FILTER_APPLY'
       EXPORTING
-        it_filter                    = lt_filters
+        it_filter              = lt_filters
       IMPORTING
-        et_filter_index_inside       = lt_scope
+        et_filter_index_inside = lt_scope
       TABLES
-        it_data                      = <lt_table>.
+        it_data                = <lt_table>.
 
     mark_indexed(
       it_scope    = lt_scope
@@ -660,9 +660,9 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
   METHOD setup_columns.
 
     DATA:
-      lt_columns      TYPE salv_t_column_ref,
-      ls_column       TYPE salv_s_column_ref,
-      lo_column       TYPE REF TO cl_salv_column_list.
+      lt_columns TYPE salv_t_column_ref,
+      ls_column  TYPE salv_s_column_ref,
+      lo_column  TYPE REF TO cl_salv_column_list.
 
     FIELD-SYMBOLS <ls_column_to_display> TYPE zif_abapgit_popups=>ty_alv_column.
 
@@ -718,12 +718,12 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
   METHOD setup_toolbar.
 
     DATA:
-      lv_report         TYPE sy-repid,
-      lv_pfstatus       TYPE sy-pfkey,
-      lo_functions      TYPE REF TO cl_salv_functions_list,
-      lt_func_list      TYPE salv_t_ui_func,
-      lv_fn             TYPE string,
-      ls_func           LIKE LINE OF lt_func_list.
+      lv_report    TYPE sy-repid,
+      lv_pfstatus  TYPE sy-pfkey,
+      lo_functions TYPE REF TO cl_salv_functions_list,
+      lt_func_list TYPE salv_t_ui_func,
+      lv_fn        TYPE string,
+      ls_func      LIKE LINE OF lt_func_list.
 
     CALL FUNCTION 'RS_CUA_STATUS_CHECK'
       EXPORTING

--- a/src/zabapgit.prog.xml
+++ b/src/zabapgit.prog.xml
@@ -109,7 +109,7 @@
       <TEXT_TYPE>S</TEXT_TYPE>
       <TEXT_NAME>ICON_SELECT_BLOCK</TEXT_NAME>
       <ICON_ID>@4C@</ICON_ID>
-      <FUN_TEXT>Mark/Toggle selected</FUN_TEXT>
+      <FUN_TEXT>Mark/Toggle Selected</FUN_TEXT>
      </RSMPE_FUNT>
     </FUN>
     <BUT>

--- a/src/zabapgit.prog.xml
+++ b/src/zabapgit.prog.xml
@@ -85,7 +85,7 @@
       <TEXT_TYPE>S</TEXT_TYPE>
       <TEXT_NAME>ICON_SELECT_ALL</TEXT_NAME>
       <ICON_ID>@4B@</ICON_ID>
-      <FUN_TEXT>Select All</FUN_TEXT>
+      <FUN_TEXT>Select All Visible</FUN_TEXT>
      </RSMPE_FUNT>
      <RSMPE_FUNT>
       <CODE>SEL_CAT</CODE>
@@ -101,7 +101,7 @@
       <TEXT_TYPE>S</TEXT_TYPE>
       <TEXT_NAME>ICON_DESELECT_ALL</TEXT_NAME>
       <ICON_ID>@4D@</ICON_ID>
-      <FUN_TEXT>Deselect All</FUN_TEXT>
+      <FUN_TEXT>Deselect All Visible</FUN_TEXT>
      </RSMPE_FUNT>
      <RSMPE_FUNT>
       <CODE>SEL_KEY</CODE>
@@ -109,7 +109,7 @@
       <TEXT_TYPE>S</TEXT_TYPE>
       <TEXT_NAME>ICON_SELECT_BLOCK</TEXT_NAME>
       <ICON_ID>@4C@</ICON_ID>
-      <FUN_TEXT>Mark selected or all visible</FUN_TEXT>
+      <FUN_TEXT>Mark/Toggle selected</FUN_TEXT>
      </RSMPE_FUNT>
     </FUN>
     <BUT>


### PR DESCRIPTION
Back to this comment: https://github.com/abapGit/abapGit/pull/6093#issuecomment-1446787779

> Actually one usability concern ... intuitively, I'd expect that "Select All" (and also Deselect All) is applied to visible records ... Although it is not a hard rule and also a matter of habit, but may be a source of confusion ...

So after some practical hands on, my own, and my colleagues, I think the current logic is indeed imperfect. And the double nature of "halfpainted" button was confusing. Also the fact the "(de)select all" does something that is not visible on the screen. Here are some changes:

![image](https://user-images.githubusercontent.com/15635498/227592580-5bb0977f-9b74-4a04-88b7-330e3dee90eb.png)

Button 1 - marks all VISIBLE, which means mark ALL in case of no filter
Button 2 - UNmarks all VISIBLE, which means UNmark ALL in case of no filter
Button 3 - mark SELECTED and resets the selection (the use case from Marc)

Feels better.

@mbtools @christianguenter2 What do you think ?



