### PR TITLE
`zcl_abapgit_html_action_utils` refactoring for ABAP Cloud

### DIFF
--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -672,7 +672,7 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
   METHOD zif_abapgit_repo_srv~validate_package.
 
-    DATA: lv_as4user TYPE tdevc-as4user,
+    DATA: lv_as4user TYPE usnam,
           li_repo    TYPE REF TO zif_abapgit_repo,
           lv_reason  TYPE string.
 

--- a/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
@@ -52,7 +52,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
+CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
 
 
   METHOD add_field.
@@ -105,7 +105,21 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
   METHOD fields_to_string.
 
-    rv_string = cl_http_utility=>fields_to_string( it_fields ).
+* There is no equivalent to cl_http_utility=>fields_to_string released in ABAP Cloud,
+* see cl_web_http_utility
+
+    DATA lt_tab   TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+    DATA lv_str   TYPE string.
+    DATA ls_field LIKE LINE OF it_fields.
+
+    LOOP AT it_fields INTO ls_field.
+      ls_field-value = cl_http_utility=>escape_url( ls_field-value ).
+      lv_str = ls_field-name && '=' && ls_field-value.
+      APPEND lv_str TO lt_tab.
+    ENDLOOP.
+    rv_string = concat_lines_of(
+      table = lt_tab
+      sep   = '&' ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
@@ -45,14 +45,14 @@ CLASS zcl_abapgit_html_action_utils DEFINITION
 
     CLASS-METHODS fields_to_string
       IMPORTING
-        !it_fields TYPE tihttpnvp
+        !it_fields       TYPE tihttpnvp
       RETURNING
         VALUE(rv_string) TYPE string.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
 
   METHOD add_field.
@@ -78,11 +78,6 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD fields_to_string.
-
-    rv_string = cl_http_utility=>fields_to_string( it_fields ).
-
-  ENDMETHOD.
 
   METHOD dbkey_encode.
 
@@ -104,6 +99,13 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
     add_field( EXPORTING iv_name = 'PATH'
                          ig_field = iv_path CHANGING ct_field = lt_fields ).
     rv_string = fields_to_string( lt_fields ).
+
+  ENDMETHOD.
+
+
+  METHOD fields_to_string.
+
+    rv_string = cl_http_utility=>fields_to_string( it_fields ).
 
   ENDMETHOD.
 
@@ -160,5 +162,4 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
     rv_string = fields_to_string( lt_fields ).
 
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
@@ -42,6 +42,12 @@ CLASS zcl_abapgit_html_action_utils DEFINITION
         !ig_field TYPE any
       CHANGING
         !ct_field TYPE tihttpnvp .
+
+    CLASS-METHODS fields_to_string
+      IMPORTING
+        !it_fields TYPE tihttpnvp
+      RETURNING
+        VALUE(rv_string) TYPE string.
 ENDCLASS.
 
 
@@ -72,34 +78,39 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD fields_to_string.
+
+    rv_string = cl_http_utility=>fields_to_string( it_fields ).
+
+  ENDMETHOD.
 
   METHOD dbkey_encode.
 
-    DATA: lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
 
     add_field( EXPORTING iv_name = 'TYPE'
                          ig_field = is_key-type CHANGING ct_field = lt_fields ).
     add_field( EXPORTING iv_name = 'VALUE'
                          ig_field = is_key-value CHANGING ct_field = lt_fields ).
 
-    rv_string = cl_http_utility=>fields_to_string( lt_fields ).
+    rv_string = fields_to_string( lt_fields ).
 
   ENDMETHOD.
 
 
   METHOD dir_encode.
 
-    DATA: lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
     add_field( EXPORTING iv_name = 'PATH'
                          ig_field = iv_path CHANGING ct_field = lt_fields ).
-    rv_string = cl_http_utility=>fields_to_string( lt_fields ).
+    rv_string = fields_to_string( lt_fields ).
 
   ENDMETHOD.
 
 
   METHOD file_encode.
 
-    DATA: lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
 
 
     add_field( EXPORTING iv_name = 'KEY'
@@ -109,14 +120,14 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
     add_field( EXPORTING iv_name = 'FILENAME'
                          ig_field = ig_file CHANGING ct_field = lt_fields ).
 
-    rv_string = cl_http_utility=>fields_to_string( lt_fields ).
+    rv_string = fields_to_string( lt_fields ).
 
   ENDMETHOD.
 
 
   METHOD jump_encode.
 
-    DATA: lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
 
 
     add_field( EXPORTING iv_name = 'TYPE'
@@ -129,14 +140,14 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
                            ig_field = iv_filename CHANGING ct_field = lt_fields ).
     ENDIF.
 
-    rv_string = cl_http_utility=>fields_to_string( lt_fields ).
+    rv_string = fields_to_string( lt_fields ).
 
   ENDMETHOD.
 
 
   METHOD obj_encode.
 
-    DATA: lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
 
 
     add_field( EXPORTING iv_name = 'KEY'
@@ -146,7 +157,7 @@ CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
     add_field( EXPORTING iv_name = 'OBJ_NAME'
                          ig_field = ig_object CHANGING ct_field = lt_fields ).
 
-    rv_string = cl_http_utility=>fields_to_string( lt_fields ).
+    rv_string = fields_to_string( lt_fields ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_html_action_utils.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_action_utils.clas.testclasses.abap
@@ -1,0 +1,22 @@
+CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
+
+  PRIVATE SECTION.
+    METHODS dir_encode FOR TESTING.
+ENDCLASS.
+
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD dir_encode.
+
+    DATA lv_encoded TYPE string.
+
+    lv_encoded = zcl_abapgit_html_action_utils=>dir_encode( '/hello.,()[]' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_encoded
+      exp = 'PATH=%2fhello.%2c()%5b%5d' ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_html_action_utils.clas.xml
+++ b/src/ui/lib/zcl_abapgit_html_action_utils.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
* redirect calls to `cl_http_utility=>fields_to_string` to new private method
* add basic unit test
* rewrite `fields_to_string` so it uses semi-released methods(replace cl_http_utility=>escape_url with cl_web_http_utility=>escape_url)
* plus get rid of type `tdevc-as4user`