### PR TITLE
Do not assign T packages to a transport request

### DIFF
--- a/src/objects/sap/zcl_abapgit_sap_package.clas.abap
+++ b/src/objects/sap/zcl_abapgit_sap_package.clas.abap
@@ -48,7 +48,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
         rv_are_changes_rec_in_tr_req = li_package->wbo_korr_flag.
       WHEN 1.
         " For new packages, derive from package name
-        rv_are_changes_rec_in_tr_req = boolc( mv_package(1) <> '$' ).
+        rv_are_changes_rec_in_tr_req = boolc( mv_package(1) <> '$' AND mv_package(1) <> 'T' ).
       WHEN OTHERS.
         zcx_abapgit_exception=>raise_t100( ).
     ENDCASE.


### PR DESCRIPTION
When doing pull to a new T package, then abapgit asks for a transport request. T packages are local and they do not need to be assigned to a transport request.

This change updates the condition which decides if a new package should be assigned to a transport request or not.

Closes #6505 