### PR TITLE
TABU: Several enhancements

### DIFF
--- a/src/cts/zif_abapgit_cts_api.intf.abap
+++ b/src/cts/zif_abapgit_cts_api.intf.abap
@@ -1,6 +1,21 @@
 INTERFACE zif_abapgit_cts_api
   PUBLIC .
 
+  CONSTANTS:
+    BEGIN OF c_transport_type,
+      wb_request   TYPE c LENGTH 1 VALUE 'K', "workbench request
+      wb_repair    TYPE c LENGTH 1 VALUE 'R', "workbench repair
+      wb_task      TYPE c LENGTH 1 VALUE 'S', "workbench task
+      cust_request TYPE c LENGTH 1 VALUE 'W', "customizing request
+      cust_task    TYPE c LENGTH 1 VALUE 'Q', "customizing task
+    END OF c_transport_type.
+
+  CONSTANTS:
+    BEGIN OF c_transport_category,
+      workbench   TYPE c LENGTH 4 VALUE 'SYST',
+      customizing TYPE c LENGTH 4 VALUE 'CUST',
+    END OF c_transport_category.
+
   TYPES: BEGIN OF ty_transport,
            obj_type TYPE tadir-object,
            obj_name TYPE tadir-obj_name,
@@ -62,9 +77,12 @@ INTERFACE zif_abapgit_cts_api
 
   METHODS create_transport_entries
     IMPORTING
+      iv_transport TYPE trkorr
       it_table_ins TYPE ANY TABLE
       it_table_upd TYPE ANY TABLE
       it_table_del TYPE ANY TABLE
-      iv_tabname   TYPE tabname.
+      iv_tabname   TYPE tabname
+    RAISING
+      zcx_abapgit_exception.
 
 ENDINTERFACE.

--- a/src/data/zcl_abapgit_data_config.clas.abap
+++ b/src/data/zcl_abapgit_data_config.clas.abap
@@ -22,7 +22,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_DATA_CONFIG IMPLEMENTATION.
+CLASS zcl_abapgit_data_config IMPLEMENTATION.
 
 
   METHOD dump.
@@ -124,7 +124,7 @@ CLASS ZCL_ABAPGIT_DATA_CONFIG IMPLEMENTATION.
       ls_file-data = dump( ls_config ).
       ls_file-sha1 = zcl_abapgit_hash=>sha1_blob( ls_file-data ).
       ls_config-type = zif_abapgit_data_config=>c_config.
-      ls_file-filename = zcl_abapgit_data_utils=>build_filename( ls_config ).
+      ls_file-filename = zcl_abapgit_data_utils=>build_data_filename( ls_config ).
       APPEND ls_file TO rt_files.
     ENDLOOP.
 

--- a/src/data/zcl_abapgit_data_deserializer.clas.abap
+++ b/src/data/zcl_abapgit_data_deserializer.clas.abap
@@ -81,7 +81,7 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
 
   METHOD determine_transport_request.
 
-    DATA: li_exit TYPE REF TO zif_abapgit_exit.
+    DATA li_exit TYPE REF TO zif_abapgit_exit.
 
     li_exit = zcl_abapgit_exit=>get_instance( ).
 
@@ -313,32 +313,10 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
   METHOD zif_abapgit_data_deserializer~deserialize_check.
 
     DATA lt_configs TYPE zif_abapgit_data_config=>ty_config_tt.
-    DATA ls_config LIKE LINE OF lt_configs.
-    DATA lv_is_customizing TYPE abap_bool.
-    DATA lv_required TYPE abap_bool.
 
     lt_configs = ii_config->get_configs( ).
 
-    LOOP AT lt_configs INTO ls_config.
-      ASSERT ls_config-type = zif_abapgit_data_config=>c_data_type-tabu. " todo
-      ASSERT ls_config-name IS NOT INITIAL.
-
-      lv_is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
-
-      IF ls_config-is_customizing = abap_true AND lv_is_customizing = abap_false.
-        zcx_abapgit_exception=>raise( |Table { ls_config-name } is | &&
-          |not a customizing table but marked for customizing in repo| ).
-      ELSEIF ls_config-is_customizing = abap_false AND lv_is_customizing = abap_true.
-        zcx_abapgit_exception=>raise( |Table { ls_config-name } is | &&
-          |a customizing table but not marked for customizing in repo| ).
-      ENDIF.
-
-      IF ls_config-is_customizing = abap_true.
-        lv_required = abap_true.
-      ENDIF.
-    ENDLOOP.
-
-    IF lv_required = abap_true.
+    IF lt_configs IS NOT INITIAL.
       rs_checks-required     = abap_true.
       rs_checks-type-request = zif_abapgit_cts_api=>c_transport_type-cust_request.
       rs_checks-type-task    = zif_abapgit_cts_api=>c_transport_type-cust_task.

--- a/src/data/zcl_abapgit_data_deserializer.clas.abap
+++ b/src/data/zcl_abapgit_data_deserializer.clas.abap
@@ -41,16 +41,18 @@ CLASS zcl_abapgit_data_deserializer DEFINITION
         VALUE(rr_data) TYPE REF TO data
       RAISING
         zcx_abapgit_exception .
+    METHODS determine_transport_request
+      IMPORTING
+        io_repo                     TYPE REF TO zcl_abapgit_repo
+        iv_transport_type           TYPE zif_abapgit_definitions=>ty_transport_type
+      RETURNING
+        VALUE(rv_transport_request) TYPE trkorr.
     METHODS is_table_allowed_to_edit
       IMPORTING
         !is_result                TYPE zif_abapgit_data_deserializer=>ty_result
       RETURNING
         VALUE(rv_allowed_to_edit) TYPE abap_bool .
-    METHODS is_customizing_table
-      IMPORTING
-        !iv_name              TYPE tadir-obj_name
-      RETURNING
-        VALUE(rv_customizing) TYPE abap_bool .
+
 ENDCLASS.
 
 
@@ -77,35 +79,22 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD is_customizing_table.
+  METHOD determine_transport_request.
 
-    DATA lv_contflag       TYPE c LENGTH 1.
-    DATA lo_table          TYPE REF TO object.
-    DATA lo_content        TYPE REF TO object.
-    DATA lo_delivery_class TYPE REF TO object.
-    FIELD-SYMBOLS <ls_any> TYPE any.
+    DATA: li_exit TYPE REF TO zif_abapgit_exit.
 
-    TRY.
-        CALL METHOD ('XCO_CP_ABAP_DICTIONARY')=>database_table
-          EXPORTING
-            iv_name           = iv_name
-          RECEIVING
-            ro_database_table = lo_table.
-        CALL METHOD lo_table->('IF_XCO_DATABASE_TABLE~CONTENT')
-          RECEIVING
-            ro_content = lo_content.
-        CALL METHOD lo_content->('IF_XCO_DBT_CONTENT~GET_DELIVERY_CLASS')
-          RECEIVING
-            ro_delivery_class = lo_delivery_class.
-        ASSIGN lo_delivery_class->('VALUE') TO <ls_any>.
-        lv_contflag = <ls_any>.
-      CATCH cx_sy_dyn_call_illegal_class.
-        SELECT SINGLE contflag FROM ('DD02L') INTO lv_contflag WHERE tabname = iv_name.
-    ENDTRY.
+    li_exit = zcl_abapgit_exit=>get_instance( ).
 
-    IF lv_contflag = 'C'.
-      rv_customizing = abap_true.
-    ENDIF.
+    " Use transport from repo settings if maintained, or determine via user exit.
+    " If transport keeps empty here, it'll requested later via popup.
+    rv_transport_request = io_repo->get_local_settings( )-customizing_request.
+
+    li_exit->determine_transport_request(
+      EXPORTING
+        io_repo              = io_repo
+        iv_transport_type    = iv_transport_type
+      CHANGING
+        cv_transport_request = rv_transport_request ).
 
   ENDMETHOD.
 
@@ -218,6 +207,7 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
 
     DATA ls_result  LIKE LINE OF it_result.
     DATA li_cts_api TYPE REF TO zif_abapgit_cts_api.
+    DATA ls_file LIKE LINE OF rt_accessed_files.
 
     FIELD-SYMBOLS:
       <lt_ins> TYPE ANY TABLE,
@@ -252,16 +242,19 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
 
       ASSIGN ls_result-inserts->* TO <lt_ins>.
       ASSIGN ls_result-deletes->* TO <lt_del>.
-      ASSIGN ls_result-updates->* TO <lt_upd>.
+      ASSIGN ls_result-updates->* TO <lt_upd>. " not used
 
-      IF is_customizing_table( ls_result-name ) = abap_true.
+      IF zcl_abapgit_data_utils=>is_customizing_table( ls_result-name ) = abap_true.
         li_cts_api->create_transport_entries(
+          iv_transport = is_checks-customizing-transport
           it_table_ins = <lt_ins>
           it_table_upd = <lt_upd>
           it_table_del = <lt_del>
           iv_tabname   = |{ ls_result-name }| ).
       ENDIF.
 
+      INSERT ls_result-file INTO TABLE rt_accessed_files. " data file
+      INSERT ls_result-config INTO TABLE rt_accessed_files. " config file
     ENDLOOP.
 
   ENDMETHOD.
@@ -288,7 +281,7 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
       READ TABLE it_files INTO ls_file
         WITH KEY file_path
         COMPONENTS path     = zif_abapgit_data_config=>c_default_path
-                   filename = zcl_abapgit_data_utils=>build_filename( ls_config ).
+                   filename = zcl_abapgit_data_utils=>build_data_filename( ls_config ).
       IF sy-subrc = 0.
         convert_json_to_itab(
           ir_data = lr_data
@@ -299,10 +292,60 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
           it_where = ls_config-where
           ir_data  = lr_data ).
 
+        MOVE-CORRESPONDING ls_file TO ls_result-file. " data file
+
+        READ TABLE it_files INTO ls_file
+          WITH KEY file_path
+          COMPONENTS path     = zif_abapgit_data_config=>c_default_path
+                     filename = zcl_abapgit_data_utils=>build_config_filename( ls_config ).
+        ASSERT sy-subrc = 0.
+
+        MOVE-CORRESPONDING ls_file TO ls_result-config. " config file
+
         INSERT ls_result INTO TABLE rt_result.
       ENDIF.
 
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_data_deserializer~deserialize_check.
+
+    DATA lt_configs TYPE zif_abapgit_data_config=>ty_config_tt.
+    DATA ls_config LIKE LINE OF lt_configs.
+    DATA lv_is_customizing TYPE abap_bool.
+    DATA lv_required TYPE abap_bool.
+
+    lt_configs = ii_config->get_configs( ).
+
+    LOOP AT lt_configs INTO ls_config.
+      ASSERT ls_config-type = zif_abapgit_data_config=>c_data_type-tabu. " todo
+      ASSERT ls_config-name IS NOT INITIAL.
+
+      lv_is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
+
+      IF ls_config-is_customizing = abap_true AND lv_is_customizing = abap_false.
+        zcx_abapgit_exception=>raise( |Table { ls_config-name } is | &&
+          |not a customizing table but marked for customizing in repo| ).
+      ELSEIF ls_config-is_customizing = abap_false AND lv_is_customizing = abap_true.
+        zcx_abapgit_exception=>raise( |Table { ls_config-name } is | &&
+          |a customizing table but not marked for customizing in repo| ).
+      ENDIF.
+
+      IF ls_config-is_customizing = abap_true.
+        lv_required = abap_true.
+      ENDIF.
+    ENDLOOP.
+
+    IF lv_required = abap_true.
+      rs_checks-required     = abap_true.
+      rs_checks-type-request = zif_abapgit_cts_api=>c_transport_type-cust_request.
+      rs_checks-type-task    = zif_abapgit_cts_api=>c_transport_type-cust_task.
+      rs_checks-transport    = determine_transport_request(
+                                 io_repo           = io_repo
+                                 iv_transport_type = rs_checks-type ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/data/zcl_abapgit_data_serializer.clas.abap
+++ b/src/data/zcl_abapgit_data_serializer.clas.abap
@@ -128,7 +128,7 @@ CLASS zcl_abapgit_data_serializer IMPLEMENTATION.
         ls_file-data = zcl_abapgit_convert=>string_to_xstring_utf8( '[]' ).
       ENDIF.
 
-      ls_file-filename = zcl_abapgit_data_utils=>build_filename( ls_config ).
+      ls_file-filename = zcl_abapgit_data_utils=>build_data_filename( ls_config ).
       ls_file-sha1 = zcl_abapgit_hash=>sha1_blob( ls_file-data ).
       APPEND ls_file TO rt_files.
     ENDLOOP.

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -11,7 +11,12 @@ CLASS zcl_abapgit_data_utils DEFINITION
         VALUE(rr_data) TYPE REF TO data
       RAISING
         zcx_abapgit_exception.
-    CLASS-METHODS build_filename
+    CLASS-METHODS build_data_filename
+      IMPORTING
+        !is_config         TYPE zif_abapgit_data_config=>ty_config
+      RETURNING
+        VALUE(rv_filename) TYPE string.
+    CLASS-METHODS build_config_filename
       IMPORTING
         !is_config         TYPE zif_abapgit_data_config=>ty_config
       RETURNING
@@ -28,6 +33,11 @@ CLASS zcl_abapgit_data_utils DEFINITION
         !iv_name         TYPE tadir-obj_name
       RETURNING
         VALUE(rv_exists) TYPE abap_bool.
+    CLASS-METHODS is_customizing_table
+      IMPORTING
+        !iv_name              TYPE tadir-obj_name
+      RETURNING
+        VALUE(rv_customizing) TYPE abap_bool.
   PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES ty_names TYPE STANDARD TABLE OF abap_compname WITH DEFAULT KEY .
@@ -45,7 +55,16 @@ ENDCLASS.
 CLASS zcl_abapgit_data_utils IMPLEMENTATION.
 
 
-  METHOD build_filename.
+  METHOD build_config_filename.
+
+    rv_filename = to_lower( |{ is_config-name }.{ zif_abapgit_data_config=>c_config }.{ zif_abapgit_data_config=>c_default_format }| ).
+
+    REPLACE ALL OCCURRENCES OF '/' IN rv_filename WITH '#'.
+
+  ENDMETHOD.
+
+
+  METHOD build_data_filename.
 
     rv_filename = to_lower( |{ is_config-name }.{ is_config-type }.{ zif_abapgit_data_config=>c_default_format }| ).
 
@@ -122,6 +141,43 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
         rv_exists = abap_true.
       CATCH zcx_abapgit_exception ##NO_HANDLER.
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD is_customizing_table.
+
+    DATA lv_contflag       TYPE c LENGTH 1.
+    DATA lo_table          TYPE REF TO object.
+    DATA lo_content        TYPE REF TO object.
+    DATA lo_delivery_class TYPE REF TO object.
+    FIELD-SYMBOLS <ls_any> TYPE any.
+
+    TRY.
+        CALL METHOD ('XCO_CP_ABAP_DICTIONARY')=>database_table
+          EXPORTING
+            iv_name           = iv_name
+          RECEIVING
+            ro_database_table = lo_table.
+        CALL METHOD lo_table->('IF_XCO_DATABASE_TABLE~CONTENT')
+          RECEIVING
+            ro_content = lo_content.
+        CALL METHOD lo_content->('IF_XCO_DBT_CONTENT~GET_DELIVERY_CLASS')
+          RECEIVING
+            ro_delivery_class = lo_delivery_class.
+        ASSIGN lo_delivery_class->('VALUE') TO <ls_any>.
+        lv_contflag = <ls_any>.
+      CATCH cx_sy_dyn_call_illegal_class.
+        SELECT SINGLE contflag FROM ('DD02L') INTO lv_contflag WHERE tabname = iv_name.
+    ENDTRY.
+
+    IF lv_contflag = 'C'.
+      rv_customizing = abap_true.
+    ELSEIF lv_contflag IS NOT INITIAL.
+      rv_customizing = abap_false.
+    ELSE.
+      rv_customizing = abap_undefined. " table does not exist
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/data/zcl_abapgit_data_utils.clas.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.abap
@@ -57,7 +57,8 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
 
   METHOD build_config_filename.
 
-    rv_filename = to_lower( |{ is_config-name }.{ zif_abapgit_data_config=>c_config }.{ zif_abapgit_data_config=>c_default_format }| ).
+    rv_filename = to_lower( |{ is_config-name }.{ zif_abapgit_data_config=>c_config }|
+      && |.{ zif_abapgit_data_config=>c_default_format }| ).
 
     REPLACE ALL OCCURRENCES OF '/' IN rv_filename WITH '#'.
 
@@ -66,7 +67,8 @@ CLASS zcl_abapgit_data_utils IMPLEMENTATION.
 
   METHOD build_data_filename.
 
-    rv_filename = to_lower( |{ is_config-name }.{ is_config-type }.{ zif_abapgit_data_config=>c_default_format }| ).
+    rv_filename = to_lower( |{ is_config-name }.{ is_config-type }|
+      && |.{ zif_abapgit_data_config=>c_default_format }| ).
 
     REPLACE ALL OCCURRENCES OF '/' IN rv_filename WITH '#'.
 

--- a/src/data/zcl_abapgit_data_utils.clas.testclasses.abap
+++ b/src/data/zcl_abapgit_data_utils.clas.testclasses.abap
@@ -5,13 +5,14 @@ CLASS ltcl_data_utils_test DEFINITION FINAL
 
   PRIVATE SECTION.
 
-    METHODS build_filename FOR TESTING.
+    METHODS build_data_filename FOR TESTING.
+    METHODS build_config_filename FOR TESTING.
 
 ENDCLASS.
 
 CLASS ltcl_data_utils_test IMPLEMENTATION.
 
-  METHOD build_filename.
+  METHOD build_data_filename.
 
     DATA ls_config TYPE zif_abapgit_data_config=>ty_config.
 
@@ -19,15 +20,35 @@ CLASS ltcl_data_utils_test IMPLEMENTATION.
     ls_config-type = 'TABU'.
 
     cl_abap_unit_assert=>assert_equals(
-      act = zcl_abapgit_data_utils=>build_filename( ls_config )
+      act = zcl_abapgit_data_utils=>build_data_filename( ls_config )
       exp = 't100.tabu.json' ).
 
     ls_config-name = '/NSPC/T200'.
     ls_config-type = 'TABU'.
 
     cl_abap_unit_assert=>assert_equals(
-      act = zcl_abapgit_data_utils=>build_filename( ls_config )
+      act = zcl_abapgit_data_utils=>build_data_filename( ls_config )
       exp = '#nspc#t200.tabu.json' ).
+
+  ENDMETHOD.
+
+  METHOD build_config_filename.
+
+    DATA ls_config TYPE zif_abapgit_data_config=>ty_config.
+
+    ls_config-name = 'T100'.
+    ls_config-type = 'TABU'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_data_utils=>build_config_filename( ls_config )
+      exp = 't100.conf.json' ).
+
+    ls_config-name = '/NSPC/T200'.
+    ls_config-type = 'TABU'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_data_utils=>build_config_filename( ls_config )
+      exp = '#nspc#t200.conf.json' ).
 
   ENDMETHOD.
 

--- a/src/data/zif_abapgit_data_config.intf.abap
+++ b/src/data/zif_abapgit_data_config.intf.abap
@@ -6,11 +6,10 @@ INTERFACE zif_abapgit_data_config
     ty_data_type TYPE c LENGTH 4 .
   TYPES:
     BEGIN OF ty_config,
-      type           TYPE ty_data_type,
-      name           TYPE tadir-obj_name,
-      skip_initial   TYPE abap_bool,
-      is_customizing TYPE abap_bool,
-      where          TYPE string_table,
+      type         TYPE ty_data_type,
+      name         TYPE tadir-obj_name,
+      skip_initial TYPE abap_bool,
+      where        TYPE string_table,
     END OF ty_config .
   TYPES:
     ty_config_tt TYPE SORTED TABLE OF ty_config WITH UNIQUE KEY type name .

--- a/src/data/zif_abapgit_data_config.intf.abap
+++ b/src/data/zif_abapgit_data_config.intf.abap
@@ -6,10 +6,11 @@ INTERFACE zif_abapgit_data_config
     ty_data_type TYPE c LENGTH 4 .
   TYPES:
     BEGIN OF ty_config,
-      type         TYPE ty_data_type,
-      name         TYPE tadir-obj_name,
-      skip_initial TYPE abap_bool,
-      where        TYPE string_table,
+      type           TYPE ty_data_type,
+      name           TYPE tadir-obj_name,
+      skip_initial   TYPE abap_bool,
+      is_customizing TYPE abap_bool,
+      where          TYPE string_table,
     END OF ty_config .
   TYPES:
     ty_config_tt TYPE SORTED TABLE OF ty_config WITH UNIQUE KEY type name .

--- a/src/data/zif_abapgit_data_deserializer.intf.abap
+++ b/src/data/zif_abapgit_data_deserializer.intf.abap
@@ -8,8 +8,19 @@ INTERFACE zif_abapgit_data_deserializer
            deletes TYPE REF TO data,
            updates TYPE REF TO data,
            inserts TYPE REF TO data,
+           file    TYPE zif_abapgit_git_definitions=>ty_file_signature,
+           config  TYPE zif_abapgit_git_definitions=>ty_file_signature,
          END OF ty_result.
   TYPES: ty_results TYPE STANDARD TABLE OF ty_result WITH KEY type name.
+
+  METHODS deserialize_check
+    IMPORTING
+      !io_repo         TYPE REF TO zcl_abapgit_repo
+      !ii_config       TYPE REF TO zif_abapgit_data_config
+    RETURNING
+      VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks-customizing
+    RAISING
+      zcx_abapgit_exception .
 
   METHODS deserialize
     IMPORTING
@@ -22,8 +33,10 @@ INTERFACE zif_abapgit_data_deserializer
 
   METHODS actualize
     IMPORTING
-      !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
-      !it_result TYPE ty_results
+      !is_checks               TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      !it_result               TYPE ty_results
+    RETURNING
+      VALUE(rt_accessed_files) TYPE zif_abapgit_git_definitions=>ty_file_signatures_tt
     RAISING
       zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -129,7 +129,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
+CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
 
   METHOD add_apack.
@@ -173,7 +173,7 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
         IMPORTING
           es_item     = <ls_return>-item ).
 
-      <ls_return>-item-obj_type = zif_abapgit_data_config=>c_data_type-tabu.
+      <ls_return>-item-obj_type = zif_abapgit_data_config=>c_data_type-tabu. " todo
     ENDLOOP.
 
     lt_files = zcl_abapgit_data_factory=>get_serializer( )->serialize( ii_data_config ).

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -29,6 +29,7 @@ INTERFACE zif_abapgit_persistence PUBLIC.
       main_language_only           TYPE abap_bool,
       labels                       TYPE string,
       transport_request            TYPE trkorr,
+      customizing_request          TYPE trkorr,
     END OF ty_local_settings.
 
   TYPES: ty_local_checksum_tt TYPE STANDARD TABLE OF ty_local_checksum WITH DEFAULT KEY.

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -119,7 +119,6 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
       CLEAR ls_config.
       ls_config-type = zif_abapgit_data_config=>c_data_type-tabu.
       ls_config-name = to_upper( ls_key-objname ).
-      ls_config-is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
       lv_where = concatenated_key_to_where(
         iv_table  = ls_key-objname
         iv_tabkey = ls_key-tabkey ).
@@ -209,11 +208,10 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
     lo_map = ii_event->form_data( ).
 
-    ls_config-type           = zif_abapgit_data_config=>c_data_type-tabu.
-    ls_config-name           = to_upper( lo_map->get( c_id-table ) ).
-    ls_config-skip_initial   = lo_map->get( c_id-skip_initial ).
-    ls_config-is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
-    ls_config-where          = build_where( lo_map ).
+    ls_config-type         = zif_abapgit_data_config=>c_data_type-tabu.
+    ls_config-name         = to_upper( lo_map->get( c_id-table ) ).
+    ls_config-skip_initial = lo_map->get( c_id-skip_initial ).
+    ls_config-where        = build_where( lo_map ).
 
     mi_config->add_config( ls_config ).
 
@@ -242,11 +240,10 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
     lo_map = ii_event->form_data( ).
 
-    ls_config-type           = zif_abapgit_data_config=>c_data_type-tabu.
-    ls_config-name           = to_upper( lo_map->get( c_id-table ) ).
-    ls_config-skip_initial   = lo_map->has( to_upper( c_id-skip_initial ) ).
-    ls_config-is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
-    ls_config-where          = build_where( lo_map ).
+    ls_config-type         = zif_abapgit_data_config=>c_data_type-tabu.
+    ls_config-name         = to_upper( lo_map->get( c_id-table ) ).
+    ls_config-skip_initial = lo_map->has( to_upper( c_id-skip_initial ) ).
+    ls_config-where        = build_where( lo_map ).
 
     mi_config->update_config( ls_config ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -85,7 +85,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
 
   METHOD add_via_transport.
@@ -119,6 +119,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
       CLEAR ls_config.
       ls_config-type = zif_abapgit_data_config=>c_data_type-tabu.
       ls_config-name = to_upper( ls_key-objname ).
+      ls_config-is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
       lv_where = concatenated_key_to_where(
         iv_table  = ls_key-objname
         iv_tabkey = ls_key-tabkey ).
@@ -133,8 +134,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
 
     CREATE OBJECT ro_menu.
 
-    ro_menu->add( iv_txt = 'Add via transport'
+    ro_menu->add( iv_txt = 'Add Via Transport'
                   iv_act = c_event-add_via_transport ).
+    ro_menu->add( iv_txt = 'Back'
+                  iv_act = zif_abapgit_definitions=>c_action-go_back ).
 
   ENDMETHOD.
 
@@ -206,10 +209,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
 
     lo_map = ii_event->form_data( ).
 
-    ls_config-type = zif_abapgit_data_config=>c_data_type-tabu.
-    ls_config-name = to_upper( lo_map->get( c_id-table ) ).
-    ls_config-skip_initial = lo_map->get( c_id-skip_initial ).
-    ls_config-where = build_where( lo_map ).
+    ls_config-type           = zif_abapgit_data_config=>c_data_type-tabu.
+    ls_config-name           = to_upper( lo_map->get( c_id-table ) ).
+    ls_config-skip_initial   = lo_map->get( c_id-skip_initial ).
+    ls_config-is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
+    ls_config-where          = build_where( lo_map ).
 
     mi_config->add_config( ls_config ).
 
@@ -238,10 +242,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
 
     lo_map = ii_event->form_data( ).
 
-    ls_config-type = zif_abapgit_data_config=>c_data_type-tabu.
-    ls_config-name = to_upper( lo_map->get( c_id-table ) ).
-    ls_config-skip_initial = lo_map->has( to_upper( c_id-skip_initial ) ).
-    ls_config-where = build_where( lo_map ).
+    ls_config-type           = zif_abapgit_data_config=>c_data_type-tabu.
+    ls_config-name           = to_upper( lo_map->get( c_id-table ) ).
+    ls_config-skip_initial   = lo_map->has( to_upper( c_id-skip_initial ) ).
+    ls_config-is_customizing = zcl_abapgit_data_utils=>is_customizing_table( ls_config-name ).
+    ls_config-where          = build_where( lo_map ).
 
     mi_config->update_config( ls_config ).
 
@@ -263,7 +268,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
       iv_required = abap_true ).
 
     lo_form->checkbox(
-      iv_label = 'Skip initial values'
+      iv_label = 'Skip Initial Values'
       iv_name  = c_id-skip_initial ).
 
     lo_form->textarea(
@@ -319,7 +324,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DATA IMPLEMENTATION.
         iv_key = c_id-skip_initial
         iv_val = ls_config-skip_initial ).
       lo_form->checkbox(
-        iv_label = 'Skip initial values'
+        iv_label = 'Skip Initial Values'
         iv_name  = c_id-skip_initial ).
 
       lo_form_data->set(

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -30,6 +30,7 @@ CLASS zcl_abapgit_gui_page_sett_locl DEFINITION
         local                        TYPE string VALUE 'local',
         display_name                 TYPE string VALUE 'display_name',
         transport_request            TYPE string VALUE 'transport_request',
+        customizing_request          TYPE string VALUE 'customizing_request',
         labels                       TYPE string VALUE 'labels',
         ignore_subpackages           TYPE string VALUE 'ignore_subpackages',
         write_protected              TYPE string VALUE 'write_protected',
@@ -41,10 +42,11 @@ CLASS zcl_abapgit_gui_page_sett_locl DEFINITION
       END OF c_id .
     CONSTANTS:
       BEGIN OF c_event,
-        save                     TYPE string VALUE 'save',
-        choose_transport_request TYPE string VALUE 'choose_transport_request',
-        choose_labels            TYPE string VALUE 'choose-labels',
-        choose_check_variant     TYPE string VALUE 'choose_check_variant',
+        save                       TYPE string VALUE 'save',
+        choose_transport_request   TYPE string VALUE 'choose_transport_request',
+        choose_customizing_request TYPE string VALUE 'choose_customizing_request',
+        choose_labels              TYPE string VALUE 'choose-labels',
+        choose_check_variant       TYPE string VALUE 'choose_check_variant',
       END OF c_event .
 
     DATA mo_form TYPE REF TO zcl_abapgit_html_form .
@@ -82,6 +84,14 @@ CLASS zcl_abapgit_gui_page_sett_locl DEFINITION
     METHODS choose_transport_request
       RAISING
         zcx_abapgit_exception.
+    METHODS choose_customizing_request
+      RAISING
+        zcx_abapgit_exception.
+    METHODS is_customizing_included
+      RETURNING
+        VALUE(rv_result) TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -100,6 +110,26 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
       mo_form_data->set(
         iv_key = c_id-code_inspector_check_variant
         iv_val = lv_check_variant ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD choose_customizing_request.
+
+    DATA:
+      ls_transport_type      TYPE zif_abapgit_definitions=>ty_transport_type,
+      lv_customizing_request TYPE trkorr.
+
+    ls_transport_type-request = zif_abapgit_cts_api=>c_transport_type-cust_request.
+    ls_transport_type-task    = zif_abapgit_cts_api=>c_transport_type-cust_task.
+
+    lv_customizing_request = zcl_abapgit_ui_factory=>get_popups( )->popup_transport_request( ls_transport_type ).
+
+    IF lv_customizing_request IS NOT INITIAL.
+      mo_form_data->set(
+        iv_key = c_id-customizing_request
+        iv_val = lv_customizing_request ).
     ENDIF.
 
   ENDMETHOD.
@@ -130,8 +160,8 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
 
     IF lv_transport_request IS NOT INITIAL.
       mo_form_data->set(
-          iv_key = c_id-transport_request
-          iv_val = lv_transport_request ).
+        iv_key = c_id-transport_request
+        iv_val = lv_transport_request ).
     ENDIF.
 
   ENDMETHOD.
@@ -192,8 +222,16 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
       ro_form->text(
         iv_name        = c_id-transport_request
         iv_side_action = c_event-choose_transport_request
-        iv_label       = |Transport request|
+        iv_label       = |Transport Request|
         iv_hint        = 'Transport request; All changes are recorded therein and no transport popup appears|' ).
+    ENDIF.
+
+    IF is_customizing_included( ) = abap_true.
+      ro_form->text(
+        iv_name        = c_id-customizing_request
+        iv_side_action = c_event-choose_customizing_request
+        iv_label       = |Customizing Request|
+        iv_hint        = 'Customizing request; All changes are recorded therein and no customizing popup appears|' ).
     ENDIF.
 
     ro_form->text(
@@ -241,6 +279,21 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD is_customizing_included.
+
+    DATA lt_files TYPE zif_abapgit_definitions=>ty_files_item_tt.
+
+    lt_files = mo_repo->get_files_local( ).
+
+    READ TABLE lt_files TRANSPORTING NO FIELDS
+      WITH KEY item-obj_type = zif_abapgit_data_config=>c_data_type-tabu. "todo
+    IF sy-subrc = 0.
+      rv_result = abap_true.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD read_settings.
 
     DATA: li_package TYPE REF TO zif_abapgit_sap_package.
@@ -259,6 +312,12 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
       mo_form_data->set(
         iv_key = c_id-transport_request
         iv_val = ms_settings-transport_request ).
+    ENDIF.
+
+    IF is_customizing_included( ) = abap_true.
+      mo_form_data->set(
+        iv_key = c_id-customizing_request
+        iv_val = ms_settings-customizing_request ).
     ENDIF.
 
     mo_form_data->set(
@@ -293,6 +352,7 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
 
     ms_settings-display_name                 = mo_form_data->get( c_id-display_name ).
     ms_settings-transport_request            = mo_form_data->get( c_id-transport_request ).
+    ms_settings-customizing_request          = mo_form_data->get( c_id-customizing_request ).
     ms_settings-labels                       = zcl_abapgit_repo_labels=>normalize( mo_form_data->get( c_id-labels ) ).
     ms_settings-ignore_subpackages           = mo_form_data->get( c_id-ignore_subpackages ).
     ms_settings-main_language_only           = mo_form_data->get( c_id-main_language_only ).
@@ -315,9 +375,10 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
   METHOD validate_form.
 
     DATA:
-      lx_error             TYPE REF TO zcx_abapgit_exception,
-      lv_transport_request TYPE trkorr,
-      lv_check_variant     TYPE sci_chkv.
+      lx_error               TYPE REF TO zcx_abapgit_exception,
+      lv_transport_request   TYPE trkorr,
+      lv_customizing_request TYPE trkorr,
+      lv_check_variant       TYPE sci_chkv.
 
     ro_validation_log = mo_form_util->validate( io_form_data ).
 
@@ -328,6 +389,17 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
         CATCH zcx_abapgit_exception INTO lx_error.
           ro_validation_log->set(
             iv_key = c_id-transport_request
+            iv_val = lx_error->get_text( ) ).
+      ENDTRY.
+    ENDIF.
+
+    lv_customizing_request = io_form_data->get( c_id-customizing_request ).
+    IF lv_customizing_request IS NOT INITIAL.
+      TRY.
+          zcl_abapgit_transport=>validate_transport_request( lv_customizing_request ).
+        CATCH zcx_abapgit_exception INTO lx_error.
+          ro_validation_log->set(
+            iv_key = c_id-customizing_request
             iv_val = lx_error->get_text( ) ).
       ENDTRY.
     ENDIF.
@@ -373,11 +445,15 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
         choose_transport_request( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
+      WHEN c_event-choose_customizing_request.
+
+        choose_customizing_request( ).
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+
       WHEN c_event-choose_labels.
 
         choose_labels( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
-
 
       WHEN c_event-choose_check_variant.
 

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -860,6 +860,7 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
           lt_e071k   TYPE STANDARD TABLE OF e071k,
           lv_order   TYPE trkorr,
           ls_e070use TYPE e070use.
+    DATA lv_category TYPE e070-korrdev.
 
     " If default transport is set and its type matches, then use it as default for the popup
     ls_e070use = zcl_abapgit_default_transport=>get_instance( )->get( ).
@@ -869,10 +870,18 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       lv_order = ls_e070use-ordernum.
     ENDIF.
 
+    " Differentiate between customizing and WB requests
+    IF is_transport_type-request = zif_abapgit_cts_api=>c_transport_type-cust_request.
+      lv_category = zif_abapgit_cts_api=>c_transport_category-customizing.
+    ELSE.
+      lv_category = zif_abapgit_cts_api=>c_transport_category-workbench.
+    ENDIF.
+
     CALL FUNCTION 'TRINT_ORDER_CHOICE'
       EXPORTING
         wi_order_type          = is_transport_type-request
         wi_task_type           = is_transport_type-task
+        wi_category            = lv_category
         wi_order               = lv_order
       IMPORTING
         we_order               = rv_transport

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -73,6 +73,7 @@ INTERFACE zif_abapgit_definitions
       requirements    TYPE ty_requirements,
       dependencies    TYPE ty_dependencies,
       transport       TYPE ty_transport,
+      customizing     TYPE ty_transport,
     END OF ty_deserialize_checks .
   TYPES:
     BEGIN OF ty_delete_checks,


### PR DESCRIPTION
1. Add option to maintain default customizing transport in local settings (closes #6182)

  The existing `determine_transport_request` exit will be called as well (https://docs.abapgit.org/ref-exits.html)

  Note: The option will only be visible if some data selection is configured.

![image](https://user-images.githubusercontent.com/59966492/229790980-e7b98b8c-8100-4251-acd1-94e5ca922f51.png)

2. Persist checksums for pull config and data

![image](https://user-images.githubusercontent.com/59966492/229791064-79aee0e9-e6cc-431a-9ddc-06b040efd29a.png)

3. Add a "Back" option for Data Config page

![image](https://user-images.githubusercontent.com/59966492/229791400-b56551d3-c46c-47df-9161-cd9403ba3911.png)

4. Other technical changes

- Adjust capitalization of some label
- Move `is_customizing_table` to `zcl_abapgit_data_utils`
- Add `deserialize_check` to `zcl_abapgit_data_deserializer`

Overall, "Data" now works very similar to "Objects" :-)

Test repo: https://github.com/abapGit-tests/TABU_custom_table 

I think with these changes, we can remove the "Beta" from the "Data" feature. 

Future enhancements: 

- https://github.com/abapGit/abapGit/issues/6181
- https://github.com/abapGit/abapGit/issues/6190