### PR TITLE
FIX and Features about Autologon to Repo

### DIFF
--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -133,7 +133,7 @@ CLASS ZCL_ABAPGIT_HTTP IMPLEMENTATION.
 
       cl_http_client=>create_by_url(
         EXPORTING
-          url                = zcl_abapgit_url=>host( iv_url )
+          url                = zcl_abapgit_url=>host( iv_url ) " Note IV_URL provide the same result faster
           ssl_id             = zcl_abapgit_exit=>get_instance( )->get_ssl_id( )
           proxy_host         = lo_proxy_configuration->get_proxy_url( iv_url )
           proxy_service      = lo_proxy_configuration->get_proxy_port( iv_url )
@@ -178,7 +178,9 @@ CLASS ZCL_ABAPGIT_HTTP IMPLEMENTATION.
     li_client->request->set_header_field(
         name  = 'user-agent'
         value = get_agent( ) ).
-    lv_uri = zcl_abapgit_url=>path_name( iv_url ) &&
+* RFC destination may contains Prefix PATH
+    lv_uri = COND string( WHEN li_client->path_prefix IS INITIAL THEN zcl_abapgit_url=>path_name( iv_url )
+                          ELSE || ) &&
              '/info/refs?service=git-' &&
              iv_service &&
              '-pack'.

--- a/src/ui/zcl_abapgit_password_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_password_dialog.clas.abap
@@ -5,6 +5,8 @@ CLASS zcl_abapgit_password_dialog DEFINITION
 
   PUBLIC SECTION.
 
+  class-data GV_NO_DIALOG type ABAP_BOOL .
+  
     CLASS-METHODS popup
       IMPORTING
         !iv_repo_url TYPE string
@@ -26,7 +28,7 @@ CLASS zcl_abapgit_password_dialog IMPLEMENTATION.
 
     DATA: lx_error TYPE REF TO cx_sy_dyn_call_illegal_form.
 
-    IF zcl_abapgit_ui_factory=>get_frontend_services( )->gui_is_available( ) = abap_true.
+    IF zcl_abapgit_ui_factory=>get_frontend_services( )->gui_is_available( ) = abap_true AND GV_NO_DIALOG IS INITIAL.
 
       TRY.
           PERFORM password_popup


### PR DESCRIPTION
Fixed usage of RFC Destination for HTTP client as with PATH Prefix they failed uri is supposed to be at server root.
Enhancement: This allow a default implementation of zif_abapgit_exit~create_http_client to find the proper RFC Destination with **FULL URL matching**.= Both Server AND Path must match the URL to choose the RFC Destination.

Add feature to prevent Password dialog is we need to use ZCL_ABAPGIT_DEFAULT_AUTH_INFO even on DIALOG / Foreground.