### PR TITLE
fix syntax warnings regarding secondary key

### DIFF
--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -87,7 +87,8 @@ CLASS zcl_abapgit_file_deserialize IMPLEMENTATION.
     DELETE rt_results WHERE obj_type IS INITIAL.
     "log objects w/o object type
     IF sy-subrc = 0 AND ii_log IS BOUND.
-      LOOP AT lt_objects REFERENCE INTO lr_object WHERE obj_type IS INITIAL.
+      LOOP AT lt_objects REFERENCE INTO lr_object USING KEY sec_key
+                         WHERE obj_type IS INITIAL.
         CHECK lr_object->obj_name IS NOT INITIAL.
         ls_item-devclass = lr_object->package.
         ls_item-obj_type = lr_object->obj_type.

--- a/src/repo/zcl_abapgit_file_status.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_file_status.clas.locals_imp.abap
@@ -288,7 +288,8 @@ CLASS lcl_status_consistency_checks IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_result> LIKE LINE OF it_results.
 
-    LOOP AT it_results ASSIGNING <ls_result> WHERE package IS INITIAL AND obj_type = 'DEVC'.
+    LOOP AT it_results ASSIGNING <ls_result> USING KEY sec_key
+                       WHERE package IS INITIAL AND obj_type = 'DEVC'.
 
       IF zcl_abapgit_factory=>get_sap_package( |{ <ls_result>-obj_name }| )->exists( ) = abap_true.
         " If package already exist but is not included in the package hierarchy of

--- a/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
@@ -581,6 +581,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     ELSEIF is_object IS NOT INITIAL.  " Diff for whole object
 
       LOOP AT lt_status ASSIGNING <ls_status>
+          USING KEY sec_key
           WHERE obj_type = is_object-obj_type
           AND obj_name = is_object-obj_name
           AND match IS INITIAL.


### PR DESCRIPTION
fixes these warnings
![grafik](https://github.com/abapGit/abapGit/assets/17437789/7f764a78-3543-48ad-bf0e-7b556836f975)
