### PR TITLE
Item graph - performance improvement

### DIFF
--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -255,7 +255,7 @@ CLASS zcl_abapgit_file_deserialize IMPLEMENTATION.
 
     WHILE lo_graph->has_vertices( ) = abap_true.
       ls_item = lo_graph->get_next( ii_log ).
-      READ TABLE it_results INTO ls_result WITH KEY
+      READ TABLE it_results INTO ls_result WITH KEY sec_key COMPONENTS
         obj_name = ls_item-obj_name
         obj_type = ls_item-obj_type.
       ASSERT sy-subrc = 0.

--- a/src/objects/core/zcl_abapgit_item_graph.clas.abap
+++ b/src/objects/core/zcl_abapgit_item_graph.clas.abap
@@ -23,7 +23,7 @@ CLASS zcl_abapgit_item_graph DEFINITION
     TYPES:
       BEGIN OF ty_vertex.
         INCLUDE TYPE zif_abapgit_definitions=>ty_item AS item.
-      TYPES:
+    TYPES:
         has_inbound_edge TYPE abap_bool,
       END OF ty_vertex,
       BEGIN OF ty_edge,
@@ -43,7 +43,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_ITEM_GRAPH IMPLEMENTATION.
+CLASS zcl_abapgit_item_graph IMPLEMENTATION.
 
 
   METHOD add_edge.
@@ -57,7 +57,7 @@ CLASS ZCL_ABAPGIT_ITEM_GRAPH IMPLEMENTATION.
 
 
   METHOD constructor.
-    MOVE-CORRESPONDING it_items TO mt_vertices.
+    mt_vertices = it_items.
   ENDMETHOD.
 
 
@@ -65,7 +65,7 @@ CLASS ZCL_ABAPGIT_ITEM_GRAPH IMPLEMENTATION.
 * find a vertex with no inbound edges, if it does not exist pick anything
 
     DATA lv_index  TYPE i.
-    FIELD-SYMBOLS: <ls_vertex> TYPE zcl_abapgit_item_graph=>ty_vertex.
+    FIELD-SYMBOLS: <ls_vertex> TYPE ty_vertex.
 
     LOOP AT mt_vertices ASSIGNING <ls_vertex>
                         WHERE has_inbound_edge = abap_false.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -140,7 +140,9 @@ INTERFACE zif_abapgit_definitions
       origlang  TYPE tadir-masterlang,
     END OF ty_result .
   TYPES:
-    ty_results_tt TYPE STANDARD TABLE OF ty_result WITH DEFAULT KEY .
+    ty_results_tt TYPE STANDARD TABLE OF ty_result WITH DEFAULT KEY
+                       WITH NON-UNIQUE SORTED KEY sec_key
+                       COMPONENTS obj_type obj_name.
   TYPES:
     ty_results_ts_path TYPE HASHED TABLE OF ty_result WITH UNIQUE KEY path filename .
   TYPES:


### PR DESCRIPTION
We had severe performance issues with a large offline repo (~10 000 objects). Runtime of the item graph calculation exceeded several hours. With this fix it goes down to a few minutes.