### PR TITLE
wip, Generic modal popups

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -669,7 +669,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
   METHOD on_popup_event.
 
     DATA:
-      lv_pull_request TYPE ty_remote_settings-pull_request.
+      lv_pull_req TYPE ty_remote_settings-pull_request.
 
     mo_popup->normalize( ii_event->form_data( ) ).
 
@@ -677,20 +677,20 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       WHEN zcl_abapgit_gui_popup=>c_event-ok.
         mo_popup->validate( ).
 
-        CASE mo_popup->get_form_id( ).
-          WHEN c_popup-pull_request.
-            IF mo_popup->is_valid( ) = abap_true.
-              lv_pull_request = get_pull_request( mo_popup->get_value( zcl_abapgit_gui_popup_picklist=>c_selected_row ) ).
-            ENDIF.
+        IF mo_popup->is_valid( ) = abap_true.
+          CASE mo_popup->get_form_id( ).
+            WHEN c_popup-pull_request.
+              lv_pull_req = get_pull_request( mo_popup->get_value( zcl_abapgit_gui_popup_picklist=>c_selected_row ) ).
 
-            IF lv_pull_request IS NOT INITIAL.
-              mo_form_data->set(
-                iv_key = c_id-pull_request
-                iv_val = lv_pull_request ).
-              CLEAR mo_popup. "closes modal
-            ENDIF.
+              IF lv_pull_req IS NOT INITIAL.
+                mo_form_data->set(
+                  iv_key = c_id-pull_request
+                  iv_val = lv_pull_req ).
+                CLEAR mo_popup. "closes modal
+              ENDIF.
 
-        ENDCASE.
+          ENDCASE.
+        ENDIF.
 
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -168,9 +168,9 @@ CLASS zcl_abapgit_gui_page_sett_remo DEFINITION
         zcx_abapgit_exception.
     METHODS get_pull_request
       IMPORTING
-        !iv_selected_row TYPE string
+        !iv_selected_row       TYPE string
       RETURNING
-        VALUE(rv_val)    TYPE string
+        VALUE(rv_pull_request) TYPE string
       RAISING
         zcx_abapgit_exception.
 
@@ -484,7 +484,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
 
     READ TABLE mt_pulls INDEX lv_index INTO ls_pull.
     IF sy-subrc = 0.
-      rv_val = ls_pull-head_url && '@' && ls_pull-head_branch.
+      rv_pull_request = ls_pull-head_url && '@' && ls_pull-head_branch.
     ENDIF.
 
   ENDMETHOD.
@@ -832,7 +832,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       lv_branch                TYPE ty_remote_settings-branch,
       lv_url                   TYPE ty_remote_settings-url,
       lv_branch_check_error_id TYPE string,
-      lv_pull_req              TYPE ty_remote_settings-pull_request,
+      lv_pull_request          TYPE ty_remote_settings-pull_request,
       lv_commit                TYPE ty_remote_settings-commit.
 
     ro_validation_log = mo_form_util->validate( io_form_data ).
@@ -878,8 +878,8 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
           CONDENSE lv_branch.
           lv_branch_check_error_id = c_id-tag.
         WHEN c_head_types-pull_request.
-          lv_pull_req = io_form_data->get( c_id-pull_request ).
-          SPLIT lv_pull_req AT '@' INTO lv_url lv_branch.
+          lv_pull_request = io_form_data->get( c_id-pull_request ).
+          SPLIT lv_pull_request AT '@' INTO lv_url lv_branch.
           IF lv_branch IS NOT INITIAL.
             lv_branch = zif_abapgit_definitions=>c_git_branch-heads_prefix && lv_branch.
           ENDIF.
@@ -917,11 +917,11 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
   METHOD zif_abapgit_gui_event_handler~on_event.
 
     DATA:
-      lv_url      TYPE ty_remote_settings-url,
-      lv_branch   TYPE ty_remote_settings-branch,
-      lv_tag      TYPE ty_remote_settings-tag,
-      lv_commit   TYPE ty_remote_settings-commit,
-      lv_pull_req TYPE ty_remote_settings-pull_request.
+      lv_url          TYPE ty_remote_settings-url,
+      lv_branch       TYPE ty_remote_settings-branch,
+      lv_tag          TYPE ty_remote_settings-tag,
+      lv_commit       TYPE ty_remote_settings-commit,
+      lv_pull_request TYPE ty_remote_settings-pull_request.
 
     IF mo_popup IS INITIAL.
       mo_form_data = mo_form_util->normalize( ii_event->form_data( ) ).
@@ -1013,13 +1013,13 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
 
       WHEN c_popup-pull_request_ok.
         IF mo_popup->is_valid( ) = abap_true.
-          lv_pull_req = get_pull_request( mo_popup->get_value( zcl_abapgit_gui_popup_picklist=>c_selected_row ) ).
+          lv_pull_request = get_pull_request( mo_popup->get_value( zcl_abapgit_gui_popup_picklist=>c_selected_row ) ).
         ENDIF.
 
-        IF lv_pull_req IS NOT INITIAL.
+        IF lv_pull_request IS NOT INITIAL.
           mo_form_data->set(
             iv_key = c_id-pull_request
-            iv_val = lv_pull_req ).
+            iv_val = lv_pull_request ).
           CLEAR mo_popup.
         ENDIF.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -965,7 +965,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       lv_tag    TYPE ty_remote_settings-tag,
       lv_commit TYPE ty_remote_settings-commit.
 
-    IF mo_popup IS NOT INITIAL.
+    IF mo_popup IS INITIAL.
       mo_form_data = mo_form_util->normalize( ii_event->form_data( ) ).
     ENDIF.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -927,7 +927,6 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       mo_form_data = mo_form_util->normalize( ii_event->form_data( ) ).
     ELSE.
       mo_popup->normalize( ii_event->form_data( ) ).
-      mo_popup->validate( ).
     ENDIF.
 
     CASE ii_event->mv_action.
@@ -1012,6 +1011,8 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
       WHEN c_popup-pull_request_ok.
+        mo_popup->validate( ).
+
         IF mo_popup->is_valid( ) = abap_true.
           lv_pull_request = get_pull_request( mo_popup->get_value( zcl_abapgit_gui_popup_picklist=>c_selected_row ) ).
         ENDIF.
@@ -1020,13 +1021,13 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
           mo_form_data->set(
             iv_key = c_id-pull_request
             iv_val = lv_pull_request ).
-          CLEAR mo_popup.
+          CLEAR mo_popup. "closes modal
         ENDIF.
 
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
       WHEN c_popup-pull_request_cancel.
-        CLEAR mo_popup.
+        CLEAR mo_popup. "closes modal
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
 
     ENDCASE.

--- a/src/ui/popups/package.devc.xml
+++ b/src/ui/popups/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>abapGit - GUI Popups</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
@@ -148,13 +148,7 @@ CLASS zcl_abapgit_gui_popup IMPLEMENTATION.
 
   METHOD render.
 
-    DATA:
-      lv_closed TYPE string,
-      lv_style  TYPE string.
-
-*    IF is_valid( ) = abap_true.
-*      lv_closed = ' closed'.
-*    ENDIF.
+    DATA lv_style TYPE string.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
@@ -164,7 +158,7 @@ CLASS zcl_abapgit_gui_popup IMPLEMENTATION.
 
     lv_style = |width:{ ms_form-width }px; height:{ ms_form-height }px;|.
 
-    ri_html->add( |<div class="modal{ lv_closed }" id="{ ms_form-id }" style="{ lv_style }">| ).
+    ri_html->add( |<div class="modal" id="{ ms_form-id }" style="{ lv_style }">| ).
     ri_html->add( |<div class="modal-guts">| ).
     ri_html->add( mo_form->render(
                     iv_form_class     = ms_form-class
@@ -172,7 +166,7 @@ CLASS zcl_abapgit_gui_popup IMPLEMENTATION.
                     io_validation_log = mo_validation_log ) ).
     ri_html->add( |</div>| ).
     ri_html->add( |</div>| ).
-    ri_html->add( |<div class="modal-overlay{ lv_closed }" id="{ ms_form-id }-overlay"></div>| ).
+    ri_html->add( |<div class="modal-overlay" id="{ ms_form-id }-overlay"></div>| ).
 
     mo_validation_log->clear( ).
 

--- a/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
@@ -4,6 +4,12 @@ CLASS zcl_abapgit_gui_popup DEFINITION
 
   PUBLIC SECTION.
 
+    CONSTANTS:
+      BEGIN OF c_event,
+        ok     TYPE string VALUE 'ok',
+        cancel TYPE string VALUE 'cancel',
+      END OF c_event.
+
     METHODS constructor
       IMPORTING
         !iv_form_id TYPE string
@@ -50,6 +56,10 @@ CLASS zcl_abapgit_gui_popup DEFINITION
         !iv_key       TYPE string
       RETURNING
         VALUE(rt_val) TYPE string_table.
+
+    METHODS get_form_id
+      RETURNING
+        VALUE(rv_id) TYPE string.
 
   PROTECTED SECTION.
 
@@ -111,6 +121,11 @@ CLASS zcl_abapgit_gui_popup IMPLEMENTATION.
 
     CREATE OBJECT mo_form_data.
     CREATE OBJECT mo_validation_log.
+  ENDMETHOD.
+
+
+  METHOD get_form_id.
+    rv_id = ms_form-id.
   ENDMETHOD.
 
 

--- a/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
@@ -1,0 +1,196 @@
+CLASS zcl_abapgit_gui_popup DEFINITION
+  PUBLIC
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !iv_form_id TYPE string
+        !iv_class   TYPE string DEFAULT 'modal-dialog'
+        !io_form    TYPE REF TO zcl_abapgit_html_form.
+
+    METHODS set_dimensions
+      IMPORTING
+        !iv_width  TYPE i OPTIONAL
+        !iv_height TYPE i OPTIONAL.
+
+    METHODS render
+      RETURNING
+        VALUE(ri_html) TYPE REF TO zif_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS normalize
+      IMPORTING
+        !io_form_data TYPE REF TO zcl_abapgit_string_map
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS validate
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS clear
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS is_valid
+      RETURNING
+        VALUE(rv_valid) TYPE string.
+
+    METHODS get_value
+      IMPORTING
+        !iv_key       TYPE string
+      RETURNING
+        VALUE(rv_val) TYPE string.
+
+    METHODS get_values
+      IMPORTING
+        !iv_key       TYPE string
+      RETURNING
+        VALUE(rt_val) TYPE string_table.
+
+  PROTECTED SECTION.
+
+    METHODS add_validation_error
+      IMPORTING
+        !iv_key  TYPE string
+        !iv_text TYPE string
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS get_form_values
+      IMPORTING
+        !iv_val       TYPE string
+      RETURNING
+        VALUE(rt_val) TYPE string_table.
+
+  PRIVATE SECTION.
+
+    DATA:
+      BEGIN OF ms_form,
+        id     TYPE string,
+        class  TYPE string,
+        width  TYPE i,
+        height TYPE i,
+      END OF ms_form.
+
+    DATA mo_form TYPE REF TO zcl_abapgit_html_form.
+    DATA mo_form_util TYPE REF TO zcl_abapgit_html_form_utils.
+    DATA mo_form_data TYPE REF TO zcl_abapgit_string_map.
+    DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_popup IMPLEMENTATION.
+
+
+  METHOD add_validation_error.
+    mo_validation_log->set(
+      iv_key = |{ ms_form-id }-{ iv_key }|
+      iv_val = iv_text ).
+  ENDMETHOD.
+
+
+  METHOD clear.
+    mo_form_data->clear( ).
+  ENDMETHOD.
+
+
+  METHOD constructor.
+    ms_form-id     = iv_form_id.
+    ms_form-class  = iv_class.
+    ms_form-width  = 680.
+    ms_form-height = 300.
+
+    mo_form        = io_form.
+    mo_form_util   = zcl_abapgit_html_form_utils=>create( io_form ).
+
+    CREATE OBJECT mo_form_data.
+    CREATE OBJECT mo_validation_log.
+  ENDMETHOD.
+
+
+  METHOD get_form_values.
+    " Redefine to return multiple values
+    INSERT iv_val INTO TABLE rt_val.
+  ENDMETHOD.
+
+
+  METHOD get_value.
+    " Returns single form value
+    rv_val = mo_form_data->get( |{ ms_form-id }-{ iv_key }| ).
+  ENDMETHOD.
+
+
+  METHOD get_values.
+    " Return multiple values based on form input
+    rt_val = get_form_values( get_value( iv_key ) ).
+  ENDMETHOD.
+
+
+  METHOD is_valid.
+    rv_valid = mo_validation_log->is_empty( ).
+  ENDMETHOD.
+
+
+  METHOD normalize.
+    IF mo_form IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    mo_form_data = mo_form_util->normalize( io_form_data ).
+  ENDMETHOD.
+
+
+  METHOD render.
+
+    DATA:
+      lv_closed TYPE string,
+      lv_style  TYPE string.
+
+*    IF is_valid( ) = abap_true.
+*      lv_closed = ' closed'.
+*    ENDIF.
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    IF mo_form IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    lv_style = |width:{ ms_form-width }px; height:{ ms_form-height }px;|.
+
+    ri_html->add( |<div class="modal{ lv_closed }" id="{ ms_form-id }" style="{ lv_style }">| ).
+    ri_html->add( |<div class="modal-guts">| ).
+    ri_html->add( mo_form->render(
+                    iv_form_class     = ms_form-class
+                    io_values         = mo_form_data
+                    io_validation_log = mo_validation_log ) ).
+    ri_html->add( |</div>| ).
+    ri_html->add( |</div>| ).
+    ri_html->add( |<div class="modal-overlay{ lv_closed }" id="{ ms_form-id }-overlay"></div>| ).
+
+    mo_validation_log->clear( ).
+
+  ENDMETHOD.
+
+
+  METHOD set_dimensions.
+    IF iv_width IS NOT INITIAL.
+      ms_form-width  = iv_width.
+    ENDIF.
+    IF iv_height IS NOT INITIAL.
+      ms_form-height = iv_height.
+    ENDIF.
+  ENDMETHOD.
+
+
+  METHOD validate.
+    " Redefine to add own validation rules
+    mo_validation_log = mo_form_util->validate( mo_form_data ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup.clas.abap
@@ -6,8 +6,8 @@ CLASS zcl_abapgit_gui_popup DEFINITION
 
     CONSTANTS:
       BEGIN OF c_event,
-        ok     TYPE string VALUE 'ok',
-        cancel TYPE string VALUE 'cancel',
+        ok     TYPE string VALUE 'popup-ok',
+        cancel TYPE string VALUE 'popup-cancel',
       END OF c_event.
 
     METHODS constructor

--- a/src/ui/popups/zcl_abapgit_gui_popup.clas.xml
+++ b/src/ui/popups/zcl_abapgit_gui_popup.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_POPUP</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI Popup</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.abap
@@ -8,12 +8,6 @@ CLASS zcl_abapgit_gui_popup_picklist DEFINITION
 
     CONSTANTS c_selected_row TYPE string VALUE 'selected_row'.
 
-    CONSTANTS:
-      BEGIN OF c_event,
-        ok     TYPE string VALUE 'ok',
-        cancel TYPE string VALUE 'cancel',
-      END OF c_event.
-
     CLASS-METHODS create
       IMPORTING
         !iv_form_id     TYPE string
@@ -23,8 +17,8 @@ CLASS zcl_abapgit_gui_popup_picklist DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-    METHODS validate
-        REDEFINITION.
+    METHODS validate REDEFINITION.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -79,10 +73,10 @@ CLASS zcl_abapgit_gui_popup_picklist IMPLEMENTATION.
     ro_form->command(
       iv_label    = 'OK'
       iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
-      iv_action   = |{ iv_form_id }-{ c_event-ok }|
+      iv_action   = |{ zcl_abapgit_gui_popup=>c_event-ok }|
     )->command(
       iv_label    = 'Cancel'
-      iv_action   = |{ iv_form_id }-{ c_event-cancel }| ).
+      iv_action   = |{ zcl_abapgit_gui_popup=>c_event-cancel }| ).
 
   ENDMETHOD.
 

--- a/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.abap
@@ -6,8 +6,7 @@ CLASS zcl_abapgit_gui_popup_picklist DEFINITION
 
   PUBLIC SECTION.
 
-    CONSTANTS:
-      c_selected_row TYPE string VALUE 'selected_row'.
+    CONSTANTS c_selected_row TYPE string VALUE 'selected_row'.
 
     CONSTANTS:
       BEGIN OF c_event,
@@ -18,12 +17,14 @@ CLASS zcl_abapgit_gui_popup_picklist DEFINITION
     CLASS-METHODS create
       IMPORTING
         !iv_form_id     TYPE string
-        it_list         TYPE STANDARD TABLE
+        !it_list        TYPE STANDARD TABLE
       RETURNING
         VALUE(ro_popup) TYPE REF TO zcl_abapgit_gui_popup_picklist
       RAISING
         zcx_abapgit_exception.
 
+    METHODS validate
+        REDEFINITION.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -82,6 +83,19 @@ CLASS zcl_abapgit_gui_popup_picklist IMPLEMENTATION.
     )->command(
       iv_label    = 'Cancel'
       iv_action   = |{ iv_form_id }-{ c_event-cancel }| ).
+
+  ENDMETHOD.
+
+
+  METHOD validate.
+
+    super->validate( ).
+
+    IF get_value( c_selected_row ) IS INITIAL.
+      add_validation_error(
+        iv_key  = c_selected_row
+        iv_text = |You have to select one item| ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.abap
+++ b/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.abap
@@ -1,0 +1,87 @@
+CLASS zcl_abapgit_gui_popup_picklist DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_popup
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    CONSTANTS:
+      c_selected_row TYPE string VALUE 'selected_row'.
+
+    CONSTANTS:
+      BEGIN OF c_event,
+        ok     TYPE string VALUE 'ok',
+        cancel TYPE string VALUE 'cancel',
+      END OF c_event.
+
+    CLASS-METHODS create
+      IMPORTING
+        !iv_form_id     TYPE string
+        it_list         TYPE STANDARD TABLE
+      RETURNING
+        VALUE(ro_popup) TYPE REF TO zcl_abapgit_gui_popup_picklist
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CLASS-METHODS get_form_schema
+      IMPORTING
+        !iv_form_id    TYPE string
+        it_list        TYPE STANDARD TABLE
+      RETURNING
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_popup_picklist IMPLEMENTATION.
+
+
+  METHOD create.
+
+    CREATE OBJECT ro_popup
+      EXPORTING
+        iv_form_id = iv_form_id
+        io_form    = get_form_schema(
+                       iv_form_id = iv_form_id
+                       it_list    = it_list ).
+
+    ro_popup->set_dimensions( iv_height = 120 + lines( it_list ) * 25 ).
+
+  ENDMETHOD.
+
+
+  METHOD get_form_schema.
+
+    FIELD-SYMBOLS <ls_row> TYPE any.
+
+    ro_form = zcl_abapgit_html_form=>create( iv_form_id = iv_form_id ).
+
+    " Always prefix names with form id to distinguish them from the calling page and other popups
+    ro_form->radio(
+      iv_name     = |{ iv_form_id }-{ c_selected_row }|
+      iv_condense = abap_true
+      iv_label    = 'Select a Value from the List' ).
+
+    LOOP AT it_list ASSIGNING <ls_row>.
+      ro_form->option(
+        iv_label = <ls_row>
+        iv_value = |{ sy-tabix }| ).
+    ENDLOOP.
+
+    ro_form->command(
+      iv_label    = 'OK'
+      iv_cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main
+      iv_action   = |{ iv_form_id }-{ c_event-ok }|
+    )->command(
+      iv_label    = 'Cancel'
+      iv_action   = |{ iv_form_id }-{ c_event-cancel }| ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.xml
+++ b/src/ui/popups/zcl_abapgit_gui_popup_picklist.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_POPUP_PICKLIST</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI Popup Pick from List</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1502,4 +1502,57 @@ table.unit_tests {
 /* Warning if wrong browser control is used */
 .browser-control-warning {
   width: 100%;
-}
+}
+
+/* MODAL POPUP */
+/* https://css-tricks.com/considerations-styling-modal/ */
+
+.modal {
+    /* center on screen */
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    /* size */
+    width: 680px;
+    max-width: 100%;
+    height: 260px;
+    max-height: 100%;
+    /* infront of overlay */
+    z-index: 1010;
+    /* show by default */
+    display: block;
+    /* style */
+    background: lightgray;
+    border-radius: 6px;
+}
+
+.modal-guts {
+    /* cover the modal */
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* spacing as needed */
+    padding: 5px 0px;
+    /* let it scroll */
+    overflow: auto;
+}
+
+.modal-guts .dialog {
+    margin-top: inherit;
+    margin-bottom: inherit;
+    padding: inherit;
+}
+
+.modal-overlay {
+    /* darken and prevent interactions with background */
+    z-index: 1000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
This took a while to figure out but here are modal popups in abapGit 😀 

Might need a bit of CSS fine-tuning but works like a charm otherwise.

![saplogon_1396](https://github.com/abapGit/abapGit/assets/59966492/0e6a1faa-4492-401f-8d71-b8f32e56a573)

How it works:

- Page contains a reference to popup object (`mo_popup`)
- If popup object is defined, then it's rendered as a modal overlay
- Events from the popup form are then processed by the page again (`on_popup_event`)

To implement a new popup type, create a class inheriting from `zcl_abapgit_gui_popup` and define the form (for example, `zcl_abapgit_gui_popup_picklist`). You probably want to set the popup dimensions and maybe add validations. I don't think it could be simpler.

