### PR TITLE
unit test page result: show syntax errors

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -53,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_RUNIT IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
 
 
   METHOD build_tadir.

--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -225,7 +225,6 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
     LOOP AT <lt_indices> ASSIGNING <ls_alert_by_index>.
       ASSIGN COMPONENT 'ALERTS' OF STRUCTURE <ls_alert_by_index> TO <lt_alerts>.
       LOOP AT <lt_alerts> ASSIGNING <ls_alert> WHERE ('KIND = ''F'' OR KIND = ''S'' OR KIND = ''E'' OR KIND = ''W''').
-        BREAK-POINT.
         CLEAR lv_text.
         ASSIGN COMPONENT 'HEADER-PARAMS' OF STRUCTURE <ls_alert> TO <lt_params>.
         LOOP AT <lt_params> INTO lv_params.

--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -53,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_RUNIT IMPLEMENTATION.
 
 
   METHOD build_tadir.
@@ -201,6 +201,8 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
     FIELD-SYMBOLS <ls_class>          TYPE any.
     FIELD-SYMBOLS <ls_method>         TYPE any.
     FIELD-SYMBOLS <lv_any>            TYPE any.
+    FIELD-SYMBOLS <lt_text_info>      TYPE ANY TABLE.
+    FIELD-SYMBOLS <ls_text_info>      TYPE any.
     FIELD-SYMBOLS <lt_params>         TYPE string_table.
 
 
@@ -222,10 +224,20 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
 
     LOOP AT <lt_indices> ASSIGNING <ls_alert_by_index>.
       ASSIGN COMPONENT 'ALERTS' OF STRUCTURE <ls_alert_by_index> TO <lt_alerts>.
-      LOOP AT <lt_alerts> ASSIGNING <ls_alert> WHERE ('KIND = ''F'' OR KIND = ''S'' OR KIND = ''E''').
+      LOOP AT <lt_alerts> ASSIGNING <ls_alert> WHERE ('KIND = ''F'' OR KIND = ''S'' OR KIND = ''E'' OR KIND = ''W''').
+        BREAK-POINT.
+        CLEAR lv_text.
         ASSIGN COMPONENT 'HEADER-PARAMS' OF STRUCTURE <ls_alert> TO <lt_params>.
         LOOP AT <lt_params> INTO lv_params.
-          lv_text = lv_params.
+          lv_text = lv_text && lv_params.
+        ENDLOOP.
+
+        ASSIGN COMPONENT 'TEXT_INFOS' OF STRUCTURE <ls_alert> TO <lt_text_info>.
+        LOOP AT <lt_text_info> ASSIGNING <ls_text_info>.
+          ASSIGN COMPONENT 'PARAMS' OF STRUCTURE <ls_text_info> TO <lt_params>.
+          LOOP AT <lt_params> INTO lv_params.
+            lv_text = lv_text && lv_params.
+          ENDLOOP.
         ENDLOOP.
         ri_html->add( |<tr><td><span class="boxed red-filled-set">{ lv_text }</span></td></tr>| ).
         lv_count = lv_count + 1.


### PR DESCRIPTION
I ran the unit tests via the unit test page, all green

however, I did have a syntax error, which was not shown on the results of unit test page, with this change it now shows the syntax error