### PR TITLE
Fix GUI actions for Edge browser control

### DIFF
--- a/src/ui/core/zcl_abapgit_gui_event.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.abap
@@ -45,7 +45,7 @@ CLASS zcl_abapgit_gui_event IMPLEMENTATION.
 
     " Edge Webview control returns upper case action but abapGit requires lower case (#4841)
     zif_abapgit_gui_event~mi_gui_services = ii_gui_services.
-    zif_abapgit_gui_event~mv_action       = to_lower( iv_action ). 
+    zif_abapgit_gui_event~mv_action       = to_lower( iv_action ).
     zif_abapgit_gui_event~mv_getdata      = iv_getdata.
     zif_abapgit_gui_event~mt_postdata     = it_postdata.
 

--- a/src/ui/core/zcl_abapgit_gui_event.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.abap
@@ -43,8 +43,9 @@ CLASS zcl_abapgit_gui_event IMPLEMENTATION.
 
   METHOD constructor.
 
+    " Edge Webview control returns upper case action but abapGit requires lower case (#4841)
     zif_abapgit_gui_event~mi_gui_services = ii_gui_services.
-    zif_abapgit_gui_event~mv_action       = iv_action.
+    zif_abapgit_gui_event~mv_action       = to_lower( iv_action ). 
     zif_abapgit_gui_event~mv_getdata      = iv_getdata.
     zif_abapgit_gui_event~mt_postdata     = it_postdata.
 


### PR DESCRIPTION
Edge Webview browser control returns upper case action but abapGit requires lower case.

Closes #4841