### PR TITLE
SICF: Remove special TADIR logic

### DIFF
--- a/src/objects/core/zcl_abapgit_tadir.clas.abap
+++ b/src/objects/core/zcl_abapgit_tadir.clas.abap
@@ -68,14 +68,6 @@ CLASS zcl_abapgit_tadir DEFINITION
         !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS adjust_objects
-      IMPORTING
-        !iv_package TYPE tadir-devclass
-        !io_dot     TYPE REF TO zcl_abapgit_dot_abapgit
-      CHANGING
-        !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt
-      RAISING
-        zcx_abapgit_exception ##NEEDED.
     METHODS is_sots_excluded
       IMPORTING
         !it_packages      TYPE zif_abapgit_sap_package=>ty_devclass_tt
@@ -175,34 +167,6 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD adjust_objects.
-
-    " Todo, replace with solution that will work with any object type (might depend on iv_package and io_dot)
-
-    FIELD-SYMBOLS <ls_tadir> LIKE LINE OF ct_tadir.
-
-    LOOP AT ct_tadir ASSIGNING <ls_tadir>.
-
-      IF <ls_tadir>-object = 'SICF'.
-        " Replace the internal GUID with a hash of the path
-        TRY.
-            CALL METHOD ('ZCL_ABAPGIT_OBJECT_SICF')=>read_sicf_url
-              EXPORTING
-                iv_obj_name = <ls_tadir>-obj_name
-              RECEIVING
-                rv_hash     = <ls_tadir>-obj_name+15.
-
-          CATCH cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-            " SICF might not be supported in some systems, assume this code is not called
-        ENDTRY.
-      ENDIF.
-
-      CLEAR <ls_tadir>-korrnum.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
   METHOD build.
 
     DATA lt_packages TYPE zif_abapgit_sap_package=>ty_devclass_tt.
@@ -229,13 +193,6 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
         ct_tadir   = rt_tadir ).
 
     determine_path(
-      EXPORTING
-        iv_package = iv_package
-        io_dot     = io_dot
-      CHANGING
-        ct_tadir   = rt_tadir ).
-
-    adjust_objects(
       EXPORTING
         iv_package = iv_package
         io_dot     = io_dot
@@ -304,8 +261,9 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
       ENDIF.
 
       <ls_tadir>-path = lv_path.
-
+      <ls_tadir>-korrnum = ''.
     ENDLOOP.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -8,10 +8,10 @@ CLASS zcl_abapgit_object_sicf DEFINITION
 
     INTERFACES zif_abapgit_object .
 
-    TYPES: ty_hash TYPE c LENGTH 25.
-
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    TYPES ty_hash TYPE c LENGTH 25.
 
     TYPES:
       ty_icfhandler_tt TYPE STANDARD TABLE OF icfhandler WITH DEFAULT KEY .

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -10,21 +10,6 @@ CLASS zcl_abapgit_object_sicf DEFINITION
 
     TYPES: ty_hash TYPE c LENGTH 25.
 
-    CLASS-METHODS read_tadir_sicf
-      IMPORTING
-        !iv_pgmid       TYPE tadir-pgmid DEFAULT 'R3TR'
-        !iv_obj_name    TYPE tadir-obj_name
-      RETURNING
-        VALUE(rs_tadir) TYPE zif_abapgit_definitions=>ty_tadir
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS read_sicf_url
-      IMPORTING
-        !iv_obj_name   TYPE tadir-obj_name
-      RETURNING
-        VALUE(rv_hash) TYPE ty_hash
-      RAISING
-        zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -55,7 +40,6 @@ CLASS zcl_abapgit_object_sicf DEFINITION
         !es_icfdocu    TYPE icfdocu
         !et_icfhandler TYPE ty_icfhandler_tt
         !ev_url        TYPE string
-        !ev_obj_name   TYPE sobj_name
       RAISING
         zcx_abapgit_exception .
     METHODS insert_sicf
@@ -88,6 +72,14 @@ CLASS zcl_abapgit_object_sicf DEFINITION
         VALUE(rv_parent) TYPE icfparguid
       RAISING
         zcx_abapgit_exception .
+
+    CLASS-METHODS get_hash_from_object
+      IMPORTING
+        !iv_obj_name   TYPE tadir-obj_name
+      RETURNING
+        VALUE(rv_hash) TYPE ty_hash
+      RAISING
+        zcx_abapgit_exception.
 ENDCLASS.
 
 
@@ -165,14 +157,11 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
   METHOD deserialize_otr.
 
     DATA:
-      lv_obj_name TYPE sobj_name,
       lt_sots     TYPE zcl_abapgit_sots_handler=>ty_sots_tt,
       lt_sots_use TYPE zcl_abapgit_sots_handler=>ty_sots_use_tt.
 
     FIELD-SYMBOLS:
       <ls_sots_use> LIKE LINE OF lt_sots_use.
-
-    read( IMPORTING ev_obj_name = lv_obj_name ).
 
     io_xml->read( EXPORTING iv_name = 'SOTS'
                   CHANGING cg_data = lt_sots ).
@@ -180,7 +169,7 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
                   CHANGING cg_data = lt_sots_use ).
 
     LOOP AT lt_sots_use ASSIGNING <ls_sots_use>.
-      <ls_sots_use>-obj_name = lv_obj_name.
+      <ls_sots_use>-obj_name = ms_item-obj_name.
     ENDLOOP.
 
     zcl_abapgit_sots_handler=>create_sots_from_data(
@@ -213,11 +202,49 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_hash_from_object.
+
+    DATA:
+      lv_icfnodguid TYPE icfservice-icfnodguid,
+      lv_url        TYPE icfurlbuf,
+      lv_ext_url    TYPE string.
+
+    SELECT SINGLE icfnodguid FROM icfservice INTO lv_icfnodguid
+      WHERE icf_name = iv_obj_name(15)
+      AND icfparguid = iv_obj_name+15.
+
+    IF sy-subrc = 0.
+      CALL FUNCTION 'HTTP_GET_URL_FROM_NODGUID'
+        EXPORTING
+          nodguid      = lv_icfnodguid
+        IMPORTING
+          url          = lv_url
+          extended_url = lv_ext_url
+        EXCEPTIONS
+          icf_inconst  = 1
+          OTHERS       = 2.
+      IF sy-subrc = 0.
+        " It's possible that the URL contains the system id, for example for WD applications with names
+        " longer than 15 characters. In that case, use the extended URL to generate the hash (#5064)
+        IF lv_ext_url <> lv_url.
+          rv_hash = zcl_abapgit_hash=>sha1_raw( zcl_abapgit_convert=>string_to_xstring_utf8( |{ lv_ext_url }| ) ).
+        ELSE.
+          rv_hash = zcl_abapgit_hash=>sha1_raw( zcl_abapgit_convert=>string_to_xstring_utf8( |{ lv_url }| ) ).
+        ENDIF.
+      ENDIF.
+    ELSE.
+      rv_hash = to_lower( iv_obj_name+15 ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD insert_sicf.
 
     DATA: lt_icfhndlist TYPE icfhndlist,
           ls_icfserdesc TYPE icfserdesc,
           ls_icfdocu    TYPE icfdocu,
+          lv_icfnodguid TYPE icfnodguid,
           lv_parent     TYPE icfparguid.
 
 
@@ -241,6 +268,8 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
         icfserdesc                = ls_icfserdesc
         icfactive                 = abap_true
         icfaltnme                 = is_icfservice-icfaltnme
+      IMPORTING
+        icfnodguid                = lv_icfnodguid
       EXCEPTIONS
         empty_icf_name            = 1
         no_new_virtual_host       = 2
@@ -273,6 +302,10 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
+    " Update item with name assigned by system
+    SELECT SINGLE icfparguid INTO ms_item-obj_name+15 FROM icfservice
+      WHERE icfnodguid = lv_icfnodguid.
+
   ENDMETHOD.
 
 
@@ -290,8 +323,8 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
     CLEAR et_icfhandler.
     CLEAR ev_url.
 
-    ls_key = read_tadir_sicf( ms_item-obj_name )-obj_name.
-    ev_obj_name = ls_key.
+    ls_key-icf_name   = ms_item-obj_name(15).
+    ls_key-icfparguid = ms_item-obj_name+15.
 
     cl_icf_tree=>if_icf_tree~get_info_from_serv(
       EXPORTING
@@ -334,87 +367,19 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD read_sicf_url.
-
-* note: this method is called dynamically from some places
-
-    DATA: lv_name       TYPE icfservice-icf_name,
-          lv_url        TYPE icfurlbuf,
-          lv_string     TYPE string,
-          lv_icfnodguid TYPE icfservice-icfnodguid,
-          lv_parguid    TYPE icfservice-icfparguid.
-
-
-    lv_name    = iv_obj_name.
-    lv_parguid = iv_obj_name+15.
-
-    SELECT SINGLE icfnodguid FROM icfservice INTO lv_icfnodguid
-      WHERE icf_name = lv_name
-      AND icfparguid = lv_parguid.
-
-    CALL FUNCTION 'HTTP_GET_URL_FROM_NODGUID'
-      EXPORTING
-        nodguid     = lv_icfnodguid
-      IMPORTING
-        url         = lv_url
-      EXCEPTIONS
-        icf_inconst = 1
-        OTHERS      = 2.
-    IF sy-subrc = 0.
-      lv_string = lv_url.
-      rv_hash = zcl_abapgit_hash=>sha1_raw( zcl_abapgit_convert=>string_to_xstring_utf8( lv_string ) ).
-      rv_hash = to_upper( rv_hash ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD read_tadir_sicf.
-
-* note: this method is called dynamically from some places
-
-    DATA: lt_tadir    TYPE zif_abapgit_definitions=>ty_tadir_tt,
-          lv_hash     TYPE ty_hash,
-          lv_obj_name TYPE tadir-obj_name.
-
-    FIELD-SYMBOLS: <ls_tadir> LIKE LINE OF lt_tadir.
-
-
-    lv_hash = iv_obj_name+15.
-    CONCATENATE iv_obj_name(15) '%' INTO lv_obj_name.
-
-    SELECT * FROM tadir INTO CORRESPONDING FIELDS OF TABLE lt_tadir
-      WHERE pgmid = iv_pgmid
-      AND object = 'SICF'
-      AND obj_name LIKE lv_obj_name
-      ORDER BY PRIMARY KEY ##TOO_MANY_ITAB_FIELDS.      "#EC CI_GENBUFF
-
-    LOOP AT lt_tadir ASSIGNING <ls_tadir>.
-      IF read_sicf_url( <ls_tadir>-obj_name ) = to_upper( lv_hash ).
-        rs_tadir = <ls_tadir>.
-        RETURN.
-      ENDIF.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
   METHOD serialize_otr.
 
     DATA:
-      lv_obj_name TYPE sobj_name,
       lt_sots     TYPE zcl_abapgit_sots_handler=>ty_sots_tt,
       lt_sots_use TYPE zcl_abapgit_sots_handler=>ty_sots_use_tt.
 
     FIELD-SYMBOLS:
       <ls_sots_use> LIKE LINE OF lt_sots_use.
 
-    read( IMPORTING ev_obj_name = lv_obj_name ).
-
     zcl_abapgit_sots_handler=>read_sots(
       EXPORTING
         iv_object   = ms_item-obj_type
-        iv_obj_name = lv_obj_name
+        iv_obj_name = ms_item-obj_name
       IMPORTING
         et_sots     = lt_sots
         et_sots_use = lt_sots_use ).
@@ -436,7 +401,7 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_list> LIKE LINE OF it_list.
 
 
-* convert to sorted table
+    " Convert to sorted table
     LOOP AT it_list ASSIGNING <ls_list>.
       INSERT <ls_list>-icfhandler INTO TABLE rt_list.
     ENDLOOP.
@@ -463,12 +428,9 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
 
   METHOD zif_abapgit_object~delete.
 
-    DATA:
-      ls_icfservice TYPE icfservice,
-      lv_obj_name   TYPE sobj_name.
+    DATA ls_icfservice TYPE icfservice.
 
-    read( IMPORTING es_icfservice = ls_icfservice
-                    ev_obj_name   = lv_obj_name ).
+    read( IMPORTING es_icfservice = ls_icfservice ).
 
     IF ls_icfservice IS INITIAL.
       " It seems that the ICF service doesn't exist anymore.
@@ -486,7 +448,7 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
     " OTR long texts
     zcl_abapgit_sots_handler=>delete_sots(
       iv_object   = ms_item-obj_type
-      iv_obj_name = lv_obj_name ).
+      iv_obj_name = ms_item-obj_name ).
 
     " Delete Application Customizing Data the hard way, as it isn't done by the API.
     " If we wouldn't we would get errors from the API if entrys exist.
@@ -566,14 +528,10 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
 
     DATA ls_key TYPE ty_sicf_key.
 
-    ls_key = read_tadir_sicf( ms_item-obj_name )-obj_name.
-
-    IF ls_key IS NOT INITIAL.
-      SELECT SINGLE icfaltnme FROM icfservice INTO ls_key-icf_name
-        WHERE icf_name = ls_key-icf_name
-        AND icfparguid = ls_key-icfparguid.
-      rv_bool = boolc( sy-subrc = 0 ).
-    ENDIF.
+    SELECT SINGLE icfaltnme FROM icfservice INTO ls_key-icf_name
+      WHERE icf_name = ms_item-obj_name(15)
+      AND icfparguid = ms_item-obj_name+15.
+    rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
 
@@ -646,12 +604,42 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~map_filename_to_object.
-    RETURN.
+
+    DATA:
+      lt_tadir    TYPE zif_abapgit_definitions=>ty_tadir_tt,
+      lv_hash     TYPE ty_hash,
+      lv_obj_name TYPE tadir-obj_name.
+
+    FIELD-SYMBOLS <ls_tadir> LIKE LINE OF lt_tadir.
+
+    lv_obj_name = to_upper( iv_filename(15) ) && '%'.
+    lv_hash     = iv_filename+15(25).
+
+    SELECT * FROM tadir INTO CORRESPONDING FIELDS OF TABLE lt_tadir
+      WHERE pgmid = 'R3TR'
+      AND object  = 'SICF'
+      AND obj_name LIKE lv_obj_name
+      ORDER BY PRIMARY KEY ##TOO_MANY_ITAB_FIELDS.      "#EC CI_GENBUFF
+
+    LOOP AT lt_tadir ASSIGNING <ls_tadir>.
+      IF get_hash_from_object( <ls_tadir>-obj_name ) = lv_hash.
+        cs_item-obj_name = <ls_tadir>-obj_name.
+        RETURN.
+      ENDIF.
+    ENDLOOP.
+
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~map_object_to_filename.
-    RETURN.
+
+    DATA:
+      lv_rest     TYPE string,
+      lv_old_name TYPE string.
+
+    SPLIT cv_filename AT '.' INTO lv_old_name lv_rest.
+    cv_filename = |{ cv_filename(15) }{ get_hash_from_object( is_item-obj_name ) }.{ lv_rest }|.
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Leveraging the new serializer interface. The change removes the special logic translating TADIR into ITEM for `SICF` and replaces it with an equivalent mapping between object and filenames. 

The implementation of the serializer class is now much more straight forward. It's always using `ms_item` to refer to the object which is equivalent to the tadir entry like for other objects. 

Ref #3453, #4187, #5064 
Closes #6172

PS: Breaks `zcl_abapgit_ci_repo` (https://github.com/abapGit/CI/pull/228)