### PR TITLE
Fix dump related to exit implementations

### DIFF
--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -23,12 +23,14 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
   METHOD get_instance.
 
     DATA lv_class_name TYPE string.
+
     lv_class_name = 'ZCL_ABAPGIT_USER_EXIT'.
-    IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true. 
-      " Prevent accidental usage of exit handlers in the developer version 
-      lv_class_name = |\\PROGRAM={ sy-repid }\\CLASS={ lv_class_name }|. 
-    ENDIF. 
-  
+
+    IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true.
+      " Prevent accidental usage of exit handlers in the developer version
+      lv_class_name = |\\PROGRAM={ sy-repid }\\CLASS={ lv_class_name }|.
+    ENDIF.
+
     IF gi_exit IS INITIAL.
       TRY.
           CREATE OBJECT gi_exit TYPE (lv_class_name).

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -22,9 +22,18 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
   METHOD get_instance.
 
+    DATA lv_class_name TYPE string.
+    
+    lv_class_name = 'ZCL_ABAPGIT_USER_EXIT'.
+    
+    IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true. 
+      " Prevent accidental usage of exit handlers in the developer version 
+      lv_class_name = |\\PROGRAM={ sy-repid }\\CLASS={ lv_class_name }|. 
+    ENDIF. 
+  
     IF gi_exit IS INITIAL.
       TRY.
-          CREATE OBJECT gi_exit TYPE ('ZCL_ABAPGIT_USER_EXIT').
+          CREATE OBJECT gi_exit TYPE (lv_class_name).
         CATCH cx_sy_create_object_error ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -23,7 +23,6 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
   METHOD get_instance.
 
     DATA lv_class_name TYPE string.
-    
     lv_class_name = 'ZCL_ABAPGIT_USER_EXIT'.
     
     IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true. 

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -24,7 +24,6 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
 
     DATA lv_class_name TYPE string.
     lv_class_name = 'ZCL_ABAPGIT_USER_EXIT'.
-    
     IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true. 
       " Prevent accidental usage of exit handlers in the developer version 
       lv_class_name = |\\PROGRAM={ sy-repid }\\CLASS={ lv_class_name }|. 


### PR DESCRIPTION
Fixes dump in standalone version if exit class for developer version exists (`zcl_abapgit_user_exit`) but not the exit include for standalone version (`zabapgit_user_exit`).

Closes #6265