### PR TITLE
ECATT: Avoid diffs between dialog and background

### DIFF
--- a/src/objects/zcl_abapgit_object_ecatt_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_ecatt_super.clas.abap
@@ -189,7 +189,8 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
     clear_element( EXPORTING iv_name     = |TADIR_RESP|
                    CHANGING  ci_document = ci_document ).
 
-    clear_element( EXPORTING iv_name     = |VAR_EXT_PATH|
+    " Clearing just VAR_EXT_PATH will lead to diffs in batch
+    clear_element( EXPORTING iv_name     = |ETVAR_EXT|
                    CHANGING  ci_document = ci_document ).
 
   ENDMETHOD.


### PR DESCRIPTION
Ref https://github.com/abapGit/abapGit/issues/2722

![image](https://user-images.githubusercontent.com/59966492/233827172-b3951a8c-923d-4a75-bf9f-31aa216eaa51.png)

Fixes diff due to user-specific settings that are loaded only in dialog processes. The corresponding XML field is now cleared in a way that avoids diffs.