### PR TITLE
CLAS: Serialize long texts for exception classes

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -620,6 +620,9 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
     zcl_abapgit_sotr_handler=>create_sotr(
       iv_package = iv_package
       io_xml     = ii_xml ).
+    zcl_abapgit_sots_handler=>create_sots(
+      iv_package = iv_package
+      io_xml     = ii_xml ).
   ENDMETHOD.
 
 
@@ -896,6 +899,11 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
 
   METHOD zif_abapgit_oo_object_fnc~read_sotr.
     zcl_abapgit_sotr_handler=>read_sotr(
+      iv_pgmid    = 'LIMU'
+      iv_object   = 'CPUB'
+      iv_obj_name = iv_object_name
+      io_xml      = ii_xml ).
+    zcl_abapgit_sots_handler=>read_sots(
       iv_pgmid    = 'LIMU'
       iv_object   = 'CPUB'
       iv_obj_name = iv_object_name


### PR DESCRIPTION
Test repo: https://github.com/abapGit-tests/CLAS_with_SOTR

Serializes the exception longtext (`SOTS`) as part of the class `XML`.

Ref #4480