### PR TITLE
Fix link hints for radio buttons with edge control

### DIFF
--- a/src/ui/lib/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.abap
@@ -656,7 +656,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
         lv_checked = ' checked'.
       ENDIF.
 
-      CLEAR lv_onclick.
+      " With edge browser control radio buttons aren't checked automatically when
+      " activated with link hints. Therefore we need to check them manually.
       IF is_field-click IS NOT INITIAL.
         lv_onclick = |onclick="|
                   && |var form = document.getElementById('{ mv_form_id }');|

--- a/src/ui/lib/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.abap
@@ -646,6 +646,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     ii_html->add( |<div class="radio-container">| ).
 
     LOOP AT is_field-subitems ASSIGNING <ls_opt>.
+
+      lv_opt_id = |{ is_field-name }{ sy-tabix }|.
       lv_opt_value = escape( val    = <ls_opt>-value
                              format = cl_abap_format=>e_html_attr ).
 
@@ -656,11 +658,15 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
 
       CLEAR lv_onclick.
       IF is_field-click IS NOT INITIAL.
-        lv_onclick = |onclick="document.getElementById('{ mv_form_id }').action = 'sapevent:|
-                  && |{ is_field-click }'; document.getElementById('{ mv_form_id }').submit()"|.
+        lv_onclick = |onclick="|
+                  && |var form = document.getElementById('{ mv_form_id }');|
+                  && |document.getElementById('{ lv_opt_id }').checked = true;|
+                  && |form.action = 'sapevent:{ is_field-click }';|
+                  && |form.submit();"|.
+      ELSE.
+        lv_onclick = |onclick="document.getElementById('{ lv_opt_id }').checked = true;"|.
       ENDIF.
 
-      lv_opt_id = |{ is_field-name }{ sy-tabix }|.
       IF is_field-condense = abap_true.
         ii_html->add( '<div>' ).
       ENDIF.


### PR DESCRIPTION
Link hints for radio buttons were not working with edge browser control. This changes fixes that.

![abapgit](https://github.com/abapGit/abapGit/assets/17437789/6f9fc89b-3c32-47ef-ab9b-6b3db856b2ff)
