### PR TITLE
IWOM/IWPR/TRAN: Implement `changed_by`

### DIFF
--- a/src/objects/zcl_abapgit_object_aqbg.clas.abap
+++ b/src/objects/zcl_abapgit_object_aqbg.clas.abap
@@ -69,7 +69,7 @@ CLASS zcl_abapgit_object_aqbg IMPLEMENTATION.
   METHOD zif_abapgit_object~changed_by.
     SELECT SINGLE bgunam FROM aqgdbbg INTO rv_user WHERE num = ms_item-obj_name.
     IF sy-subrc <> 0.
-      rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+      rv_user = c_user_unknown.
     ENDIF.
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_aqqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_aqqu.clas.abap
@@ -46,7 +46,7 @@ CLASS zcl_abapgit_object_aqqu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+    rv_user = c_user_unknown.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_aqsg.clas.abap
+++ b/src/objects/zcl_abapgit_object_aqsg.clas.abap
@@ -46,7 +46,7 @@ CLASS zcl_abapgit_object_aqsg IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+    rv_user = c_user_unknown.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_asfc.clas.abap
+++ b/src/objects/zcl_abapgit_object_asfc.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_asfc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+    rv_user = c_user_unknown.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwom.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwom.clas.abap
@@ -57,7 +57,13 @@ CLASS zcl_abapgit_object_iwom IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+
+    SELECT SINGLE changed_by FROM ('/IWFND/I_MED_OHD') INTO rv_user
+      WHERE model_identifier = ms_item-obj_name.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwpr.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwpr.clas.abap
@@ -57,7 +57,13 @@ CLASS zcl_abapgit_object_iwpr IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+
+    SELECT SINGLE last_chg_user_id FROM ('/IWBEP/I_SBD_PR') INTO rv_user
+      WHERE project = ms_item-obj_name.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwsg.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwsg.clas.abap
@@ -63,7 +63,7 @@ CLASS zcl_abapgit_object_iwsg IMPLEMENTATION.
     SELECT SINGLE changed_by FROM ('/IWFND/I_MED_SRH') INTO rv_user
       WHERE srv_identifier = ms_item-obj_name.
     IF sy-subrc <> 0.
-      rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+      rv_user = c_user_unknown.
     ENDIF.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_sppf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sppf.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_sppf IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+    rv_user = c_user_unknown.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sucu.clas.abap
+++ b/src/objects/zcl_abapgit_object_sucu.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_sucu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = zcl_abapgit_objects_super=>c_user_unknown.
+    rv_user = c_user_unknown.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -634,8 +634,20 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-* looks like "changed by user" is not stored in the database
-    rv_user = c_user_unknown.
+    " Changed-by-user is not stored in transaction metadata
+    " Instead, use owner of last transport or object directory
+
+    DATA lv_transport TYPE trkorr.
+
+    lv_transport = zcl_abapgit_factory=>get_cts_api( )->get_transport_for_object( ms_item ).
+
+    IF lv_transport IS NOT INITIAL.
+      SELECT SINGLE as4user FROM e070 INTO rv_user WHERE trkorr = lv_transport.
+    ELSE.
+      SELECT SINGLE author FROM tadir INTO rv_user
+        WHERE pgmid = 'R3TR' AND object = ms_item-obj_type AND obj_name = ms_item-obj_name.
+    ENDIF.
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
- Lookup primary table for `IWOM` and `IWPR`
- Lookup last transport or object directory for `TRAN`
- Remove unnecessary super-class prefix for a few object types