### PR TITLE
move get_jumper() to new objects factory

### DIFF
--- a/src/objects/zcl_abapgit_object_aqbg.clas.abap
+++ b/src/objects/zcl_abapgit_object_aqbg.clas.abap
@@ -144,7 +144,7 @@ CLASS zcl_abapgit_object_aqbg IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'RS38S-BGNUM'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode      = 'SQ03'
       it_bdcdata    = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_aqqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_aqqu.clas.abap
@@ -118,7 +118,7 @@ CLASS zcl_abapgit_object_aqqu IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'RS38R-QNUM'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode      = 'SQ01'
       it_bdcdata    = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_aqsg.clas.abap
+++ b/src/objects/zcl_abapgit_object_aqsg.clas.abap
@@ -118,7 +118,7 @@ CLASS zcl_abapgit_object_aqsg IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'RS38Q-NAME'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode      = 'SQ02'
       it_bdcdata    = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_chdo.clas.abap
+++ b/src/objects/zcl_abapgit_object_chdo.clas.abap
@@ -352,7 +352,7 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
     ls_bdcdata-fval = '=DISP'.
     APPEND ls_bdcdata TO lt_bdcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SCDO'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -135,7 +135,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
+CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -927,7 +927,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
     ENDCASE.
 
     IF ls_item-obj_name IS NOT INITIAL.
-      rv_exit = zcl_abapgit_ui_factory=>get_gui_jumper( )->jump( ls_item ).
+      rv_exit = zcl_abapgit_objects_factory=>get_gui_jumper( )->jump( ls_item ).
     ENDIF.
 
     " Otherwise covered by ZCL_ABAPGIT_OBJECTS=>JUMP

--- a/src/objects/zcl_abapgit_object_cus1.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus1.clas.abap
@@ -32,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CUS1 IMPLEMENTATION.
+CLASS zcl_abapgit_object_cus1 IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -163,7 +163,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS1 IMPLEMENTATION.
     <ls_bdc_data>-fnam = 'BDC_OKCODE'.
     <ls_bdc_data>-fval = '=ACT_DISP'.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'S_CUS_ACTIVITY'
       it_bdcdata = lt_bdc_data ).
 

--- a/src/objects/zcl_abapgit_object_dial.clas.abap
+++ b/src/objects/zcl_abapgit_object_dial.clas.abap
@@ -76,7 +76,7 @@ CLASS zcl_abapgit_object_dial IMPLEMENTATION.
     ls_bcdata-fval = '=BACK'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode      = 'SE35'
       it_bdcdata    = lt_bcdata
       iv_new_window = abap_false ).

--- a/src/objects/zcl_abapgit_object_doct.clas.abap
+++ b/src/objects/zcl_abapgit_object_doct.clas.abap
@@ -18,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DOCT IMPLEMENTATION.
+CLASS zcl_abapgit_object_doct IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -150,7 +150,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOCT IMPLEMENTATION.
     ls_bcdata-fval = '=SHOW'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SE61'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_form.clas.abap
+++ b/src/objects/zcl_abapgit_object_form.clas.abap
@@ -384,7 +384,7 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'RSSCF-TDFORM'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SE71'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -162,7 +162,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
+CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
 
   METHOD check_rfc_parameters.
@@ -1332,7 +1332,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
     LOOP AT lt_functions ASSIGNING <ls_function> WHERE funcname = ls_item-obj_name.
       ls_item-obj_name = <ls_function>-include.
-      rv_exit = zcl_abapgit_ui_factory=>get_gui_jumper( )->jump( ls_item ).
+      rv_exit = zcl_abapgit_objects_factory=>get_gui_jumper( )->jump( ls_item ).
       IF rv_exit = abap_true.
         RETURN.
       ENDIF.
@@ -1341,7 +1341,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
     lt_includes = includes( ).
 
     LOOP AT lt_includes ASSIGNING <lv_include> WHERE table_line = ls_item-obj_name.
-      rv_exit = zcl_abapgit_ui_factory=>get_gui_jumper( )->jump( ls_item ).
+      rv_exit = zcl_abapgit_objects_factory=>get_gui_jumper( )->jump( ls_item ).
       IF rv_exit = abap_true.
         RETURN.
       ENDIF.

--- a/src/objects/zcl_abapgit_object_idoc.clas.abap
+++ b/src/objects/zcl_abapgit_object_idoc.clas.abap
@@ -311,7 +311,7 @@ CLASS zcl_abapgit_object_idoc IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'BDC_OKCODE'.
     <ls_bdcdata>-fval = '=DISP'.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'WE30'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_iext.clas.abap
+++ b/src/objects/zcl_abapgit_object_iext.clas.abap
@@ -173,7 +173,7 @@ CLASS zcl_abapgit_object_iext IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'BDC_OKCODE'.
     <ls_bdcdata>-fval = '=DISP'.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'WE30'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_iwmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwmo.clas.abap
@@ -150,7 +150,7 @@ CLASS zcl_abapgit_object_iwmo IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'GS_MODEL_SCREEN_100-VERSION'.
     <ls_bdcdata>-fval = lv_version.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = '/IWBEP/REG_MODEL'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_iwsv.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwsv.clas.abap
@@ -150,7 +150,7 @@ CLASS zcl_abapgit_object_iwsv IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'GS_SCREEN_100-VERSION'.
     <ls_bdcdata>-fval = lv_version.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = '/IWBEP/REG_SERVICE'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_nrob.clas.abap
+++ b/src/objects/zcl_abapgit_object_nrob.clas.abap
@@ -298,7 +298,7 @@ CLASS zcl_abapgit_object_nrob IMPLEMENTATION.
     ls_bcdata-fval = '=DISP'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SNRO'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_pers.clas.abap
+++ b/src/objects/zcl_abapgit_object_pers.clas.abap
@@ -197,7 +197,7 @@ CLASS zcl_abapgit_object_pers IMPLEMENTATION.
     ls_bcdata-fval = '=PERSDISPLAY'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'PERSREG'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -47,7 +47,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
+CLASS zcl_abapgit_object_shi3 IMPLEMENTATION.
 
 
   METHOD clear_fields.
@@ -209,7 +209,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'BMENUNAME-ID'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SE43'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_shma.clas.abap
+++ b/src/objects/zcl_abapgit_object_shma.clas.abap
@@ -251,7 +251,7 @@ CLASS zcl_abapgit_object_shma IMPLEMENTATION.
     ls_bcdata-fval = '=SHOW'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SHMA'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -84,7 +84,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
+CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
 
 
   METHOD change_sicf.
@@ -595,7 +595,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
     ls_bcdata-fval = '=ONLI'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SICF'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -389,7 +389,7 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'BDC_OKCODE'.
     <ls_bdcdata>-fval = '=DISPLAY'.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SMARTFORMS'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_ssst.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssst.clas.abap
@@ -204,7 +204,7 @@ CLASS zcl_abapgit_object_ssst IMPLEMENTATION.
     ls_bcdata-fval = '=DISPLAY'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SMARTSTYLES'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_styl.clas.abap
+++ b/src/objects/zcl_abapgit_object_styl.clas.abap
@@ -165,7 +165,7 @@ CLASS zcl_abapgit_object_styl IMPLEMENTATION.
     ls_bcdata-fval = '=SHOW'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SE72'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -106,7 +106,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
+CLASS zcl_abapgit_object_tran IMPLEMENTATION.
 
 
   METHOD add_data.
@@ -855,7 +855,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TRAN IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'TSTC-TCODE'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode      = 'SE93'
       it_bdcdata    = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_udmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_udmo.clas.abap
@@ -728,7 +728,7 @@ CLASS zcl_abapgit_object_udmo IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'RSUD3-OBJ_KEY'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SD11'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_ueno.clas.abap
+++ b/src/objects/zcl_abapgit_object_ueno.clas.abap
@@ -696,7 +696,7 @@ CLASS zcl_abapgit_object_ueno IMPLEMENTATION.
     <ls_bdcdata>-fnam = 'RSUD3-OBJ_KEY'.
     <ls_bdcdata>-fval = ms_item-obj_name.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SD11'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_object_vcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_vcls.clas.abap
@@ -239,7 +239,7 @@ CLASS zcl_abapgit_object_vcls IMPLEMENTATION.
     ls_bcdata-fval = '=CLSH'.
     APPEND ls_bcdata TO lt_bcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SE54'
       it_bdcdata = lt_bcdata ).
 

--- a/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_w3xx_super.clas.abap
@@ -387,7 +387,7 @@ CLASS zcl_abapgit_object_w3xx_super IMPLEMENTATION.
     ls_bdcdata-fval = '=ONLI'.
     APPEND ls_bdcdata TO lt_bdcdata.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_batch_input(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_batch_input(
       iv_tcode   = 'SMW0'
       it_bdcdata = lt_bdcdata ).
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -1100,7 +1100,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     IF lv_exit = abap_false.
       " Open object in new window with generic jumper
-      lv_exit = zcl_abapgit_ui_factory=>get_gui_jumper( )->jump(
+      lv_exit = zcl_abapgit_objects_factory=>get_gui_jumper( )->jump(
         is_item        = is_item
         is_sub_item    = is_sub_item
         iv_line_number = iv_line_number

--- a/src/objects/zcl_abapgit_objects_factory.clas.abap
+++ b/src/objects/zcl_abapgit_objects_factory.clas.abap
@@ -1,0 +1,30 @@
+CLASS zcl_abapgit_objects_factory DEFINITION
+  PUBLIC
+  CREATE PRIVATE
+  GLOBAL FRIENDS zcl_abapgit_objects_injector .
+
+  PUBLIC SECTION.
+    CLASS-METHODS get_gui_jumper
+      RETURNING
+        VALUE(ri_gui_jumper) TYPE REF TO zif_abapgit_gui_jumper .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CLASS-DATA gi_gui_jumper TYPE REF TO zif_abapgit_gui_jumper .
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_objects_factory IMPLEMENTATION.
+
+  METHOD get_gui_jumper.
+
+    IF gi_gui_jumper IS INITIAL.
+      CREATE OBJECT gi_gui_jumper TYPE zcl_abapgit_gui_jumper.
+    ENDIF.
+
+    ri_gui_jumper = gi_gui_jumper.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/zcl_abapgit_objects_factory.clas.xml
+++ b/src/objects/zcl_abapgit_objects_factory.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECTS_FACTORY</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Objects Factory</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/zcl_abapgit_objects_injector.clas.abap
+++ b/src/objects/zcl_abapgit_objects_injector.clas.abap
@@ -1,0 +1,24 @@
+CLASS zcl_abapgit_objects_injector DEFINITION
+  PUBLIC
+  CREATE PRIVATE .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS set_gui_jumper
+      IMPORTING
+        !ii_gui_jumper TYPE REF TO zif_abapgit_gui_jumper .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_objects_injector IMPLEMENTATION.
+
+  METHOD set_gui_jumper.
+
+    zcl_abapgit_ui_factory=>gi_gui_jumper = ii_gui_jumper.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/zcl_abapgit_objects_injector.clas.abap
+++ b/src/objects/zcl_abapgit_objects_injector.clas.abap
@@ -17,7 +17,7 @@ CLASS zcl_abapgit_objects_injector IMPLEMENTATION.
 
   METHOD set_gui_jumper.
 
-    zcl_abapgit_ui_factory=>gi_gui_jumper = ii_gui_jumper.
+    zcl_abapgit_objects_factory=>gi_gui_jumper = ii_gui_jumper.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_objects_injector.clas.xml
+++ b/src/objects/zcl_abapgit_objects_injector.clas.xml
@@ -10,7 +10,6 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
-    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/objects/zcl_abapgit_objects_injector.clas.xml
+++ b/src/objects/zcl_abapgit_objects_injector.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECTS_INJECTOR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Objects Injector</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -688,7 +688,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |Please install the abapGit repository| ).
     ENDIF.
 
-    zcl_abapgit_ui_factory=>get_gui_jumper( )->jump_abapgit(
+    zcl_abapgit_objects_factory=>get_gui_jumper( )->jump_abapgit(
       iv_language = lv_main_language
       iv_key      = mo_repo->get_key( ) ).
 

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -32,9 +32,6 @@ CLASS zcl_abapgit_ui_factory DEFINITION
         !iv_disable_query_table TYPE abap_bool DEFAULT abap_true
       RETURNING
         VALUE(ri_viewer)        TYPE REF TO zif_abapgit_html_viewer .
-    CLASS-METHODS get_gui_jumper
-      RETURNING
-        VALUE(ri_gui_jumper) TYPE REF TO zif_abapgit_gui_jumper .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -43,7 +40,6 @@ CLASS zcl_abapgit_ui_factory DEFINITION
     CLASS-DATA go_gui TYPE REF TO zcl_abapgit_gui .
     CLASS-DATA gi_fe_services TYPE REF TO zif_abapgit_frontend_services .
     CLASS-DATA gi_gui_services TYPE REF TO zif_abapgit_gui_services .
-    CLASS-DATA gi_gui_jumper TYPE REF TO zif_abapgit_gui_jumper .
 ENDCLASS.
 
 
@@ -155,17 +151,6 @@ CLASS zcl_abapgit_ui_factory IMPLEMENTATION.
           ii_asset_man      = li_asset_man.
     ENDIF.
     ro_gui = go_gui.
-
-  ENDMETHOD.
-
-
-  METHOD get_gui_jumper.
-
-    IF gi_gui_jumper IS INITIAL.
-      CREATE OBJECT gi_gui_jumper TYPE zcl_abapgit_gui_jumper.
-    ENDIF.
-
-    ri_gui_jumper = gi_gui_jumper.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_ui_injector.clas.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.abap
@@ -19,9 +19,6 @@ CLASS zcl_abapgit_ui_injector DEFINITION
     CLASS-METHODS set_html_viewer
       IMPORTING
         !ii_html_viewer TYPE REF TO zif_abapgit_html_viewer .
-    CLASS-METHODS set_gui_jumper
-      IMPORTING
-        !ii_gui_jumper TYPE REF TO zif_abapgit_gui_jumper .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -41,13 +38,6 @@ CLASS zcl_abapgit_ui_injector IMPLEMENTATION.
   METHOD set_frontend_services.
 
     zcl_abapgit_ui_factory=>gi_fe_services = ii_fe_serv.
-
-  ENDMETHOD.
-
-
-  METHOD set_gui_jumper.
-
-    zcl_abapgit_ui_factory=>gi_gui_jumper = ii_gui_jumper.
 
   ENDMETHOD.
 


### PR DESCRIPTION
https://abaplint.app/stats/abapGit/abapGit/package_coupling?folder=/src/ui

jumper is in objects folder, this should decouple many object handlers from the ui package