### PR TITLE
added auto confirmation of transport messages

### DIFF
--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -11,7 +11,7 @@ CLASS zcl_abapgit_cts_api DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    DATA: gv_confirm_transp_msgs_called TYPE abap_bool.
+    DATA: mv_confirm_transp_msgs_called TYPE abap_bool.
 
     "! Returns the transport request / task the object is currently locked in
     "! @parameter iv_program_id | Program ID
@@ -435,12 +435,12 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
 
     FIELD-SYMBOLS: <lt_confirmed_messages> TYPE STANDARD TABLE.
 
-    IF gv_confirm_transp_msgs_called = abap_true.
+    IF mv_confirm_transp_msgs_called = abap_true.
       RETURN.
     ENDIF.
 
     " remember the call to avoid duplicates in GT_CONFIRMED_MESSAGES
-    gv_confirm_transp_msgs_called = abap_true.
+    mv_confirm_transp_msgs_called = abap_true.
 
 
     " Auto-confirm certain messages (requires SAP Note 1609940)

--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -415,4 +415,54 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
       WHERE trkorr = iv_trkorr ##SUBRC_OK.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_cts_api~confirm_transport_messages.
+
+    TYPES: BEGIN OF ty_s_message,
+             id TYPE symsgid,
+             ty TYPE symsgty,
+             no TYPE symsgno,
+             v1 TYPE symsgv,
+             v2 TYPE symsgv,
+             v3 TYPE symsgv,
+             v4 TYPE symsgv,
+           END OF ty_s_message.
+
+    DATA ls_message TYPE ty_s_message.
+
+    FIELD-SYMBOLS: <lt_confirmed_messages> TYPE STANDARD TABLE.
+
+    " Auto-confirm certain messages (requires SAP Note 1609940)
+    PERFORM dummy IN PROGRAM saplstrd IF FOUND.  "load function group STRD once into memory
+
+    ASSIGN ('(SAPLSTRD)GT_CONFIRMED_MESSAGES') TO <lt_confirmed_messages>.
+
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    " Object can only be created in package of namespace
+    ls_message-id = 'TR'.
+    ls_message-no = '007'.
+    INSERT ls_message INTO TABLE <lt_confirmed_messages>.
+
+    " Original system set to "SAP"
+    ls_message-id = 'TR'.
+    ls_message-no = '013'.
+    INSERT ls_message INTO TABLE <lt_confirmed_messages>.
+
+    " Make repairs in foreign namespaces only if they are urgent
+    ls_message-id = 'TR'.
+    ls_message-no = '852'.
+    INSERT ls_message INTO TABLE <lt_confirmed_messages>.
+
+    " Make repairs in foreign namespaces only if they are urgent
+    ls_message-id = 'TK'.
+    ls_message-no = '016'.
+    INSERT ls_message INTO TABLE <lt_confirmed_messages>.
+
+    rv_messages_confirmed = abap_true.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -11,6 +11,8 @@ CLASS zcl_abapgit_cts_api DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
 
+    DATA: gv_confirm_transp_msgs_called TYPE abap_bool.
+
     "! Returns the transport request / task the object is currently locked in
     "! @parameter iv_program_id | Program ID
     "! @parameter iv_object_type | Object type
@@ -432,6 +434,14 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
     DATA ls_message TYPE ty_s_message.
 
     FIELD-SYMBOLS: <lt_confirmed_messages> TYPE STANDARD TABLE.
+
+    IF gv_confirm_transp_msgs_called = abap_true.
+      RETURN.
+    ENDIF.
+
+    " remember the call to avoid duplicates in GT_CONFIRMED_MESSAGES
+    gv_confirm_transp_msgs_called = abap_true.
+
 
     " Auto-confirm certain messages (requires SAP Note 1609940)
     PERFORM dummy IN PROGRAM saplstrd IF FOUND.  "load function group STRD once into memory

--- a/src/cts/zif_abapgit_cts_api.intf.abap
+++ b/src/cts/zif_abapgit_cts_api.intf.abap
@@ -105,4 +105,8 @@ INTERFACE zif_abapgit_cts_api
     RAISING
       zcx_abapgit_exception.
 
+  METHODS confirm_transport_messages
+    RETURNING
+      VALUE(rv_messages_confirmed) TYPE abap_bool .
+
 ENDINTERFACE.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -87,6 +87,12 @@ CLASS zcl_abapgit_objects DEFINITION
         VALUE(rv_active) TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS confirm_transport_message
+      IMPORTING
+        !iv_msgid                   TYPE symsgid
+        !iv_msgno                   TYPE symsgno
+      RETURNING
+        VALUE(rv_message_confirmed) TYPE abap_bool .
   PROTECTED SECTION.
 
   PRIVATE SECTION.
@@ -110,6 +116,7 @@ CLASS zcl_abapgit_objects DEFINITION
     CLASS-DATA gt_obj_serializer_map TYPE ty_obj_serializer_map .
     CLASS-DATA gt_supported_obj_types TYPE ty_supported_types_tt .
     CLASS-DATA gv_supported_obj_types_loaded TYPE abap_bool .
+    CLASS-DATA gv_confirm_trans_msg_possible TYPE zif_abapgit_definitions=>ty_yes_no .
 
     CLASS-METHODS check_duplicates
       IMPORTING
@@ -209,6 +216,7 @@ CLASS zcl_abapgit_objects DEFINITION
         !iv_filename    TYPE string
       RETURNING
         VALUE(rv_extra) TYPE string.
+    CLASS-METHODS confirm_transport_messages .
 ENDCLASS.
 
 
@@ -663,6 +671,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     lo_timer = zcl_abapgit_timer=>create(
       iv_text  = 'Deserialize:'
       iv_count = lines( lt_items ) )->start( ).
+
+    confirm_transport_messages( ).
 
     check_objects_locked( iv_language = io_repo->get_dot_abapgit( )->get_main_language( )
                           it_items    = lt_items ).
@@ -1266,6 +1276,73 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
           without_crossreference = abap_true
           with_tcode_index       = abap_true.
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD confirm_transport_message.
+
+    TYPES: BEGIN OF ty_s_message,
+             id TYPE symsgid,
+             ty TYPE symsgty,
+             no TYPE symsgno,
+             v1 TYPE symsgv,
+             v2 TYPE symsgv,
+             v3 TYPE symsgv,
+             v4 TYPE symsgv,
+           END OF ty_s_message.
+
+    TYPES ty_t_messages TYPE STANDARD TABLE OF ty_s_message.
+
+    DATA ls_message TYPE ty_s_message.
+
+    FIELD-SYMBOLS: <lt_confirmed_messages> TYPE ty_t_messages.
+
+    CHECK gv_confirm_trans_msg_possible <> zif_abapgit_definitions=>c_no.
+    " auto-confirmation of transport messages is not possible in this system.
+
+    IF gv_confirm_trans_msg_possible IS INITIAL.
+      " Auto-confirm certain messages (requires SAP Note 1609940)
+      PERFORM dummy IN PROGRAM saplstrd IF FOUND.  "load function group STRD once into memory
+    ENDIF.
+
+    ASSIGN ('(SAPLSTRD)GT_CONFIRMED_MESSAGES') TO <lt_confirmed_messages>.
+
+    IF sy-subrc = 0.
+      gv_confirm_trans_msg_possible = zif_abapgit_definitions=>c_yes.
+    ELSE.
+      gv_confirm_trans_msg_possible = zif_abapgit_definitions=>c_no.
+      RETURN. ">>>>>>>>>>>>>>
+    ENDIF.
+
+    ls_message-id = iv_msgid.
+    ls_message-no = iv_msgno.
+    COLLECT ls_message INTO <lt_confirmed_messages>.
+
+    rv_message_confirmed = abap_true.
+
+  ENDMETHOD.
+
+
+  METHOD confirm_transport_messages.
+
+    CHECK confirm_transport_message( " Object can only be created in package of namespace
+                                     iv_msgid = 'TR'
+                                     iv_msgno = '007' ) = abap_true.
+
+    " no need to confirm others when messages cannot be auto-confirmed (SAP Note 1609940 probably missing)
+
+    confirm_transport_message(: " Original system set to "SAP"
+                                iv_msgid = 'TR'
+                                iv_msgno = '013' ),
+
+                                " Make repairs in foreign namespaces only if they are urgent
+                                iv_msgid = 'TR'
+                                iv_msgno = '852' ),
+
+                                " Make repairs in foreign namespaces only if they are urgent
+                                iv_msgid = 'TK'
+                                iv_msgno = '016' ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -1296,10 +1296,12 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     DATA ls_message TYPE ty_s_message.
 
-    FIELD-SYMBOLS: <lt_confirmed_messages> TYPE ty_t_messages.
+    FIELD-SYMBOLS: <lt_confirmed_messages> TYPE STANDARD TABLE.
 
-    CHECK gv_confirm_trans_msg_possible <> zif_abapgit_definitions=>c_no.
-    " auto-confirmation of transport messages is not possible in this system.
+    IF gv_confirm_trans_msg_possible = zif_abapgit_definitions=>c_no.
+      " auto-confirmation of transport messages is not possible in this system.
+      RETURN. ">>>>>>>>>
+    ENDIF.
 
     IF gv_confirm_trans_msg_possible IS INITIAL.
       " Auto-confirm certain messages (requires SAP Note 1609940)
@@ -1326,23 +1328,24 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
   METHOD confirm_transport_messages.
 
-    CHECK confirm_transport_message( " Object can only be created in package of namespace
+    IF confirm_transport_message( " Object can only be created in package of namespace
                                      iv_msgid = 'TR'
-                                     iv_msgno = '007' ) = abap_true.
+                                     iv_msgno = '007' ) = abap_false.
+      " no need to confirm others when messages cannot be auto-confirmed (SAP Note 1609940 probably missing)
+      RETURN. " >>>>>>>>>>>>>>>>>>>>
+    ENDIF.
 
-    " no need to confirm others when messages cannot be auto-confirmed (SAP Note 1609940 probably missing)
+    " Original system set to "SAP"
+    confirm_transport_message( iv_msgid = 'TR'
+                               iv_msgno = '013' ).
 
-    confirm_transport_message(: " Original system set to "SAP"
-                                iv_msgid = 'TR'
-                                iv_msgno = '013' ),
+    " Make repairs in foreign namespaces only if they are urgent
+    confirm_transport_message( iv_msgid = 'TR'
+                               iv_msgno = '852' ).
 
-                                " Make repairs in foreign namespaces only if they are urgent
-                                iv_msgid = 'TR'
-                                iv_msgno = '852' ),
-
-                                " Make repairs in foreign namespaces only if they are urgent
-                                iv_msgid = 'TK'
-                                iv_msgno = '016' ).
+    " Make repairs in foreign namespaces only if they are urgent
+    confirm_transport_message( iv_msgid = 'TK'
+                               iv_msgno = '016' ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -1292,8 +1292,6 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
              v4 TYPE symsgv,
            END OF ty_s_message.
 
-    TYPES ty_t_messages TYPE STANDARD TABLE OF ty_s_message.
-
     DATA ls_message TYPE ty_s_message.
 
     FIELD-SYMBOLS: <lt_confirmed_messages> TYPE STANDARD TABLE.


### PR DESCRIPTION
Implementation for avoiding SAP Transport messages that might come up during deserialization (pull) as suggested here:
https://github.com/abapGit/abapGit/issues/6314#issuecomment-1598847796