### PR TITLE
Downport: Fix syntax errors in unit tests

### DIFF
--- a/src/git/zcl_abapgit_git_commit.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_commit.clas.testclasses.abap
@@ -193,15 +193,17 @@ CLASS ltc_parent_handling IMPLEMENTATION.
 
 
   METHOD parent_should_be_missing.
-    cl_abap_unit_assert=>assert_true(
-        zcl_abapgit_git_commit=>is_missing( it_commits = mt_commits
-                                            iv_sha1    = iv_sha1 ) ).
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_git_commit=>is_missing( it_commits = mt_commits
+                                                iv_sha1    = iv_sha1 )
+      exp = abap_true ).
   ENDMETHOD.
 
   METHOD parent_should_not_be_missing.
-    cl_abap_unit_assert=>assert_false(
-        zcl_abapgit_git_commit=>is_missing( it_commits = mt_commits
-                                            iv_sha1    = iv_sha1 ) ).
+    cl_abap_unit_assert=>assert_equals(
+      act = zcl_abapgit_git_commit=>is_missing( it_commits = mt_commits
+                                                iv_sha1    = iv_sha1 )
+      exp = abap_false ).
   ENDMETHOD.
 
   METHOD given_commit.

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.testclasses.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.testclasses.abap
@@ -213,7 +213,9 @@ CLASS ltcl_create_package IMPLEMENTATION.
 
   METHOD then_popup_is_shown.
 
-    cl_abap_unit_assert=>assert_true( mo_popups_mock->was_create_package_popup_shown( )  ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_popups_mock->was_create_package_popup_shown( )
+      exp = abap_true ).
 
   ENDMETHOD.
 
@@ -227,7 +229,9 @@ CLASS ltcl_create_package IMPLEMENTATION.
 
   METHOD then_no_package_is_created.
 
-    cl_abap_unit_assert=>assert_false( mo_sap_package_mock->was_create_called( ) ).
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_sap_package_mock->was_create_called( )
+      exp = abap_false ).
 
   ENDMETHOD.
 
@@ -241,10 +245,13 @@ CLASS ltcl_create_package IMPLEMENTATION.
 
   METHOD then_package_is_created.
 
-    cl_abap_unit_assert=>assert_true( mo_sap_package_mock->was_create_called( ) ).
     cl_abap_unit_assert=>assert_equals(
-        exp = mv_package
-        act = mv_created_package ).
+      act = mo_sap_package_mock->was_create_called( )
+      exp = abap_true ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = mv_package
+      act = mv_created_package ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Ref #6436