### PR TITLE
Escape display name for javascript repo catalog

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -1043,7 +1043,8 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     LOOP AT lt_repo_list ASSIGNING <ls_repo>.
       lv_repo_json = |\{ key: "{ <ls_repo>-key
         }", isOffline: "{ <ls_repo>-offline
-        }", displayName: "{ <ls_repo>-local_settings-display_name }"  \}|.
+        }", displayName: "{ escape( val = <ls_repo>-local_settings-display_name
+                                    format = cl_abap_format=>e_html_js ) }"  \}|.
       IF sy-tabix < lv_size.
         lv_repo_json = lv_repo_json && ','.
       ENDIF.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -100,7 +100,9 @@ ENDCLASS.
 CLASS ltd_repo_srv IMPLEMENTATION.
 
   METHOD add_repository.
-    DATA(new_repo) = NEW ltd_repo( ).
+    DATA new_repo TYPE REF TO ltd_repo.
+
+    CREATE OBJECT new_repo.
     new_repo->set_display_name( display_name ).
 
     APPEND new_repo TO repositories.
@@ -133,6 +135,7 @@ CLASS ltcl_render_repo IMPLEMENTATION.
   METHOD setup.
     CREATE OBJECT repo_srv.
     zcl_abapgit_repo_srv=>inject_instance( ii_srv = repo_srv ).
+
     CREATE OBJECT mo_chunk_lib.
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -25,7 +25,7 @@ CLASS ltd_repo DEFINITION FINAL FOR TESTING
     DATA ms_data TYPE zif_abapgit_persistence=>ty_repo READ-ONLY.
 
     METHODS set_display_name
-      IMPORTING !display_name TYPE csequence.
+      IMPORTING !iv_display_name TYPE csequence.
 ENDCLASS.
 
 
@@ -176,7 +176,7 @@ ENDCLASS.
 CLASS ltd_repo IMPLEMENTATION.
 
   METHOD set_display_name.
-    ms_data-local_settings-display_name = display_name.
+    ms_data-local_settings-display_name = iv_display_name.
   ENDMETHOD.
 
   METHOD zif_abapgit_repo~get_name.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -55,7 +55,7 @@ CLASS ltcl_render_repo DEFINITION FINAL FOR TESTING
 
     METHODS:
       setup,
-      render_repo_palette FOR TESTING RAISING cx_static_check.
+      render_repo_palette_display_nm FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -109,8 +109,12 @@ CLASS ltd_repo_srv IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_repo_srv~list.
-    LOOP AT repositories INTO DATA(repo).
-      APPEND CAST #( repo ) TO rt_list.
+    DATA local_repo TYPE REF TO ltd_repo.
+    DATA repo TYPE REF TO zif_abapgit_repo.
+
+    LOOP AT repositories INTO local_repo.
+      repo ?= local_repo.
+      APPEND local_repo TO rt_list.
     ENDLOOP.
   ENDMETHOD.
 
@@ -134,13 +138,13 @@ CLASS ltcl_render_repo IMPLEMENTATION.
 
   METHOD setup.
     CREATE OBJECT repo_srv.
-    zcl_abapgit_repo_srv=>inject_instance( ii_srv = repo_srv ).
+    zcl_abapgit_repo_srv=>inject_instance( repo_srv ).
 
     CREATE OBJECT mo_chunk_lib.
   ENDMETHOD.
 
 
-  METHOD render_repo_palette.
+  METHOD render_repo_palette_display_nm.
     DATA ag_exception TYPE REF TO zcx_abapgit_exception.
     DATA html_chunk TYPE REF TO zif_abapgit_html.
     DATA html_string TYPE string.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -14,7 +14,55 @@ CLASS ltcl_normalize_program_name DEFINITION FINAL FOR TESTING
 
 ENDCLASS.
 
-CLASS zcl_abapgit_gui_chunk_lib DEFINITION LOCAL FRIENDS ltcl_normalize_program_name.
+
+CLASS ltd_repo DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PUBLIC SECTION.
+    INTERFACES zif_abapgit_repo PARTIALLY IMPLEMENTED.
+
+    DATA ms_data TYPE zif_abapgit_persistence=>ty_repo READ-ONLY.
+
+    METHODS set_display_name
+      IMPORTING !display_name TYPE csequence.
+ENDCLASS.
+
+
+CLASS ltd_repo_srv DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PUBLIC SECTION.
+    INTERFACES zif_abapgit_repo_srv PARTIALLY IMPLEMENTED.
+
+    METHODS add_repository
+      IMPORTING !display_name TYPE csequence.
+
+  PRIVATE SECTION.
+    DATA repositories TYPE STANDARD TABLE OF REF TO ltd_repo.
+ENDCLASS.
+
+
+CLASS ltcl_render_repo DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    DATA:
+      mo_chunk_lib TYPE REF TO zcl_abapgit_gui_chunk_lib.
+    DATA repo_srv TYPE REF TO ltd_repo_srv.
+
+    METHODS:
+      setup,
+      render_repo_palette FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+CLASS zcl_abapgit_gui_chunk_lib DEFINITION
+  LOCAL FRIENDS ltcl_normalize_program_name
+                ltcl_render_repo.
+
 
 CLASS ltcl_normalize_program_name IMPLEMENTATION.
 
@@ -44,6 +92,112 @@ CLASS ltcl_normalize_program_name IMPLEMENTATION.
       act = mo_chunk_lib->normalize_program_name( 'ZSOME_PROG_ENDING_WITH_CP' )
       exp = `ZSOME_PROG_ENDING_WITH_CP` ).
 
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltd_repo_srv IMPLEMENTATION.
+
+  METHOD add_repository.
+    DATA(new_repo) = NEW ltd_repo( ).
+    new_repo->set_display_name( display_name ).
+
+    APPEND new_repo TO repositories.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~list.
+    LOOP AT repositories INTO DATA(repo).
+      APPEND CAST #( repo ) TO rt_list.
+    ENDLOOP.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltd_repo IMPLEMENTATION.
+
+  METHOD set_display_name.
+    ms_data-local_settings-display_name = display_name.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_name.
+    rv_name = ms_data-local_settings-display_name.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltcl_render_repo IMPLEMENTATION.
+
+  METHOD setup.
+    CREATE OBJECT repo_srv.
+    zcl_abapgit_repo_srv=>inject_instance( ii_srv = repo_srv ).
+    CREATE OBJECT mo_chunk_lib.
+  ENDMETHOD.
+
+
+  METHOD render_repo_palette.
+    DATA ag_exception TYPE REF TO zcx_abapgit_exception.
+    DATA html_chunk TYPE REF TO zif_abapgit_html.
+    DATA html_string TYPE string.
+
+    repo_srv->add_repository( display_name = |Simple test| ).
+    TRY.
+        mo_chunk_lib->render_repo_palette(
+          EXPORTING
+            iv_action = zif_abapgit_definitions=>c_action-go_repo
+          RECEIVING
+            ri_html   = html_chunk ).
+        html_chunk->render(
+          RECEIVING
+            rv_html = html_string ).
+        cl_abap_unit_assert=>assert_char_cp(
+            act = html_string
+            exp = |*displayName: "Simple test"*| ).
+      CATCH zcx_abapgit_exception INTO ag_exception.
+        cl_abap_unit_assert=>fail(
+            msg    = 'abapGit exception'
+            detail = ag_exception->get_text( ) ).
+    ENDTRY.
+
+    repo_srv->add_repository( display_name = |'Single' quotation marks| ).
+    TRY.
+        mo_chunk_lib->render_repo_palette(
+          EXPORTING
+            iv_action = zif_abapgit_definitions=>c_action-go_repo
+          RECEIVING
+            ri_html   = html_chunk ).
+        html_chunk->render(
+          RECEIVING
+            rv_html = html_string ).
+        cl_abap_unit_assert=>assert_char_cp(
+            act = html_string
+            exp = |*displayName: "\\'Single\\' quotation marks"*| ).
+      CATCH zcx_abapgit_exception INTO ag_exception.
+        cl_abap_unit_assert=>fail(
+            msg    = 'abapGit exception'
+            detail = ag_exception->get_text( ) ).
+    ENDTRY.
+
+    repo_srv->add_repository( display_name = |"Double quotation marks"| ).
+    TRY.
+        mo_chunk_lib->render_repo_palette(
+          EXPORTING
+            iv_action = zif_abapgit_definitions=>c_action-go_repo
+          RECEIVING
+            ri_html   = html_chunk ).
+        html_chunk->render(
+          RECEIVING
+            rv_html = html_string ).
+        cl_abap_unit_assert=>assert_char_cp(
+            act = html_string
+            exp = |*displayName: "\\"Double quotation marks\\""*| ).
+      CATCH zcx_abapgit_exception INTO ag_exception.
+        cl_abap_unit_assert=>fail(
+            msg    = 'abapGit exception'
+            detail = ag_exception->get_text( ) ).
+    ENDTRY.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -37,7 +37,7 @@ CLASS ltd_repo_srv DEFINITION FINAL FOR TESTING
     INTERFACES zif_abapgit_repo_srv.
 
     METHODS add_repository
-      IMPORTING !display_name TYPE csequence.
+      IMPORTING !iv_display_name TYPE csequence.
 
   PRIVATE SECTION.
     DATA mt_repositories TYPE STANDARD TABLE OF REF TO ltd_repo.
@@ -103,7 +103,7 @@ CLASS ltd_repo_srv IMPLEMENTATION.
     DATA lo_new_repo TYPE REF TO ltd_repo.
 
     CREATE OBJECT lo_new_repo.
-    lo_new_repo->set_display_name( display_name ).
+    lo_new_repo->set_display_name( iv_display_name ).
 
     APPEND lo_new_repo TO mt_repositories.
   ENDMETHOD.
@@ -249,13 +249,12 @@ CLASS ltcl_render_repo IMPLEMENTATION.
     DATA lo_html TYPE REF TO zif_abapgit_html.
     DATA lv_html_as_string TYPE string.
 
-    mo_repo_srv->add_repository( display_name = |Simple test| ).
-    mo_repo_srv->add_repository( display_name = |'Single' quotation marks| ).
-    mo_repo_srv->add_repository( display_name = |"Double quotation marks"| ).
+    mo_repo_srv->add_repository( |Simple test| ).
+    mo_repo_srv->add_repository( |'Single' quotation marks| ).
+    mo_repo_srv->add_repository( |"Double quotation marks"| ).
 
     TRY.
-        lo_html = mo_chunk_lib->render_repo_palette(
-                      iv_action = zif_abapgit_definitions=>c_action-go_repo ).
+        lo_html = mo_chunk_lib->render_repo_palette( zif_abapgit_definitions=>c_action-go_repo ).
         lv_html_as_string = lo_html->render( ).
 
         cl_abap_unit_assert=>assert_char_cp(
@@ -269,6 +268,7 @@ CLASS ltcl_render_repo IMPLEMENTATION.
         cl_abap_unit_assert=>assert_char_cp(
             act = lv_html_as_string
             exp = |*displayName: "\\"Double quotation marks\\""*| ).
+
       CATCH zcx_abapgit_exception INTO lx_abapgit.
         cl_abap_unit_assert=>fail(
             msg    = 'abapGit exception'

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -20,7 +20,7 @@ CLASS ltd_repo DEFINITION FINAL FOR TESTING
   RISK LEVEL HARMLESS.
 
   PUBLIC SECTION.
-    INTERFACES zif_abapgit_repo PARTIALLY IMPLEMENTED.
+    INTERFACES zif_abapgit_repo.
 
     DATA ms_data TYPE zif_abapgit_persistence=>ty_repo READ-ONLY.
 
@@ -34,7 +34,7 @@ CLASS ltd_repo_srv DEFINITION FINAL FOR TESTING
   RISK LEVEL HARMLESS.
 
   PUBLIC SECTION.
-    INTERFACES zif_abapgit_repo_srv PARTIALLY IMPLEMENTED.
+    INTERFACES zif_abapgit_repo_srv.
 
     METHODS add_repository
       IMPORTING !display_name TYPE csequence.
@@ -118,6 +118,58 @@ CLASS ltd_repo_srv IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
+  METHOD zif_abapgit_repo_srv~delete.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~get.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~get_label_list.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~get_repo_from_package.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~get_repo_from_url.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~init.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~is_repo_installed.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~list_favorites.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~new_offline.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~new_online.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~purge.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~validate_package.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo_srv~validate_url.
+
+  ENDMETHOD.
+
 ENDCLASS.
 
 
@@ -129,6 +181,54 @@ CLASS ltd_repo IMPLEMENTATION.
 
   METHOD zif_abapgit_repo~get_name.
     rv_name = ms_data-local_settings-display_name.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~checksums.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~deserialize.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~deserialize_checks.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_dot_abapgit.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_files_local.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_files_remote.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_key.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_local_settings.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~get_package.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~is_offline.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~refresh.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_repo~set_dot_abapgit.
+
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
Escape display name for javascript repository catalog. Without this escaping a display name containing double quote characters caused Javascript syntax error, which manifested itself through the warning about Edge browser control being displayed although the Internet Explorer browser control was being used.

Solves #6481 