### PR TITLE
Replace RS_NAME_SPLIT_NAMESPACE in TADIR class

### DIFF
--- a/src/objects/core/zcl_abapgit_tadir.clas.abap
+++ b/src/objects/core/zcl_abapgit_tadir.clas.abap
@@ -106,32 +106,27 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
 
   METHOD add_namespace.
 
-    DATA:
-      lv_name      TYPE progname,
-      lv_namespace TYPE namespace.
+    DATA ls_tadir  TYPE zif_abapgit_definitions=>ty_tadir.
+    DATA ls_obj_with_namespace TYPE zif_abapgit_definitions=>ty_obj_namespace.
 
     FIELD-SYMBOLS <ls_tadir> LIKE LINE OF ct_tadir.
 
-    lv_name = iv_object.
+    TRY.
+        ls_obj_with_namespace = zcl_abapgit_factory=>get_sap_namespace(  )->split_by_name( iv_object ).
+      CATCH zcx_abapgit_exception.
+        "Ignore the exception like before the replacement of the FM RS_NAME_SPLIT_NAMESPACE
+        RETURN.
+    ENDTRY.
 
-    CALL FUNCTION 'RS_NAME_SPLIT_NAMESPACE'
-      EXPORTING
-        name_with_namespace = lv_name
-      IMPORTING
-        namespace           = lv_namespace
-      EXCEPTIONS
-        delimiter_error     = 1
-        OTHERS              = 2.
-
-    IF sy-subrc = 0 AND lv_namespace IS NOT INITIAL.
+    IF ls_obj_with_namespace-namespace IS NOT INITIAL.
 
       READ TABLE ct_tadir TRANSPORTING NO FIELDS
-        WITH KEY pgmid = 'R3TR' object = 'NSPC' obj_name = lv_namespace.
+        WITH KEY pgmid = 'R3TR' object = 'NSPC' obj_name = ls_obj_with_namespace-namespace.
       IF sy-subrc <> 0.
         APPEND INITIAL LINE TO ct_tadir ASSIGNING <ls_tadir>.
         <ls_tadir>-pgmid      = 'R3TR'.
         <ls_tadir>-object     = 'NSPC'.
-        <ls_tadir>-obj_name   = lv_namespace.
+        <ls_tadir>-obj_name   = ls_obj_with_namespace-namespace.
         <ls_tadir>-devclass   = iv_package.
         <ls_tadir>-srcsystem  = sy-sysid.
         <ls_tadir>-masterlang = sy-langu.

--- a/src/objects/sap/zcl_abapgit_sap_namespace.clas.abap
+++ b/src/objects/sap/zcl_abapgit_sap_namespace.clas.abap
@@ -11,7 +11,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SAP_NAMESPACE IMPLEMENTATION.
+CLASS zcl_abapgit_sap_namespace IMPLEMENTATION.
 
 
   METHOD zif_abapgit_sap_namespace~exists.
@@ -26,4 +26,31 @@ CLASS ZCL_ABAPGIT_SAP_NAMESPACE IMPLEMENTATION.
     SELECT SINGLE editflag FROM trnspace INTO lv_editflag WHERE namespace = iv_namespace.
     rv_yes = boolc( sy-subrc = 0 AND lv_editflag = 'X' ).
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_sap_namespace~split_by_name.
+    DATA lv_regex TYPE string.
+    DATA lv_object TYPE string.
+    DATA lv_length TYPE i.
+    DATA lr_ex TYPE REF TO cx_root.
+
+    lv_regex =  '^\/[^\/]{1,8}\/'.
+
+    TRY.
+        FIND REGEX lv_regex IN iv_obj_with_namespace MATCH LENGTH lv_length.
+      CATCH cx_root INTO lr_ex.
+        zcx_abapgit_exception=>raise( lr_ex->get_text( ) ).
+    ENDTRY.
+
+    IF sy-subrc = 0 AND lv_length > 1.
+      rs_obj_namespace-namespace = iv_obj_with_namespace(lv_length).
+      rs_obj_namespace-obj_without_namespace = iv_obj_with_namespace+lv_length.
+    ELSE.
+      IF iv_obj_with_namespace(1) = '/'.
+        zcx_abapgit_exception=>raise( |The object { iv_obj_with_namespace } has an invalid namespace| ).
+      ENDIF.
+      rs_obj_namespace-obj_without_namespace = iv_obj_with_namespace.
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/sap/zcl_abapgit_sap_namespace.clas.testclasses.abap
+++ b/src/objects/sap/zcl_abapgit_sap_namespace.clas.testclasses.abap
@@ -1,0 +1,74 @@
+CLASS ltcl_check_split_by_name DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
+  PRIVATE SECTION.
+    METHODS check_with_namespace FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS check_without_namespace FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS check_exception FOR TESTING RAISING zcx_abapgit_exception.
+ENDCLASS.
+
+CLASS ltcl_check_split_by_name IMPLEMENTATION.
+
+  METHOD check_with_namespace.
+
+    DATA lv_obj_with_namespace TYPE tadir-obj_name.
+    DATA ls_obj_with_namespace TYPE zif_abapgit_definitions=>ty_obj_namespace.
+    DATA lr_ex TYPE REF TO zcx_abapgit_exception.
+
+    lv_obj_with_namespace = '/BLA12345/TEST/123'.
+
+    TRY.
+        ls_obj_with_namespace = zcl_abapgit_factory=>get_sap_namespace(  )->split_by_name( lv_obj_with_namespace ).
+
+      CATCH zcx_abapgit_exception INTO lr_ex.
+        cl_abap_unit_assert=>fail( lr_ex->get_text(  ) ).
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_equals(
+       act = ls_obj_with_namespace-namespace
+       exp = '/BLA12345/' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = ls_obj_with_namespace-obj_without_namespace
+      exp = 'TEST/123' ).
+
+
+  ENDMETHOD.
+  METHOD check_without_namespace.
+
+    DATA lv_obj_with_namespace TYPE tadir-obj_name.
+    DATA ls_obj_with_namespace TYPE zif_abapgit_definitions=>ty_obj_namespace.
+    DATA lr_ex TYPE REF TO zcx_abapgit_exception.
+
+    lv_obj_with_namespace = 'ZCL_ABAPGIT_SAP_NAMESP'.
+
+    TRY.
+        ls_obj_with_namespace = zcl_abapgit_factory=>get_sap_namespace(  )->split_by_name( lv_obj_with_namespace ).
+      CATCH zcx_abapgit_exception INTO lr_ex.
+        cl_abap_unit_assert=>fail( lr_ex->get_text(  ) ).
+    ENDTRY.
+
+    cl_abap_unit_assert=>assert_equals(
+       act = ls_obj_with_namespace-namespace
+       exp = '' ).
+
+    cl_abap_unit_assert=>assert_equals(
+       act = ls_obj_with_namespace-obj_without_namespace
+       exp = 'ZCL_ABAPGIT_SAP_NAMESP' ).
+
+  ENDMETHOD.
+
+  METHOD check_exception.
+
+    DATA lv_obj_with_namespace TYPE tadir-obj_name.
+    lv_obj_with_namespace = '/TEST12345/BLA'.
+
+    TRY.
+        zcl_abapgit_factory=>get_sap_namespace(  )->split_by_name( lv_obj_with_namespace ).
+
+      CATCH zcx_abapgit_exception.
+        RETURN.
+    ENDTRY.
+
+    cl_abap_unit_assert=>fail( 'No Exception raised' ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/sap/zcl_abapgit_sap_namespace.clas.xml
+++ b/src/objects/sap/zcl_abapgit_sap_namespace.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/objects/sap/zif_abapgit_sap_namespace.intf.abap
+++ b/src/objects/sap/zif_abapgit_sap_namespace.intf.abap
@@ -13,4 +13,12 @@ INTERFACE zif_abapgit_sap_namespace
     RETURNING
       VALUE(rv_yes) TYPE abap_bool.
 
+  METHODS split_by_name
+    IMPORTING
+      iv_obj_with_namespace   TYPE tadir-obj_name
+    RETURNING
+      VALUE(rs_obj_namespace) TYPE zif_abapgit_definitions=>ty_obj_namespace
+    RAISING
+      zcx_abapgit_exception.
+
 ENDINTERFACE.

--- a/src/repo/zcl_abapgit_repo_status.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_status.clas.testclasses.abap
@@ -128,6 +128,9 @@ CLASS ltcl_run_checks IMPLEMENTATION.
   METHOD zif_abapgit_sap_namespace~is_editable.
   ENDMETHOD.
 
+  METHOD zif_abapgit_sap_namespace~split_by_name.
+  ENDMETHOD.
+
   METHOD append_result.
 
     DATA ls_result LIKE LINE OF mt_results.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -10,6 +10,11 @@ INTERFACE zif_abapgit_definitions
       devclass TYPE devclass,
     END OF ty_item_signature .
   TYPES:
+    BEGIN OF ty_obj_namespace,
+      namespace TYPE trnspace-namespace,
+      obj_without_namespace  TYPE tadir-obj_name,
+    END OF ty_obj_namespace.
+  TYPES:
     BEGIN OF ty_item.
       INCLUDE TYPE ty_item_signature.
   TYPES:


### PR DESCRIPTION
#6428 This PR replaces only the RS_NAME_SPLIT_NAMESPACE in the class zcl_abapgit_tadir with the new method
zcl_abapgit_factory=>get_sap_namespace(  )->split_by_name().

Additional adjustement to  zcl_abapgit_repo_status.clas.testclasses was required, because it implements the interface zif_abapgit_sap_namespace.
