### PR TITLE
Ensure unique form ids

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -640,7 +640,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->add(
-      |<form id='form_{ is_event-name }' method={ is_event-method } action='sapevent:{ is_event-name }'></form>| ).
+      |<form id="form_{ is_event-name }" method="{ is_event-method }" action="sapevent:{ is_event-name }"></form>| ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.abap
@@ -920,7 +920,7 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
     FIELD-SYMBOLS: <ls_command> TYPE zif_abapgit_html_form=>ty_command.
 
-    ls_hotkey_action-ui_component = 'Form'.
+    ls_hotkey_action-ui_component = |Form-{ mv_form_id }|.
 
     READ TABLE mt_commands WITH KEY cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
                            ASSIGNING <ls_command>.


### PR DESCRIPTION
If there are multiple forms (for example, hidden modal forms), this change makes sure they have a different ids.