### PR TITLE
Fix dump in when using namespaced package for repo

### DIFF
--- a/src/objects/sap/zif_abapgit_sap_namespace.intf.abap
+++ b/src/objects/sap/zif_abapgit_sap_namespace.intf.abap
@@ -15,7 +15,7 @@ INTERFACE zif_abapgit_sap_namespace
 
   METHODS split_by_name
     IMPORTING
-      iv_obj_with_namespace   TYPE tadir-obj_name
+      iv_obj_with_namespace   TYPE csequence
       iv_allow_slash_in_name  TYPE abap_bool DEFAULT abap_true
     RETURNING
       VALUE(rs_obj_namespace) TYPE zif_abapgit_definitions=>ty_obj_namespace


### PR DESCRIPTION
Fixes dump in `zcl_abapgit_sap_namespace->split_by_name`

![image](https://github.com/abapGit/abapGit/assets/59966492/9fca522e-7b50-4aa3-9043-5a9df16a15e1)
