### PR TITLE
NSPC: Automatic creation of namespaces

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -197,7 +197,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
+CLASS zcl_abapgit_objects IMPLEMENTATION.
 
 
   METHOD changed_by.
@@ -672,15 +672,17 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
       "error handling & logging added
       TRY.
-          " If package does not exist yet, it will be created with this call
-          lv_package = lo_folder_logic->path_to_package(
-            iv_top  = io_repo->get_package( )
-            io_dot  = io_repo->get_dot_abapgit( )
-            iv_path = <ls_result>-path ).
+          IF ls_item-obj_type <> 'NSPC'.
+            " If package does not exist yet, it will be created with this call
+            lv_package = lo_folder_logic->path_to_package(
+              iv_top  = io_repo->get_package( )
+              io_dot  = io_repo->get_dot_abapgit( )
+              iv_path = <ls_result>-path ).
 
-          check_main_package(
-            iv_package  = lv_package
-            iv_obj_type = ls_item-obj_type ).
+            check_main_package(
+              iv_package  = lv_package
+              iv_obj_type = ls_item-obj_type ).
+          ENDIF.
 
           IF ls_item-obj_type = 'DEVC'.
             " Packages have the same filename across different folders. The path needs to be supplied

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -100,7 +100,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
 
   METHOD activate_objects.
@@ -338,10 +338,16 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
     lt_decision = cs_checks-overwrite.
 
-    " Set all new objects to YES
-    LOOP AT lt_decision ASSIGNING <ls_decision> WHERE action = zif_abapgit_objects=>c_deserialize_action-add.
+    " If there's a new namespace, it has to be pulled before all other objects
+    READ TABLE lt_decision ASSIGNING <ls_decision> WITH KEY obj_type = 'NSPC'.
+    IF sy-subrc = 0 AND <ls_decision>-action = zif_abapgit_objects=>c_deserialize_action-add.
       <ls_decision>-decision = zif_abapgit_definitions=>c_yes.
-    ENDLOOP.
+    ELSE.
+      " Set all new objects to YES
+      LOOP AT lt_decision ASSIGNING <ls_decision> WHERE action = zif_abapgit_objects=>c_deserialize_action-add.
+        <ls_decision>-decision = zif_abapgit_definitions=>c_yes.
+      ENDLOOP.
+    ENDIF.
 
     " Ask user what to do
     popup_overwrite( CHANGING ct_overwrite = lt_decision ).


### PR DESCRIPTION
Repos with namespaces can now be pulled without having to create the namespace upfront in SE03.

When creating a repo with a namespace, you get a warning message:

![image](https://user-images.githubusercontent.com/59966492/231782196-5c02d868-eeeb-4b23-806a-a89edb4e2adf.png)

After selecting pull, only the namespace (`NSPC`) is marked and pressing continue (or `ctrl+s`) will create the namespace.

![image](https://user-images.githubusercontent.com/59966492/231782220-b6d7f5e1-6d8b-4a9c-bbc5-3a7599e90c2d.png)

You can then pull again. All other objects will be marked and can be deserialized (since the namespace now exists).

Closes #4505