### PR TITLE
Replace `zcl_abapgit_objects=>ty_serialization` with same type in interface

### DIFF
--- a/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
+++ b/src/objects/core/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
@@ -21,7 +21,7 @@ FUNCTION z_abapgit_serialize_parallel.
   DATA: ls_item  TYPE zif_abapgit_definitions=>ty_item,
         lx_error TYPE REF TO zcx_abapgit_exception,
         lv_text  TYPE c LENGTH 200,
-        ls_files TYPE zcl_abapgit_objects=>ty_serialization.
+        ls_files TYPE zif_abapgit_objects=>ty_serialization.
 
   TRY.
       ls_item-obj_type  = iv_obj_type.

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -6,18 +6,13 @@ CLASS zcl_abapgit_objects DEFINITION
 
     TYPES:
       ty_types_tt TYPE SORTED TABLE OF tadir-object WITH UNIQUE KEY table_line .
-    TYPES:
-      BEGIN OF ty_serialization,
-        files TYPE zif_abapgit_git_definitions=>ty_files_tt,
-        item  TYPE zif_abapgit_definitions=>ty_item,
-      END OF ty_serialization .
 
     CLASS-METHODS serialize
       IMPORTING
         !is_item                 TYPE zif_abapgit_definitions=>ty_item
         !io_i18n_params          TYPE REF TO zcl_abapgit_i18n_params
       RETURNING
-        VALUE(rs_files_and_item) TYPE ty_serialization
+        VALUE(rs_files_and_item) TYPE zif_abapgit_objects=>ty_serialization
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS deserialize

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -157,7 +157,6 @@ CLASS zcl_abapgit_objects DEFINITION
         zcx_abapgit_exception .
     CLASS-METHODS check_objects_locked
       IMPORTING
-        !iv_language TYPE spras
         !it_items    TYPE zif_abapgit_definitions=>ty_items_tt
       RAISING
         zcx_abapgit_exception .
@@ -528,8 +527,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
         lt_items = map_tadir_to_items( lt_tadir ).
 
-        check_objects_locked( iv_language = zif_abapgit_definitions=>c_english
-                              it_items    = lt_items ).
+        check_objects_locked( lt_items ).
 
       CATCH zcx_abapgit_exception INTO lx_error.
         zcl_abapgit_default_transport=>get_instance( )->reset( ).
@@ -672,8 +670,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     zcl_abapgit_factory=>get_cts_api( )->confirm_transport_messages( ).
 
-    check_objects_locked( iv_language = io_repo->get_dot_abapgit( )->get_main_language( )
-                          it_items    = lt_items ).
+    check_objects_locked( lt_items ).
 
     lo_i18n_params = zcl_abapgit_i18n_params=>new( is_params = determine_i18n_params(
       io_dot                = io_repo->get_dot_abapgit( )

--- a/src/objects/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_objects.clas.testclasses.abap
@@ -248,7 +248,7 @@ CLASS ltcl_serialize IMPLEMENTATION.
 
   METHOD check.
 
-    DATA: ls_files_item TYPE zcl_abapgit_objects=>ty_serialization.
+    DATA: ls_files_item TYPE zif_abapgit_objects=>ty_serialization.
 
     ls_files_item = zcl_abapgit_objects=>serialize(
       is_item        = is_item

--- a/src/objects/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_objects.clas.testclasses.abap
@@ -395,9 +395,7 @@ CLASS ltcl_check_objects_locked IMPLEMENTATION.
     DATA: lx_error TYPE REF TO zcx_abapgit_exception.
 
     TRY.
-        zcl_abapgit_objects=>check_objects_locked( iv_language = 'E'
-                                                   it_items    = mt_given_items ).
-
+        zcl_abapgit_objects=>check_objects_locked( mt_given_items ).
       CATCH zcx_abapgit_exception INTO lx_error.
         mv_exception_text = lx_error->get_text( ).
     ENDTRY.

--- a/src/utils/zcl_abapgit_timer.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_timer.clas.testclasses.abap
@@ -23,7 +23,7 @@ CLASS ltcl_timer IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_subrc(
       act = sy-subrc
-      msg = |Did not return right measurement, got: { iv_result }| ).
+      msg = 'Did not return right measurement' ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_timer.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_timer.clas.testclasses.abap
@@ -21,7 +21,7 @@ CLASS ltcl_timer IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_subrc(
       act = sy-subrc
-      msg = 'Did not return right measurement' ).
+      msg = |Did not return right measurement, got: { iv_result }| ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_zip.clas.abap
+++ b/src/utils/zcl_abapgit_zip.clas.abap
@@ -142,7 +142,7 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
           lv_folder        TYPE string,
           lv_fullpath      TYPE string,
           lv_sep           TYPE c LENGTH 1,
-          ls_files_item    TYPE zcl_abapgit_objects=>ty_serialization,
+          ls_files_item    TYPE zif_abapgit_objects=>ty_serialization,
           lo_frontend_serv TYPE REF TO zif_abapgit_frontend_services.
 
     FIELD-SYMBOLS: <ls_file> LIKE LINE OF ls_files_item-files.


### PR DESCRIPTION
Refactoring: `zcl_abapgit_objects=>ty_serialization` exists already in `zif_abapgit_objects=>ty_serialization`. 
=> replace `zcl_abapgit_objects=>ty_serialization`.