### PR TITLE
Pull dialog safeguard

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -136,6 +136,11 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
 
     CLEAR et_list.
 
+    " Make sure we don't accidentally return anything
+    IF mv_cancel = abap_true.
+      RETURN.
+    ENDIF.
+
     ASSIGN mr_table->* TO <lt_table>.
     ASSERT sy-subrc = 0.
 


### PR DESCRIPTION
I'm pretty sure, I cancelled a pull dialog the other day but objects got pulled anyway overwriting a lot of uncommitted changes (I think someone else mentioned something like it before but I can't find the reference).

I reviewed the code intensely but can't find any root cause. It might be related to the exception handling.

This change adds a safeguard so no entries are returned if the popup is cancelled and the exception didn't work properly.