### PR TITLE
Fix syntax error in `zcl_abapgit_file_deserialize`

### DIFF
--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -87,9 +87,10 @@ CLASS zcl_abapgit_file_deserialize IMPLEMENTATION.
     DELETE rt_results WHERE obj_type IS INITIAL.
     "log objects w/o object type
     IF sy-subrc = 0 AND ii_log IS BOUND.
-      LOOP AT lt_objects REFERENCE INTO lr_object USING KEY sec_key
-                         WHERE obj_type IS INITIAL.
-        CHECK lr_object->obj_name IS NOT INITIAL.
+      " Note: Moving the CHECK condition to the LOOP WHERE clause will lead to a
+      " syntax warning in higher releases and syntax error in 702
+      LOOP AT lt_objects REFERENCE INTO lr_object.
+        CHECK lr_object->obj_type IS INITIAL AND lr_object->obj_name IS NOT INITIAL.
         ls_item-devclass = lr_object->package.
         ls_item-obj_type = lr_object->obj_type.
         ls_item-obj_name = lr_object->obj_name.


### PR DESCRIPTION
The particular LOOP with secondary key is causing syntax error in 702. Moving the condition to the CHECK statement avoids the issue.

![image](https://github.com/abapGit/abapGit/assets/59966492/68333b6b-5b89-4e53-94a3-41472946b86c)

Ref #6313