### PR TITLE
omit preceding zeros in exceptions fm call

### DIFF
--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -74,13 +74,13 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
         suppress_enqueue               = space
         suppress_transport             = space
       EXCEPTIONS
-        header_without_text            = 01
-        index_without_header           = 02
-        no_authority_for_devclass_xxxx = 03
-        no_docu_found                  = 04
-        object_is_already_enqueued     = 05
-        object_is_enqueued_by_corr     = 06
-        user_break                     = 07.
+        header_without_text            = 1
+        index_without_header           = 2
+        no_authority_for_devclass_xxxx = 3
+        no_docu_found                  = 4
+        object_is_already_enqueued     = 5
+        object_is_enqueued_by_corr     = 6
+        user_break                     = 7.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_pdxx_super.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_pdxx_super.clas.testclasses.abap
@@ -76,8 +76,8 @@ CLASS ltc_lock IMPLEMENTATION.
         _scope         = '2'
         _wait          = ' '
       EXCEPTIONS
-        foreign_lock   = 01
-        system_failure = 02.
+        foreign_lock   = 1
+        system_failure = 2.
 
     cl_abap_unit_assert=>assert_subrc( exp = 0
                                        act = sy-subrc ).

--- a/src/objects/zcl_abapgit_object_scvi.clas.abap
+++ b/src/objects/zcl_abapgit_object_scvi.clas.abap
@@ -78,7 +78,7 @@ CLASS zcl_abapgit_object_scvi IMPLEMENTATION.
       EXPORTING
         scvariant = ls_screen_variant-shdsvci-scvariant
       EXCEPTIONS
-        OTHERS    = 01.
+        OTHERS    = 1.
     IF sy-subrc <> 0.
       MESSAGE e413(ms) WITH ls_screen_variant-shdsvci-scvariant INTO zcx_abapgit_exception=>null.
       zcx_abapgit_exception=>raise_t100( ).

--- a/src/objects/zcl_abapgit_object_stvi.clas.abap
+++ b/src/objects/zcl_abapgit_object_stvi.clas.abap
@@ -77,7 +77,7 @@ CLASS zcl_abapgit_object_stvi IMPLEMENTATION.
       EXPORTING
         tcvariant = ls_transaction_variant-shdtvciu-tcvariant
       EXCEPTIONS
-        OTHERS    = 01.
+        OTHERS    = 1.
     IF sy-subrc <> 0.
       MESSAGE e413(ms) WITH ls_transaction_variant-shdtvciu-tcvariant INTO zcx_abapgit_exception=>null.
       zcx_abapgit_exception=>raise_t100( ).

--- a/src/objects/zcl_abapgit_object_udmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_udmo.clas.abap
@@ -387,7 +387,7 @@ CLASS zcl_abapgit_object_udmo IMPLEMENTATION.
         obj_name   = ms_object_type-objname
         obj_type   = ms_object_type-objtype
       EXCEPTIONS
-        wrong_type = 01.
+        wrong_type = 1.
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).

--- a/src/objects/zcl_abapgit_object_ueno.clas.abap
+++ b/src/objects/zcl_abapgit_object_ueno.clas.abap
@@ -460,7 +460,7 @@ CLASS zcl_abapgit_object_ueno IMPLEMENTATION.
         obj_name   = ms_item-obj_name
         obj_type   = ms_item-obj_type
       EXCEPTIONS
-        wrong_type = 01.
+        wrong_type = 1.
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).


### PR DESCRIPTION
https://github.com/abaplint/abaplint/pull/2966 introduces a more strict check for https://rules.abaplint.org/omit_preceding_zeros/

this is for both readability plus compatibility with transpiler