### PR TITLE
Add debug option to show href-links on hover

### DIFF
--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -345,7 +345,9 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
     " Debug option to display href-link on hover
     GET PARAMETER ID 'DBT' FIELD lv_mode.
     IF lv_mode = 'HREF'.
-      lv_title = | title="{ escape( val = lv_href format = cl_abap_format=>e_html_attr ) }"|.
+      lv_title = | title="{ escape(
+        val    = lv_href
+        format = cl_abap_format=>e_html_attr ) }"|.
     ENDIF.
 
     rv_str = |<a{ lv_id }{ lv_class }{ lv_href }{ lv_click }{ lv_style }{ lv_title }>|

--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -289,6 +289,7 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
           lv_act   TYPE string,
           lv_style TYPE string,
           lv_title TYPE string.
+    DATA lv_mode TYPE tabname.
 
     lv_class = iv_class.
 
@@ -339,6 +340,12 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
 
     IF iv_title IS NOT INITIAL.
       lv_title = | title="{ iv_title }"|.
+    ENDIF.
+
+    " Debug option to display href-link on hover
+    GET PARAMETER ID 'DBT' FIELD lv_mode.
+    IF lv_mode = 'HREF'.
+      lv_title = | title="{ escape( val = lv_href format = cl_abap_format=>e_html_attr ) }"|.
     ENDIF.
 
     rv_str = |<a{ lv_id }{ lv_class }{ lv_href }{ lv_click }{ lv_style }{ lv_title }>|


### PR DESCRIPTION
By setting parameter `DBT` to `HREF`, you can quickly view the href-target on any link included in the abapGit UI. You just have to hover over the link.

Examples:

![image](https://user-images.githubusercontent.com/59966492/233692727-3c3393b8-2cce-4f84-b39b-0cee867eba6d.png)

![image](https://user-images.githubusercontent.com/59966492/233692779-3a3a8e80-dcc4-46b9-b14a-2f8ed554ad6b.png)

![image](https://user-images.githubusercontent.com/59966492/233692949-fba78352-bc85-4299-a215-854e2f84d163.png)

![image](https://user-images.githubusercontent.com/59966492/233693168-7cffa04a-3fbc-43f4-b844-1033c5aae44c.png)
