### PR TITLE
FUGR, CLAS: Enhance "changed by"

### DIFF
--- a/src/background/zcl_abapgit_background_push_au.clas.abap
+++ b/src/background/zcl_abapgit_background_push_au.clas.abap
@@ -113,7 +113,9 @@ CLASS zcl_abapgit_background_push_au IMPLEMENTATION.
     ls_files = zcl_abapgit_factory=>get_stage_logic( )->get( io_repo ).
 
     LOOP AT ls_files-local ASSIGNING <ls_local>.
-      lv_changed_by = zcl_abapgit_objects=>changed_by( <ls_local>-item ).
+      lv_changed_by = zcl_abapgit_objects=>changed_by(
+        is_item     = <ls_local>-item
+        iv_filename = <ls_local>-file-filename ).
       APPEND lv_changed_by TO lt_users.
       APPEND INITIAL LINE TO lt_changed ASSIGNING <ls_changed>.
       <ls_changed>-changed_by = lv_changed_by.

--- a/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
@@ -477,7 +477,9 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
     " Changed by
     IF <ls_local>-item-obj_type IS NOT INITIAL.
-      <ls_diff>-changed_by = zcl_abapgit_objects=>changed_by( <ls_local>-item ).
+      <ls_diff>-changed_by = zcl_abapgit_objects=>changed_by(
+        is_item     = <ls_local>-item
+        iv_filename = is_status-filename ).
     ENDIF.
     IF <ls_diff>-changed_by IS INITIAL.
       <ls_diff>-changed_by = zcl_abapgit_objects_super=>c_user_unknown.

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -504,11 +504,6 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
     ls_item-obj_type = cl_http_utility=>unescape_url( |{ iv_obj_type }| ).
     ls_item-obj_name = cl_http_utility=>unescape_url( |{ iv_obj_name }| ).
 
-    IF iv_filename IS NOT INITIAL.
-      FIND REGEX '\..*\.([\-a-z0-9_%]*)\.' IN iv_filename SUBMATCHES lv_extra.
-      lv_extra = cl_http_utility=>unescape_url( lv_extra ).
-    ENDIF.
-
     TRY.
         li_html_viewer = zcl_abapgit_ui_factory=>get_html_viewer( ).
 
@@ -519,8 +514,8 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
           zcl_abapgit_data_utils=>jump( ls_item ).
         ELSE.
           zcl_abapgit_objects=>jump(
-            is_item  = ls_item
-            iv_extra = lv_extra ).
+            is_item     = ls_item
+            iv_filename = iv_filename ).
         ENDIF.
 
         li_html_viewer->set_visiblity( abap_true ).


### PR DESCRIPTION
Leveraging the new serialize interface, the "changed_by" method for function groups and classes. On diff and stage views, sub-objects are now derived from the filename and used to determine the correct user who changed the sub-object last.

Includes minor refactor for "jump" method.

Example:

Showing different users for different parts of a class

![image](https://github.com/abapGit/abapGit/assets/59966492/0fddd0af-82f0-4064-a61a-84f747f6dc7e)

Showing different users for different parts of a function group

![image](https://github.com/abapGit/abapGit/assets/59966492/92cf55c6-f85a-4334-9a8f-0af2fb6721fb)

Note: The logic for determining the last changed user for the complete object (tadir level) remains unchanged. 