### PR TITLE
Enhance User Exit Framework

### DIFF
--- a/src/exits/zcl_abapgit_exit_caller.clas.abap
+++ b/src/exits/zcl_abapgit_exit_caller.clas.abap
@@ -1,0 +1,512 @@
+CLASS zcl_abapgit_exit_caller DEFINITION
+  PUBLIC
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_exit.
+
+    CLASS-METHODS init.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      c_exit_super TYPE seoclsname VALUE 'ZCL_ABAPGIT_EXIT_SUPER'.
+
+    TYPES:
+      ty_instance TYPE REF TO zif_abapgit_exit.
+
+    CLASS-DATA:
+      gv_init  TYPE abap_bool,
+      gi_exit  TYPE ty_instance,
+      gt_exits TYPE STANDARD TABLE OF ty_instance WITH DEFAULT KEY.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_exit_caller IMPLEMENTATION.
+
+
+  METHOD init.
+
+    DATA lv_clsname TYPE seoclsname.
+
+    CHECK gv_init IS INITIAL.
+
+    " Get all classes that inherit from abapGit default exit implementation
+    SELECT clsname FROM seometarel INTO lv_clsname
+      WHERE refclsname = c_exit_super AND reltype = '2'.
+
+      TRY.
+          CREATE OBJECT gi_exit TYPE (lv_clsname).
+          INSERT gi_exit INTO TABLE gt_exits.
+        CATCH cx_root.
+          CONTINUE. "ignore
+      ENDTRY.
+    ENDSELECT.
+
+    gv_init = abap_true.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~adjust_display_commit_url.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->adjust_display_commit_url(
+            EXPORTING
+              iv_repo_url    = iv_repo_url
+              iv_repo_name   = iv_repo_name
+              iv_repo_key    = iv_repo_key
+              iv_commit_hash = iv_commit_hash
+            CHANGING
+              cv_display_url = cv_display_url ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~adjust_display_filename.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          rv_filename = gi_exit->adjust_display_filename( iv_filename ).
+
+          IF rv_filename IS NOT INITIAL.
+            RETURN. ">>>
+          ENDIF.
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+    IF rv_filename IS INITIAL.
+      rv_filename = iv_filename.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~allow_sap_objects.
+
+    init( ).
+
+    " First call wins
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          rv_allowed = gi_exit->allow_sap_objects( ).
+
+          IF rv_allowed IS NOT INITIAL.
+            RETURN. ">>>
+          ENDIF.
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_local_host.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_local_host( CHANGING ct_hosts = ct_hosts ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_proxy_authentication.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_proxy_authentication(
+            EXPORTING
+              iv_repo_url             = iv_repo_url
+            CHANGING
+              cv_proxy_authentication = cv_proxy_authentication ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_proxy_port.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_proxy_port(
+            EXPORTING
+              iv_repo_url   = iv_repo_url
+            CHANGING
+              cv_proxy_port = cv_proxy_port ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_proxy_url.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_proxy_url(
+            EXPORTING
+              iv_repo_url  = iv_repo_url
+            CHANGING
+              cv_proxy_url = cv_proxy_url ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_supported_data_objects.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_supported_data_objects( CHANGING ct_objects = ct_objects ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_supported_object_types.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_supported_object_types( CHANGING ct_types = ct_types ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_tadir.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->change_tadir(
+            EXPORTING
+              iv_package = iv_package
+              ii_log     = ii_log
+            CHANGING
+              ct_tadir   = ct_tadir ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~create_http_client.
+
+    init( ).
+
+    " First call wins
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          ri_client = gi_exit->create_http_client( iv_url ).
+
+          IF ri_client IS NOT INITIAL.
+            RETURN. ">>>
+          ENDIF.
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~custom_serialize_abap_clif.
+
+    init( ).
+
+    " First call wins
+
+    " This exit might be called twice per object
+    " 1st call: it_source = initial
+    "    Can be used for serializing complete source
+    "    If source is returned, there will be no second call
+    " 2nd call: it_source = code as serialized by abapGit
+    "    Can be used for post-processing of source
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          rt_source = gi_exit->custom_serialize_abap_clif(
+            is_class_key = is_class_key
+            it_source    = it_source ).
+
+          IF rt_source IS NOT INITIAL.
+            RETURN. ">>>
+          ENDIF.
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+    IF rt_source IS INITIAL.
+      rt_source = it_source.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~deserialize_postprocess.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->deserialize_postprocess( is_step = is_step
+                                            ii_log  = ii_log ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~determine_transport_request.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->determine_transport_request(
+            EXPORTING
+              io_repo              = io_repo
+              iv_transport_type    = iv_transport_type
+            CHANGING
+              cv_transport_request = cv_transport_request ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~enhance_repo_toolbar.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->enhance_repo_toolbar(
+            io_menu = io_menu
+            iv_key  = iv_key
+            iv_act  = iv_act ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~get_ci_tests.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->get_ci_tests(
+            EXPORTING
+              iv_object   = iv_object
+            CHANGING
+              ct_ci_repos = ct_ci_repos ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~get_ssl_id.
+
+    init( ).
+
+    " First call wins
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          rv_ssl_id = gi_exit->get_ssl_id( ).
+
+          IF rv_ssl_id IS NOT INITIAL.
+            RETURN. ">>>
+          ENDIF.
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+    IF rv_ssl_id IS INITIAL.
+      rv_ssl_id = 'ANONYM'.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~http_client.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->http_client(
+            iv_url    = iv_url
+            ii_client = ii_client ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~on_event.
+
+    init( ).
+
+    " First call wins
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          rs_handled = gi_exit->on_event( ii_event ).
+
+          IF rs_handled IS NOT INITIAL.
+            RETURN. ">>>
+          ENDIF.
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~pre_calculate_repo_status.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->pre_calculate_repo_status(
+            EXPORTING
+              is_repo_meta = is_repo_meta
+            CHANGING
+              ct_local     = ct_local
+              ct_remote    = ct_remote ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~serialize_postprocess.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->serialize_postprocess(
+            EXPORTING
+              iv_package = iv_package
+              ii_log     = ii_log
+            CHANGING
+              ct_files   = ct_files ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~validate_before_push.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->validate_before_push(
+            is_comment = is_comment
+            io_stage   = io_stage
+            io_repo    = io_repo ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~wall_message_list.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->wall_message_list( ii_html ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~wall_message_repo.
+
+    init( ).
+
+    " Multiple calls possible
+    LOOP AT gt_exits INTO gi_exit.
+      TRY.
+          gi_exit->wall_message_repo(
+            is_repo_meta = is_repo_meta
+            ii_html      = ii_html ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDLOOP.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/exits/zcl_abapgit_exit_caller.clas.abap
+++ b/src/exits/zcl_abapgit_exit_caller.clas.abap
@@ -33,7 +33,9 @@ CLASS zcl_abapgit_exit_caller IMPLEMENTATION.
 
     DATA lv_clsname TYPE seoclsname.
 
-    CHECK gv_init IS INITIAL.
+    IF gv_init = abap_true.
+      RETURN.
+    ENDIF.
 
     " Get all classes that inherit from abapGit default exit implementation
     SELECT clsname FROM seometarel INTO lv_clsname

--- a/src/exits/zcl_abapgit_exit_caller.clas.xml
+++ b/src/exits/zcl_abapgit_exit_caller.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_EXIT_CALLER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Exit Caller</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/exits/zcl_abapgit_exit_super.clas.abap
+++ b/src/exits/zcl_abapgit_exit_super.clas.abap
@@ -1,0 +1,135 @@
+CLASS zcl_abapgit_exit_super DEFINITION
+  PUBLIC
+  CREATE PROTECTED.
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_exit.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_exit_super IMPLEMENTATION.
+
+
+  METHOD zif_abapgit_exit~adjust_display_commit_url.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~adjust_display_filename.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~allow_sap_objects.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_local_host.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_proxy_authentication.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_proxy_port.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_proxy_url.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_supported_data_objects.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_supported_object_types.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~change_tadir.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~create_http_client.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~custom_serialize_abap_clif.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~deserialize_postprocess.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~determine_transport_request.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~enhance_repo_toolbar.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~get_ci_tests.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~get_ssl_id.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~http_client.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~on_event.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~pre_calculate_repo_status.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~serialize_postprocess.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~validate_before_push.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~wall_message_list.
+    RETURN.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~wall_message_repo.
+    RETURN.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/exits/zcl_abapgit_exit_super.clas.xml
+++ b/src/exits/zcl_abapgit_exit_super.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_EXIT_SUPER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Exit Superclass</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -85,6 +85,11 @@ INTERFACE zif_abapgit_exit
       !iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
     CHANGING
       !cv_transport_request TYPE trkorr .
+  METHODS enhance_repo_toolbar
+    IMPORTING
+      !io_menu TYPE REF TO zcl_abapgit_html_toolbar
+      !iv_key  TYPE zif_abapgit_persistence=>ty_value
+      !iv_act  TYPE string.
   METHODS get_ci_tests
     IMPORTING
       !iv_object   TYPE tadir-object
@@ -132,9 +137,4 @@ INTERFACE zif_abapgit_exit
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
       !ii_html      TYPE REF TO zif_abapgit_html .
-  METHODS enhance_repo_toolbar
-    IMPORTING
-      !io_menu TYPE REF TO zcl_abapgit_html_toolbar
-      !iv_key  TYPE zif_abapgit_persistence=>ty_value
-      !iv_act  TYPE string.
 ENDINTERFACE.


### PR DESCRIPTION
Currently, we are limited to one class (`zcl_abapgit_user_exits`) for implementing all exist methods. This leads to conflicts or manual effort when several solutions need to implement exits.

```mermaid
---
title: Existing framework
---
classDiagram
  direction LR
  class zcl_abapgit_exit {
    +gi_exit zif_abapgit_exit
    +create_http_client()
    +wall_message_repo()
  }
  class zcl_abapgit_user_exit {
    +create_http_client()
    +wall_message_repo()
  }
  zcl_abapgit_exit .. zcl_abapgit_user_exit
```

Note: There's a lot of text (documentation) below but the resulting solution is actually quite simple (see code example below). 

### Goals of this Enhancement

- Compatibility: existing user exits continue to work as is
- Development: new framework is easy to implement and maintain
- Deployment: repos are able to ship user exit implementations
- Runtime: support for more than one exit class within one or more repos
- Migration: low effort to move existing user exit implementations to the new framework

### Solution

```mermaid
---
title: Enhanced framework
---
classDiagram
  class zcl_abapgit_exit_caller  {
    <<new>>
    +gt_exits zif_abapgit_exit
    +create_http_client()
    +wall_message_repo()
  }
  class zcl_abapgit_user_exit {
  }
  class zcl_abapgit_exit_super {
    <<new>>
    +create_http_client()
    +wall_message_repo()
  }
  class zcl_abapgit_user_exit_client {
    +create_http_client() redefined
  }
  class zcl_abapgit_user_exit_wall {
    +wall_message_repo() redefined
  }
  zcl_abapgit_exit_caller <|-- zcl_abapgit_user_exit : inherit
  zcl_abapgit_exit_super <|-- zcl_abapgit_user_exit_client : inherit
  zcl_abapgit_exit_super <|-- zcl_abapgit_user_exit_wall : inherit
```

1. Class `zcl_abapgit_exit_super` 

- Contains a default implementation for all exit methods (i.e. just a `RETURN` statement)
- Is used as super class for classes implementing exists
- Therefore, a class for user exists just needs to redefined the methods it wants to implement
- Changes to unused methods and addition of new methods will not impact your exit class anymore

2. Class `zcl_abapgit_exit_caller`

- Collects all sub-classes of `zcl_abapgit_exit_super` 
- Is used as a super-class for `zcl_abapgit_user_exit` (see below)
- For each exit method, `zcl_abapgit_exit_caller` calls the corresponding method in the sub-classes collected above (obviously, only redefined methods will have any effect)
- For most methods, all sub-classes will be called (cumulative effect)
- For some methods, the first successful call will win (exclusive effect)

### Limitation

Currently, the solution only works for the developer version. The standalone continues to work with the existing include `zabapgit_user_exit`. 

Note: I'm still investigating if and how this framework can work also for the standalone version.

### Downside

When adding new exit methods, we have to maintain two additional classes:

- `zif/cl_abapgit_exit`: same as before
- `zcl_abapgit_exit_super`: add `RETURN` to new method implementation
- `zcl_abapgit_exit_called`: implement a `LOOP` over all exit sub-classes

However, the additional effort is very low and only once per exit method.

### Example

The implementation of `zcl_abapgit_user_exit` is reduced to the following (no method code):

```abap
CLASS zcl_abapgit_user_exit DEFINITION
  PUBLIC
  INHERITING FROM zcl_abapgit_exit_caller
  CREATE PUBLIC.

  PUBLIC SECTION.
  PROTECTED SECTION.
  PRIVATE SECTION.
ENDCLASS.

CLASS zcl_abapgit_user_exit IMPLEMENTATION.
ENDCLASS.
```

Here is one exit classes for creating the HTTP client based and another for setting a wall message:

```abap
CLASS zcl_abapgit_user_exit_client DEFINITION
  PUBLIC
  INHERITING FROM zcl_abapgit_exit_super
  CREATE PUBLIC.

  PUBLIC SECTION.

    METHODS zif_abapgit_exit~create_http_client REDEFINITION.

  PROTECTED SECTION.
  PRIVATE SECTION.
ENDCLASS.

CLASS zcl_abapgit_user_exit_client IMPLEMENTATION.

  METHOD zif_abapgit_exit~create_http_client.

    DATA:
      lv_host        TYPE string,
      lv_destination TYPE rfcdest.

    lv_host = zcl_abapgit_url=>host( iv_url ).

    IF lv_host CS 'github'.
      lv_destination = 'GITHUB'.
    ELSE.
      RETURN.
    ENDIF.

    cl_http_client=>create_by_destination(
      EXPORTING
        destination              = lv_destination
      IMPORTING
        client                   = ri_client
      EXCEPTIONS
        argument_not_found       = 1
        destination_not_found    = 2
        destination_no_authority = 3
        plugin_not_active        = 4
        internal_error           = 5
        OTHERS                   = 6 ).

    IF sy-subrc <> 0.
      zcx_abapgit_exception=>raise_t100(  ).
    ENDIF.

    zcl_abapgit_login_manager=>clear( ).

  ENDMETHOD.
ENDCLASS.
```

```abap
CLASS zcl_abapgit_user_exit_wall DEFINITION
  PUBLIC
  INHERITING FROM zcl_abapgit_exit_super
  CREATE PUBLIC.

  PUBLIC SECTION.

    METHODS zif_abapgit_exit~wall_message_repo REDEFINITION.

  PROTECTED SECTION.
  PRIVATE SECTION.
ENDCLASS.

CLASS zcl_abapgit_user_exit_wall IMPLEMENTATION.

  METHOD zif_abapgit_exit~wall_message_repo.

  ENDMETHOD.
ENDCLASS.
```

The implementation becomes a lot simpler and more robust. Plus you can have any number of such exit sub-classes. Repositories can include sub exit sub-classes.

### Migration

You can easily transition from an existing `zcl_abapgit_user_exit` implementation to several classes:

1. Create one or more exit classes each with `zcl_abapgit_exit_super` as superclass
2. Redefine only methods as required and copy corresponding code from `zcl_abapgit_user_exit`
3. Once all methods are migrated to sub-classes, replace `zcl_abapgit_user_exit` as shown in the example above

### Practical Experience

I have distributed methods across six exit classes and four repos and it works perfectly well. 🎉 

Closes #4786
