### PR TITLE
Improve copy&paste on diff page

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
@@ -1094,6 +1094,8 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
+    " Note: CSS classes "new" and "old" are used to enable column-based copy to clipboard
+
     " New line
     lv_mark = ` `.
     IF is_diff_line-result IS NOT INITIAL.
@@ -1160,6 +1162,8 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     FIELD-SYMBOLS <ls_diff_line> LIKE LINE OF mt_delayed_lines.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    " Note: CSS classes "new" and "old" are used to enable column-based copy to clipboard
 
     " Release delayed subsequent update lines
     IF is_diff_line-result <> zif_abapgit_definitions=>c_diff-update.

--- a/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
@@ -270,7 +270,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
 
   METHOD add_filter_sub_menu.
@@ -1107,7 +1107,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     ENDIF.
     lv_new = |<td class="num diff_others" line-num="{ is_diff_line-new_num }"></td>|
           && |<td class="mark diff_others">{ lv_mark }</td>|
-          && |<td class="code{ lv_bg } diff_left">{ is_diff_line-new }</td>|.
+          && |<td class="code{ lv_bg } diff_left new">{ is_diff_line-new }</td>|.
 
     " Old line
     CLEAR lv_bg.
@@ -1123,7 +1123,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     ENDIF.
     lv_old = |<td class="num diff_others" line-num="{ is_diff_line-old_num }"></td>|
           && |<td class="mark diff_others">{ lv_mark }</td>|
-          && |<td class="code{ lv_bg } diff_right">{ is_diff_line-old }</td>|.
+          && |<td class="code{ lv_bg } diff_right old">{ is_diff_line-old }</td>|.
 
     " render line, inverse sides if remote is newer
     ri_html->add( '<tr class="diff_line">' ).
@@ -1168,7 +1168,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
         ri_html->add( |<td class="num diff_others" line-num="{ <ls_diff_line>-old_num }"></td>|
                    && |<td class="num diff_others" line-num=""></td>|
                    && |<td class="mark diff_others">-</td>|
-                   && |<td class="code diff_del diff_unified">{ <ls_diff_line>-old }</td>| ).
+                   && |<td class="code diff_del diff_unified old">{ <ls_diff_line>-old }</td>| ).
         ri_html->add( '</tr>' ).
       ENDLOOP.
       LOOP AT mt_delayed_lines ASSIGNING <ls_diff_line>.
@@ -1176,7 +1176,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
         ri_html->add( |<td class="num diff_others" line-num=""></td>|
                    && |<td class="num diff_others" line-num="{ <ls_diff_line>-new_num }"></td>|
                    && |<td class="mark diff_others">+</td>|
-                   && |<td class="code diff_ins diff_others">{ <ls_diff_line>-new }</td>| ).
+                   && |<td class="code diff_ins diff_unified new">{ <ls_diff_line>-new }</td>| ).
         ri_html->add( '</tr>' ).
       ENDLOOP.
       CLEAR mt_delayed_lines.
@@ -1190,12 +1190,12 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
         ri_html->add( |<td class="num diff_others" line-num=""></td>|
                    && |<td class="num diff_others" line-num="{ is_diff_line-new_num }"></td>|
                    && |<td class="mark diff_others">+</td>|
-                   && |<td class="code diff_ins diff_others">{ is_diff_line-new }</td>| ).
+                   && |<td class="code diff_ins diff_unified new">{ is_diff_line-new }</td>| ).
       WHEN zif_abapgit_definitions=>c_diff-delete.
         ri_html->add( |<td class="num diff_others" line-num="{ is_diff_line-old_num }"></td>|
                    && |<td class="num diff_others" line-num=""></td>|
                    && |<td class="mark diff_others">-</td>|
-                   && |<td class="code diff_del diff_unified">{ is_diff_line-old }</td>| ).
+                   && |<td class="code diff_del diff_unified old">{ is_diff_line-old }</td>| ).
       WHEN OTHERS. "none
         ri_html->add( |<td class="num diff_others" line-num="{ is_diff_line-old_num }"></td>|
                    && |<td class="num diff_others" line-num="{ is_diff_line-new_num }"></td>|

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1205,7 +1205,6 @@ DiffColumnSelection.prototype.getSelectedText = function() {
       var cellIdx = (i == 0 ? 0 : realThis.selectedColumnIdx);
       if (tr.cells.length > cellIdx) {
         var tdSelected = tr.cells[cellIdx];
-        //var tdLineNum  = tr.cells[realThis.lineNumColumnIdx];
         // decide which side to copy based on first line of selection
         if (i == 0) {
           copySide = (tdSelected.classList.contains("new") ? "new" : "old" );

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1200,20 +1200,23 @@ DiffColumnSelection.prototype.getSelectedText = function() {
   } else {
     var newline  = "";
     var realThis = this;
+    var copySide = "";
     [].forEach.call(nodes, function(tr, i) {
       var cellIdx = (i == 0 ? 0 : realThis.selectedColumnIdx);
       if (tr.cells.length > cellIdx) {
         var tdSelected = tr.cells[cellIdx];
-        var tdLineNum  = tr.cells[realThis.lineNumColumnIdx];
-        // copy is interesting for remote code, don't copy lines which exist only locally
-        if (i == 0 || tdLineNum.getAttribute("line-num") != "") {
+        //var tdLineNum  = tr.cells[realThis.lineNumColumnIdx];
+        // decide which side to copy based on first line of selection
+        if (i == 0) {
+          copySide = (tdSelected.classList.contains("new") ? "new" : "old" );
+        }
+        // copy is interesting only for one side of code, do not copy lines which exist on other side
+        if (i == 0 || copySide == "new" && !tdSelected.classList.contains("old") || copySide == "old" && !tdSelected.classList.contains("new")) {
           text += newline + tdSelected.textContent;
           // special processing for TD tag which sometimes contains newline
-          // (expl: /src/ui/zabapgit_js_common.w3mi.data.js) so don't add newline again in that case.
+          // (expl: /src/ui/zabapgit_js_common.w3mi.data.js) so do not add newline again in that case.
           var lastChar = tdSelected.textContent[tdSelected.textContent.length - 1];
-
           if (lastChar == "\n") newline = "";
-
           else newline = "\n";
         }
       }
@@ -1474,7 +1477,7 @@ LinkHints.prototype.handleKey = function(event) {
 
     var hint = this.hintsMap[this.pendingPath];
 
-    if (hint) { // we are there, we have a fully specified tooltip. Let's activate or yank it
+    if (hint) { // we are there, we have a fully specified tooltip. Let us activate or yank it
       this.displayHints(false);
       event.preventDefault();
       if (this.yankModeActive) {
@@ -1484,7 +1487,7 @@ LinkHints.prototype.handleKey = function(event) {
         this.hintActivate(hint);
       }
     } else {
-      // we are not there yet, but let's filter the link so that only
+      // we are not there yet, but let us filter the link so that only
       // the partially matched are shown
       var visibleHints = this.filterHints();
       if (!visibleHints) {


### PR DESCRIPTION
Now it works for local as well as remote code. 

You can even copy in unified view. 😃 

The first selected line defines what code is copied (local or remote). 

Example:

![image](https://user-images.githubusercontent.com/59966492/232081239-52944d57-2d19-4ebe-a5fe-f44975726b90.png)

Copy "red + white" lines:

![image](https://user-images.githubusercontent.com/59966492/232083083-1fc87c43-b656-41da-a899-ebd4a12b6ed2.png)

Copy "green + white" lines:

![image](https://user-images.githubusercontent.com/59966492/232083215-c7075326-240a-4cbe-a3ea-3c82ca449b90.png)

Closes #4799