### PR TITLE
Remove unused constant for ABAP Language Version

### DIFF
--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -410,13 +410,6 @@ INTERFACE zif_abapgit_definitions
       skip   TYPE ty_method VALUE '?',
     END OF c_method .
 
-  CONSTANTS:
-    BEGIN OF c_abap_language_version,
-      standard         TYPE c VALUE '',
-      keyuser          TYPE c VALUE '2',
-      clouddevelopment TYPE c VALUE '5',
-    END OF c_abap_language_version.
-
   TYPES:
     ty_sap_langu_tab TYPE STANDARD TABLE OF langu WITH DEFAULT KEY.
   TYPES:


### PR DESCRIPTION
Removes ALaV constant from `zif_abapgit_definitions`.

Closes https://github.com/abapGit/abapGit/issues/6421

We use the following constants for internal values for ALaV:

https://github.com/abapGit/abapGit/blob/7ae6ac291aeb42eb94e98cb70d934a9fbc91b2aa/src/objects/aff_types/zif_abapgit_aff_types_v1.intf.abap#L11-L23

External values for ALaV (for example in `.abapGit.xml`) are here:

https://github.com/abapGit/abapGit/blob/7ae6ac291aeb42eb94e98cb70d934a9fbc91b2aa/src/repo/zif_abapgit_dot_abapgit.intf.abap#L32-L37