### PR TITLE
Enable object handler for Event Consumption Model (EEEC)

### DIFF
--- a/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
+++ b/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
@@ -53,6 +53,7 @@ CLASS zcl_abapgit_aff_registry IMPLEMENTATION.
     register( iv_obj_type = 'CHKO' ).
     register( iv_obj_type = 'CHKV' ).
     register( iv_obj_type = 'EVTB' ).
+    register( iv_obj_type = 'EEEC' ).
     register( iv_obj_type = 'GSMP' ).
     register( iv_obj_type     = 'INTF'
               iv_experimental = abap_true ).

--- a/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
@@ -17,6 +17,11 @@ CLASS zcl_abapgit_object_common_aff DEFINITION
 
     METHODS get_additional_extensions
       RETURNING VALUE(rv_additional_extensions) TYPE ty_extension_mapper_pairs.
+    METHODS get_object_handler
+      RETURNING
+        VALUE(result) TYPE REF TO object
+      RAISING
+        zcx_abapgit_exception.
 
   PRIVATE SECTION.
     METHODS is_file_empty
@@ -51,7 +56,6 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     DATA: lr_intf_aff_obj    TYPE REF TO data,
           lr_intf_aff_log    TYPE REF TO data,
           lr_messages        TYPE REF TO data,
-          lo_handler_factory TYPE REF TO object,
           lo_object_handler  TYPE REF TO object,
           lo_object_aff      TYPE REF TO object,
           lo_aff_factory     TYPE REF TO object,
@@ -68,12 +72,9 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-        CREATE OBJECT lo_handler_factory TYPE ('CL_AFF_OBJECT_HANDLER_FACTORY').
-        CALL METHOD lo_handler_factory->('IF_AFF_OBJECT_HANDLER_FACTORY~GET_OBJECT_HANDLER')
-          EXPORTING
-            object_type = ms_item-obj_type
-          RECEIVING
-            result      = lo_object_handler.
+       CALL METHOD get_object_handler
+         RECEIVING
+           result   = lo_object_handler.
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
            EXPORTING
@@ -146,7 +147,6 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
           lr_intf_files_container  TYPE REF TO data,
           lr_intf_aff_log          TYPE REF TO data,
           lr_intf_aff_settings     TYPE REF TO data,
-          lo_handler_factory       TYPE REF TO object,
           lo_object_handler        TYPE REF TO object,
           lo_object_aff            TYPE REF TO object,
           lo_object_json_file      TYPE REF TO object,
@@ -181,13 +181,9 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
 
     " beyond here there will be dragons....
     TRY.
-        CREATE OBJECT lo_handler_factory TYPE ('CL_AFF_OBJECT_HANDLER_FACTORY').
-
-        CALL METHOD lo_handler_factory->('IF_AFF_OBJECT_HANDLER_FACTORY~GET_OBJECT_HANDLER')
-          EXPORTING
-            object_type = ms_item-obj_type
-          RECEIVING
-            result      = lo_object_handler.
+        CALL METHOD get_object_handler
+         RECEIVING
+           result   = lo_object_handler.
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
           EXPORTING
@@ -326,10 +322,22 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     ENDTRY.
   ENDMETHOD.
 
+  METHOD get_object_handler.
+
+    DATA lo_handler_factory TYPE REF TO object.
+
+    CREATE OBJECT lo_handler_factory TYPE ('CL_AFF_OBJECT_HANDLER_FACTORY').
+
+    CALL METHOD lo_handler_factory->('IF_AFF_OBJECT_HANDLER_FACTORY~GET_OBJECT_HANDLER')
+      EXPORTING
+        object_type = ms_item-obj_type
+      RECEIVING
+        result      = result.
+
+  ENDMETHOD.
 
   METHOD zif_abapgit_object~exists.
     DATA: lr_intf_aff_obj    TYPE REF TO data,
-          lo_handler_factory TYPE REF TO object,
           lo_object_handler  TYPE REF TO object,
           lo_object_aff      TYPE REF TO object,
           lv_name            TYPE c LENGTH 120,
@@ -340,13 +348,9 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-        CREATE OBJECT lo_handler_factory TYPE ('CL_AFF_OBJECT_HANDLER_FACTORY').
-
-        CALL METHOD lo_handler_factory->('IF_AFF_OBJECT_HANDLER_FACTORY~GET_OBJECT_HANDLER')
-          EXPORTING
-            object_type = ms_item-obj_type
+        CALL METHOD get_object_handler
           RECEIVING
-            result      = lo_object_handler.
+            result   = lo_object_handler.
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
            EXPORTING
@@ -431,7 +435,6 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
           lr_intf_aff_log          TYPE REF TO data,
           lr_intf_aff_settings     TYPE REF TO data,
           lr_messages              TYPE REF TO data,
-          lo_handler_factory       TYPE REF TO object,
           lo_object_handler        TYPE REF TO object,
           lo_object_aff            TYPE REF TO object,
           lo_object_json_file      TYPE REF TO object,
@@ -459,13 +462,9 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-        CREATE OBJECT lo_handler_factory TYPE ('CL_AFF_OBJECT_HANDLER_FACTORY').
-
-        CALL METHOD lo_handler_factory->('IF_AFF_OBJECT_HANDLER_FACTORY~GET_OBJECT_HANDLER')
-          EXPORTING
-            object_type = ms_item-obj_type
-          RECEIVING
-            result      = lo_object_handler.
+        CALL METHOD get_object_handler
+         RECEIVING
+           result   = lo_object_handler.
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
            EXPORTING

--- a/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
@@ -19,7 +19,7 @@ CLASS zcl_abapgit_object_common_aff DEFINITION
       RETURNING VALUE(rv_additional_extensions) TYPE ty_extension_mapper_pairs.
     METHODS get_object_handler
       RETURNING
-        VALUE(result) TYPE REF TO object
+        VALUE(ro_object_handler) TYPE REF TO object
       RAISING
         zcx_abapgit_exception.
 
@@ -53,15 +53,15 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
 
   METHOD zif_abapgit_object~delete.
 
-    DATA: lr_intf_aff_obj    TYPE REF TO data,
-          lr_intf_aff_log    TYPE REF TO data,
-          lr_messages        TYPE REF TO data,
-          lo_object_handler  TYPE REF TO object,
-          lo_object_aff      TYPE REF TO object,
-          lo_aff_factory     TYPE REF TO object,
-          lv_name            TYPE c LENGTH 120,
-          lx_error           TYPE REF TO cx_root,
-          lo_aff_log         TYPE REF TO object.
+    DATA: lr_intf_aff_obj   TYPE REF TO data,
+          lr_intf_aff_log   TYPE REF TO data,
+          lr_messages       TYPE REF TO data,
+          lo_object_handler TYPE REF TO object,
+          lo_object_aff     TYPE REF TO object,
+          lo_aff_factory    TYPE REF TO object,
+          lv_name           TYPE c LENGTH 120,
+          lx_error          TYPE REF TO cx_root,
+          lo_aff_log        TYPE REF TO object.
 
     FIELD-SYMBOLS: <ls_intf_aff_obj> TYPE any,
                    <ls_intf_aff_log> TYPE any,
@@ -72,9 +72,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-        get_object_handler( RECEIVING result = lo_object_handler ).
-         RECEIVING
-           result   = lo_object_handler.
+        lo_object_handler = get_object_handler( ).
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
            EXPORTING
@@ -181,9 +179,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
 
     " beyond here there will be dragons....
     TRY.
-        CALL METHOD get_object_handler
-         RECEIVING
-           result   = lo_object_handler.
+        lo_object_handler = get_object_handler( ).
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
           EXPORTING
@@ -332,7 +328,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
       EXPORTING
         object_type = ms_item-obj_type
       RECEIVING
-        result      = result.
+        result      = ro_object_handler.
 
   ENDMETHOD.
 
@@ -348,9 +344,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-        CALL METHOD get_object_handler
-          RECEIVING
-            result   = lo_object_handler.
+        lo_object_handler = get_object_handler( ).
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
            EXPORTING
@@ -462,9 +456,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-        CALL METHOD get_object_handler
-         RECEIVING
-           result   = lo_object_handler.
+        lo_object_handler = get_object_handler( ).
 
         CREATE OBJECT lo_object_aff TYPE ('CL_AFF_OBJ')
            EXPORTING

--- a/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
@@ -72,7 +72,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     lv_name = ms_item-obj_name.
 
     TRY.
-       CALL METHOD get_object_handler
+        get_object_handler( RECEIVING result = lo_object_handler ).
          RECEIVING
            result   = lo_object_handler.
 

--- a/src/objects/aff/zcl_abapgit_object_eeec.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_eeec.clas.abap
@@ -7,6 +7,9 @@ CLASS zcl_abapgit_object_eeec DEFINITION
   PUBLIC SECTION.
     METHODS:
       zif_abapgit_object~changed_by REDEFINITION .
+
+  PROTECTED SECTION.
+    METHODS: get_object_handler REDEFINITION.
 ENDCLASS.
 
 
@@ -54,6 +57,25 @@ CLASS zcl_abapgit_object_eeec IMPLEMENTATION.
         zcx_abapgit_exception=>raise( iv_text     = lx_error->get_text( )
                                       ix_previous = lx_error ).
     ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD get_object_handler.
+
+    DATA lx_error TYPE REF TO cx_root.
+
+    CALL METHOD super->get_object_handler
+      RECEIVING
+        result = result.
+
+    IF result IS NOT BOUND.
+      TRY.
+          CREATE OBJECT result TYPE ('/IWXBE/CL_EEEC_AFF_OBJECTHANDL').
+        CATCH cx_root INTO lx_error.
+          zcx_abapgit_exception=>raise( iv_text     = lx_error->get_text( )
+                                        ix_previous = lx_error ).
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/objects/aff/zcl_abapgit_object_eeec.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_eeec.clas.abap
@@ -64,13 +64,11 @@ CLASS zcl_abapgit_object_eeec IMPLEMENTATION.
 
     DATA lx_error TYPE REF TO cx_root.
 
-    CALL METHOD super->get_object_handler
-      RECEIVING
-        result = result.
+    ro_object_handler = super->get_object_handler( ).
 
-    IF result IS NOT BOUND.
+    IF ro_object_handler IS NOT BOUND.
       TRY.
-          CREATE OBJECT result TYPE ('/IWXBE/CL_EEEC_AFF_OBJECTHANDL').
+          CREATE OBJECT ro_object_handler TYPE ('/IWXBE/CL_EEEC_AFF_OBJECTHANDL').
         CATCH cx_root INTO lx_error.
           zcx_abapgit_exception=>raise( iv_text     = lx_error->get_text( )
                                         ix_previous = lx_error ).

--- a/src/objects/aff/zcl_abapgit_object_eeec.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_eeec.clas.abap
@@ -1,0 +1,60 @@
+CLASS zcl_abapgit_object_eeec DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_object_common_aff
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    METHODS:
+      zif_abapgit_object~changed_by REDEFINITION .
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_object_eeec IMPLEMENTATION.
+
+  METHOD zif_abapgit_object~changed_by.
+
+    DATA: lr_data             TYPE REF TO data,
+          lo_registry_adapter TYPE REF TO object,
+          lv_object_key       TYPE seu_objkey,
+          lx_error            TYPE REF TO cx_root.
+
+    FIELD-SYMBOLS: <ls_consumer>   TYPE any,
+                   <lv_changed_by> TYPE any.
+
+    TRY.
+        CREATE OBJECT lo_registry_adapter TYPE ('/IWXBE/CL_EEEC_REG_ADAPTER').
+        CREATE DATA lr_data TYPE ('/IWXBE/IF_REGISTRY_TYPES=>TY_S_CONSUMER').
+        ASSIGN lr_data->* TO <ls_consumer>.
+
+        lv_object_key = ms_item-obj_name.
+
+        TRY.
+            CALL METHOD lo_registry_adapter->('/IWXBE/IF_EEEC_REG_ADAPTER_WB~GET_METADATA')
+              EXPORTING
+                iv_object_key = lv_object_key
+                iv_state      = 'I'
+              RECEIVING
+                rs_consumer   = <ls_consumer>.
+
+          CATCH cx_root.
+            CALL METHOD lo_registry_adapter->('/IWXBE/IF_EEEC_REG_ADAPTER_WB~GET_METADATA')
+              EXPORTING
+                iv_object_key = lv_object_key
+                iv_state      = 'A'
+              RECEIVING
+                rs_consumer   = <ls_consumer>.
+        ENDTRY.
+
+        ASSIGN COMPONENT 'CHANGED_BY' OF STRUCTURE <ls_consumer> TO <lv_changed_by>.
+        rv_user = <lv_changed_by>.
+
+      CATCH cx_root INTO lx_error.
+        zcx_abapgit_exception=>raise( iv_text     = lx_error->get_text( )
+                                      ix_previous = lx_error ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/aff/zcl_abapgit_object_eeec.clas.xml
+++ b/src/objects/aff/zcl_abapgit_object_eeec.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECT_EEEC</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - EEEC - Event Consumption Model</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This PR implements an AFF object handler for the Event Consumption Models (EEEC). This object type was already announced in issue [6079](https://github.com/abapGit/abapGit/issues/6079) and issue [5912](https://github.com/abapGit/abapGit/issues/5912)

In addition, this PR also contains slight adjustments for the `zcl_abapgit_object_common_aff` to provide a more generic approach for the AFF object handler retrieval.