### PR TITLE
Fix potential crash in background mode

### DIFF
--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -102,6 +102,8 @@ CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
     WRITE: / 'Background mode'.
 
     LOOP AT lt_list ASSIGNING <ls_list>.
+      CREATE OBJECT li_log TYPE zcl_abapgit_log.
+
       TRY.
           lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( <ls_list>-key ).
           lv_repo_name = lo_repo->get_name( ).
@@ -112,7 +114,6 @@ CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
             iv_username = <ls_list>-username
             iv_password = <ls_list>-password ).
 
-          CREATE OBJECT li_log TYPE zcl_abapgit_log.
           CREATE OBJECT li_background TYPE (<ls_list>-method).
 
           li_background->run(


### PR DESCRIPTION
A runtime error can occur if `zcx_abapgit_exception` is raised before `li_log` is instatiated. I've moved the creation of the log to the beginning of the loop to fix this.