### PR TITLE
refactor call to TEXT_SPLIT

### DIFF
--- a/src/zcx_abapgit_exception.clas.abap
+++ b/src/zcx_abapgit_exception.clas.abap
@@ -443,52 +443,13 @@ CLASS zcx_abapgit_exception IMPLEMENTATION.
 
   METHOD split_text_to_symsg.
 
-    CONSTANTS:
-      lc_length_of_msgv           TYPE i VALUE 50,
-      lc_offset_of_last_character TYPE i VALUE 49.
+    DATA ls_msg TYPE symsg.
 
-    DATA:
-      lv_text    TYPE c LENGTH 200,
-      lv_rest    TYPE c LENGTH 200,
-      ls_msg     TYPE symsg,
-      lv_msg_var TYPE c LENGTH lc_length_of_msgv,
-      lv_index   TYPE sy-index.
-
-    lv_text = iv_text.
-
-    DO 4 TIMES.
-
-      lv_index = sy-index.
-
-      CALL FUNCTION 'TEXT_SPLIT'
-        EXPORTING
-          length = lc_length_of_msgv
-          text   = lv_text
-        IMPORTING
-          line   = lv_msg_var
-          rest   = lv_rest.
-
-      IF lv_msg_var+lc_offset_of_last_character(1) = space OR
-         lv_text+lc_length_of_msgv(1) = space.
-        " keep the space at the beginning of the rest
-        " because otherwise it's lost
-        lv_rest = | { lv_rest }|.
-      ENDIF.
-
-      lv_text = lv_rest.
-
-      CASE lv_index.
-        WHEN 1.
-          ls_msg-msgv1 = lv_msg_var.
-        WHEN 2.
-          ls_msg-msgv2 = lv_msg_var.
-        WHEN 3.
-          ls_msg-msgv3 = lv_msg_var.
-        WHEN 4.
-          ls_msg-msgv4 = lv_msg_var.
-      ENDCASE.
-
-    ENDDO.
+    cl_message_helper=>set_msg_vars_for_clike( iv_text ).
+    ls_msg-msgv1 = sy-msgv1.
+    ls_msg-msgv2 = sy-msgv2.
+    ls_msg-msgv3 = sy-msgv3.
+    ls_msg-msgv4 = sy-msgv4.
 
     " Set syst using generic error message
     MESSAGE e001(00) WITH ls_msg-msgv1 ls_msg-msgv2 ls_msg-msgv3 ls_msg-msgv4 INTO null.

--- a/src/zcx_abapgit_exception.clas.testclasses.abap
+++ b/src/zcx_abapgit_exception.clas.testclasses.abap
@@ -399,7 +399,7 @@ CLASS ltcl_split_text IMPLEMENTATION.
         v1 TYPE sy-msgv1 VALUE `Here is a very long text more than 200 characters`,
         v2 TYPE sy-msgv2 VALUE ` and we have to invent a nice story about abapGit`,
         v3 TYPE sy-msgv3 VALUE ` to fill this long message. abapGit is simply the`,
-        v4 TYPE sy-msgv4 VALUE ` greatest! #abapGit #awesome #community`,
+        v4 TYPE sy-msgv4 VALUE ` greatest! #abapGit #awesome #community #opensourc`,
       END OF lc_msg_z.
     test_set_msg_vars( iv_text = lc_text_x && lc_text_y && lc_text_z
                        is_msg  = lc_msg_z ).

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -77,7 +77,6 @@
     "extraSetup": "../test/setup.mjs",
     "skip": [
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_get_t100_longtext", "method": "test01", "note": "uses MSAG from database"},
-      {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_split_text", "method": "test_set_msg_z", "note": "some bug in fm TEXT_SPLIT in open-abap"},
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_t100",     "method": "text6", "note": "uses MSAG from database"},
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_t100",     "method": "text7", "note": "uses MSAG from database"},
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_t100",     "method": "text8", "note": "uses MSAG from database"},

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -110,8 +110,8 @@
       {"object": "ZCL_ABAPGIT_REQUIREMENT_HELPER", "class": "ltcl_formats", "method": "shorter_patch", "note": "Void type: CVERS_SDU"},
       {"object": "ZCL_ABAPGIT_REQUIREMENT_HELPER", "class": "ltcl_formats", "method": "higher_patch", "note": "Void type: CVERS_SDU"},
 
-      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "space_leading_trailing", "note": "close to working, https://github.com/open-abap/open-abap-core/pull/557 "},
-      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "bad_xml_raises_exc", "note": "handling of xml parser errors, cl_ixml, test method parse_negative"},
+      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "space_leading_trailing",          "note": "??"},
+      {"object": "ZCL_ABAPGIT_XML", "class": "ltcl_xml", "method": "bad_xml_raises_exc",              "note": "handling of xml parser errors, cl_ixml, test method parse_negative"},
       {"object": "ZCL_ABAPGIT_XML_OUTPUT", "class": "ltcl_xml_output", "method": "render_xml_string", "note": "kernel_call_transformation.mi_writer.get(...).if_sxml_writer$open_element is not a function"},
       {"object": "ZCL_ABAPGIT_XML_OUTPUT", "class": "ltcl_xml_output", "method": "add_simple_object", "note": "kernel_call_transformation.mi_writer.get(...).if_sxml_writer$open_element is not a function"},
       {"object": "ZCL_ABAPGIT_XML_INPUT", "class": "ltcl_xml", "method": "up"},

--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -77,9 +77,6 @@
     "extraSetup": "../test/setup.mjs",
     "skip": [
       {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_get_t100_longtext", "method": "test01", "note": "uses MSAG from database"},
-      {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_t100",     "method": "text6", "note": "uses MSAG from database"},
-      {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_t100",     "method": "text7", "note": "uses MSAG from database"},
-      {"object": "ZCX_ABAPGIT_EXCEPTION", "class": "ltcl_t100",     "method": "text8", "note": "uses MSAG from database"},
 
       {"object": "ZCL_ABAPGIT_XML_PRETTY", "class": "ltcl_test", "method": "pretty1",           "note": "open-abap does not add the byte order mark"},
       {"object": "ZCL_ABAPGIT_XML_PRETTY", "class": "ltcl_test", "method": "pretty2",           "note": "open-abap does not add the byte order mark"},


### PR DESCRIPTION
note: I did not check 702 compatibility

it doesnt need exactly to work like the old split, just something that works with MESSAGE

function module `TEXT_SPLIT` is not released in Steampunk, while `cl_message_helper` [is released](https://abapedia.org/steampunk-2305-api/cl_message_helper.clas.html)

plus run another unit test via open-abap
