### PR TITLE
Remove `status` from `zcl_abapgit_repo`

### DIFF
--- a/src/cts/zcl_abapgit_transport_2_branch.clas.abap
+++ b/src/cts/zcl_abapgit_transport_2_branch.clas.abap
@@ -32,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_TRANSPORT_2_BRANCH IMPLEMENTATION.
+CLASS zcl_abapgit_transport_2_branch IMPLEMENTATION.
 
 
   METHOD create.
@@ -52,7 +52,7 @@ CLASS ZCL_ABAPGIT_TRANSPORT_2_BRANCH IMPLEMENTATION.
 
     ls_stage_objects = zcl_abapgit_factory=>get_stage_logic( )->get( io_repository ).
 
-    lt_object_statuses = io_repository->status( ).
+    lt_object_statuses = zcl_abapgit_repo_status=>calculate( io_repository ).
 
     stage_transport_objects(
        it_transport_objects = it_transport_objects

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -89,20 +89,12 @@ CLASS zcl_abapgit_repo DEFINITION
         !ct_files TYPE zif_abapgit_git_definitions=>ty_files_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS reset_status .
     METHODS set_files_remote
       IMPORTING
         !it_files TYPE zif_abapgit_git_definitions=>ty_files_tt .
     METHODS set_local_settings
       IMPORTING
         !is_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings
-      RAISING
-        zcx_abapgit_exception .
-    METHODS status
-      IMPORTING
-        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception .
     METHODS switch_repo_type
@@ -116,7 +108,6 @@ CLASS zcl_abapgit_repo DEFINITION
     DATA mt_remote TYPE zif_abapgit_git_definitions=>ty_files_tt .
     DATA mv_request_local_refresh TYPE abap_bool .
     DATA mv_request_remote_refresh TYPE abap_bool .
-    DATA mt_status TYPE zif_abapgit_definitions=>ty_results_tt .
     DATA mi_log TYPE REF TO zif_abapgit_log .
     DATA mi_listener TYPE REF TO zif_abapgit_repo_listener .
     DATA mo_apack_reader TYPE REF TO zcl_abapgit_apack_reader .
@@ -560,12 +551,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
   METHOD reset_remote.
     CLEAR mt_remote.
     mv_request_remote_refresh = abap_true.
-    reset_status( ).
-  ENDMETHOD.
-
-
-  METHOD reset_status.
-    CLEAR mt_status.
   ENDMETHOD.
 
 
@@ -662,18 +647,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD status.
-
-    IF lines( mt_status ) = 0.
-      mt_status = zcl_abapgit_repo_status=>calculate( io_repo = me
-                                                      ii_log  = ii_log ).
-    ENDIF.
-
-    rt_results = mt_status.
-
-  ENDMETHOD.
-
-
   METHOD switch_repo_type.
 
     IF iv_offline = ms_data-offline.
@@ -758,7 +731,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     zif_abapgit_repo~checksums( )->update( lt_updated_files ).
 
     update_last_deserialize( ).
-    reset_status( ).
 
     COMMIT WORK AND WAIT.
 

--- a/src/repo/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/repo/zcl_abapgit_repo_content_list.clas.abap
@@ -167,7 +167,9 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
                    <ls_repo_item> LIKE LINE OF rt_repo_items.
 
 
-    lt_status = mo_repo->status( mi_log ).
+    lt_status = zcl_abapgit_repo_status=>calculate(
+      io_repo = mo_repo
+      ii_log  = mi_log ).
 
     LOOP AT lt_status ASSIGNING <ls_status>.
       AT NEW obj_name. "obj_type + obj_name

--- a/src/repo/zcl_abapgit_repo_online.clas.abap
+++ b/src/repo/zcl_abapgit_repo_online.clas.abap
@@ -311,8 +311,6 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     zif_abapgit_repo~checksums( )->update( ls_push-updated_files ).
 
-    reset_status( ).
-
   ENDMETHOD.
 
 

--- a/src/stage/zcl_abapgit_stage_logic.clas.abap
+++ b/src/stage/zcl_abapgit_stage_logic.clas.abap
@@ -89,7 +89,8 @@ CLASS zcl_abapgit_stage_logic IMPLEMENTATION.
 
     rs_files-local  = io_repo->get_files_local( ii_obj_filter = ii_obj_filter ).
     rs_files-remote = io_repo->get_files_remote( ii_obj_filter ).
-    rs_files-status = io_repo->status( ).
+    rs_files-status = zcl_abapgit_repo_status=>calculate( io_repo ).
+
     remove_identical( CHANGING cs_files = rs_files ).
     remove_ignored( EXPORTING io_repo  = io_repo
                     CHANGING  cs_files = rs_files ).

--- a/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff.clas.abap
@@ -555,8 +555,8 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
     lt_remote = mo_repo->get_files_remote( ).
     lt_local  = mo_repo->get_files_local( ).
-    mo_repo->reset_status( ).
-    lt_status = mo_repo->status( ).
+
+    lt_status = zcl_abapgit_repo_status=>calculate( mo_repo ).
 
     li_exit = zcl_abapgit_exit=>get_instance( ).
     li_exit->pre_calculate_repo_status(

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -348,7 +348,6 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
     " Make sure there're no leftovers from previous repos
     ro_repo->zif_abapgit_repo~checksums( )->rebuild( ).
-    ro_repo->reset_status( ). " TODO refactor later
 
     toggle_favorite( ro_repo->get_key( ) ).
 
@@ -381,7 +380,6 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
     " Make sure there're no leftovers from previous repos
     ro_repo->zif_abapgit_repo~checksums( )->rebuild( ).
-    ro_repo->reset_status( ). " TODO refactor later
 
     toggle_favorite( ro_repo->get_key( ) ).
 
@@ -696,7 +694,6 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     ENDIF.
 
     lo_repo->zif_abapgit_repo~checksums( )->rebuild( ).
-    lo_repo->reset_status( ). " TODO refactor later
 
     COMMIT WORK AND WAIT.
 


### PR DESCRIPTION
Continue #6178 to make repo class more focussed (ref #3799, #6107).

Status is now handled exclusively in `zcl_abapgit_repo_status`