### PR TITLE
Fix Syntax Check warnings regarding secondary keys

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -216,7 +216,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
       CLEAR lt_nodes.
 
 * files
-      LOOP AT it_expanded ASSIGNING <ls_exp> USING KEY path WHERE path = <ls_folder>-path.
+      LOOP AT it_expanded ASSIGNING <ls_exp> USING KEY path_name WHERE path = <ls_folder>-path.
         APPEND INITIAL LINE TO lt_nodes ASSIGNING <ls_node>.
         <ls_node>-chmod = <ls_exp>-chmod.
         <ls_node>-name  = <ls_exp>-name.

--- a/src/git/zif_abapgit_git_definitions.intf.abap
+++ b/src/git/zif_abapgit_git_definitions.intf.abap
@@ -93,8 +93,7 @@ INTERFACE zif_abapgit_git_definitions
     END OF ty_expanded .
   TYPES:
     ty_expanded_tt TYPE STANDARD TABLE OF ty_expanded WITH DEFAULT KEY
-      WITH NON-UNIQUE SORTED KEY path_name COMPONENTS path name
-      WITH NON-UNIQUE SORTED KEY path COMPONENTS path.
+      WITH NON-UNIQUE SORTED KEY path_name COMPONENTS path name.
 
   TYPES:
     BEGIN OF ty_create,

--- a/src/stage/zcl_abapgit_merge.clas.abap
+++ b/src/stage/zcl_abapgit_merge.clas.abap
@@ -103,11 +103,14 @@ CLASS zcl_abapgit_merge IMPLEMENTATION.
       UNASSIGN <ls_common>.
 
       READ TABLE ms_merge-stree ASSIGNING <ls_source>
-        WITH KEY path = <ls_file>-path name = <ls_file>-name. "#EC CI_SUBRC
+        WITH KEY path_name
+        COMPONENTS path = <ls_file>-path name = <ls_file>-name. "#EC CI_SUBRC
       READ TABLE ms_merge-ttree ASSIGNING <ls_target>
-        WITH KEY path = <ls_file>-path name = <ls_file>-name. "#EC CI_SUBRC
+        WITH KEY path_name
+        COMPONENTS path = <ls_file>-path name = <ls_file>-name. "#EC CI_SUBRC
       READ TABLE ms_merge-ctree ASSIGNING <ls_common>
-        WITH KEY path = <ls_file>-path name = <ls_file>-name. "#EC CI_SUBRC
+        WITH KEY path_name
+        COMPONENTS path = <ls_file>-path name = <ls_file>-name. "#EC CI_SUBRC
 
       lv_found_source = boolc( <ls_source> IS ASSIGNED ).
       lv_found_target = boolc( <ls_target> IS ASSIGNED ).
@@ -383,8 +386,9 @@ CLASS zcl_abapgit_merge IMPLEMENTATION.
       READ TABLE mt_conflicts ASSIGNING <ls_conflict> WITH KEY path = is_conflict-path
                                                                filename = is_conflict-filename.
       IF sy-subrc = 0.
-        READ TABLE ms_merge-result ASSIGNING <ls_result> WITH KEY path = is_conflict-path
-                                                                  name = is_conflict-filename.
+        READ TABLE ms_merge-result ASSIGNING <ls_result>
+          WITH KEY path_name
+          COMPONENTS path = is_conflict-path name = is_conflict-filename.
         IF sy-subrc = 0.
           <ls_result>-sha1 = is_conflict-result_sha1.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_merge.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_merge.clas.abap
@@ -144,7 +144,8 @@ CLASS zcl_abapgit_gui_page_merge IMPLEMENTATION.
     LOOP AT lt_files ASSIGNING <ls_file>.
       CLEAR ls_result.
       READ TABLE ls_merge-result INTO ls_result
-        WITH KEY path = <ls_file>-path name = <ls_file>-name.
+        WITH KEY path_name
+        COMPONENTS path = <ls_file>-path name = <ls_file>-name.
 
       ri_html->add( '<tr>' ).
       show_file( it_expanded = ls_merge-stree
@@ -181,9 +182,8 @@ CLASS zcl_abapgit_gui_page_merge IMPLEMENTATION.
 
 
     READ TABLE it_expanded ASSIGNING <ls_show>
-        WITH KEY
-        path = is_file-path
-        name = is_file-name.
+      WITH KEY path_name
+      COMPONENTS path = is_file-path name = is_file-name.
     IF sy-subrc = 0.
       IF <ls_show>-sha1 = is_result-sha1.
         ii_html->add( |<td>{ <ls_show>-path }{ <ls_show>-name }</td><td><b>{ <ls_show>-sha1(7) }</b></td>| ).


### PR DESCRIPTION
Fix these warnings
![grafik](https://github.com/abapGit/abapGit/assets/17437789/a684874b-702d-4e74-b6be-5445773349fb)
![grafik](https://github.com/abapGit/abapGit/assets/17437789/5764b30f-4300-4e94-8766-3b3815bc8b0b)
