### PR TITLE
SFxx: Fix missing lock checks and unlocking

### DIFF
--- a/src/objects/zcl_abapgit_object_sfbf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfbf.clas.abap
@@ -16,6 +16,7 @@ CLASS zcl_abapgit_object_sfbf DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     DATA mv_bf TYPE sfw_bfunction.
 
     METHODS:
+      unlock,
       activate
         RAISING zcx_abapgit_exception,
       create
@@ -93,6 +94,19 @@ CLASS zcl_abapgit_object_sfbf IMPLEMENTATION.
       CATCH cx_pak_invalid_data cx_pak_invalid_state cx_pak_not_authorized.
         zcx_abapgit_exception=>raise( 'Error from CL_SFW_BF=>GET_BF' ).
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD unlock.
+
+    CALL FUNCTION 'DEQUEUE_EEUDB'
+      EXPORTING
+        relid     = 'SF'
+        name      = ms_item-obj_name
+        _synchron = 'X'
+        _scope    = '1'
+        mode_eudb = abap_true.
 
   ENDMETHOD.
 
@@ -204,6 +218,8 @@ CLASS zcl_abapgit_object_sfbf IMPLEMENTATION.
 
     lo_bf->save_all( ).
 
+    unlock( ).
+
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_sfbf ).
 
@@ -261,9 +277,9 @@ CLASS zcl_abapgit_object_sfbf IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~is_locked.
-
-    rv_is_locked = abap_false.
-
+    rv_is_locked = exists_a_lock_entry_for( iv_lock_object = 'EEUDB'
+                                            iv_argument    = ms_item-obj_name
+                                            iv_prefix      = 'SF' ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfbs.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfbs.clas.abap
@@ -16,6 +16,7 @@ CLASS zcl_abapgit_object_sfbs DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     DATA mv_bfset TYPE sfw_bset.
 
     METHODS:
+      unlock,
       activate
         RAISING zcx_abapgit_exception,
       create
@@ -93,6 +94,19 @@ CLASS zcl_abapgit_object_sfbs IMPLEMENTATION.
       CATCH cx_pak_invalid_data cx_pak_invalid_state cx_pak_not_authorized.
         zcx_abapgit_exception=>raise( 'Error from CL_SFW_BFS=>GET_BFS' ).
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD unlock.
+
+    CALL FUNCTION 'DEQUEUE_EEUDB'
+      EXPORTING
+        relid     = 'SS'
+        name      = ms_item-obj_name
+        _synchron = 'X'
+        _scope    = '1'
+        mode_eudb = abap_true.
 
   ENDMETHOD.
 
@@ -187,6 +201,8 @@ CLASS zcl_abapgit_object_sfbs IMPLEMENTATION.
 
     lo_bfs->save_all( ).
 
+    unlock( ).
+
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_sfbs ).
 
@@ -243,7 +259,9 @@ CLASS zcl_abapgit_object_sfbs IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~is_locked.
-    rv_is_locked = abap_false.
+    rv_is_locked = exists_a_lock_entry_for( iv_lock_object = 'EEUDB'
+                                            iv_argument    = ms_item-obj_name
+                                            iv_prefix      = 'SS' ).
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sfsw.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfsw.clas.abap
@@ -16,6 +16,7 @@ CLASS zcl_abapgit_object_sfsw DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     DATA mv_switch TYPE sfw_switch_id.
 
     METHODS:
+      unlock,
       activate
         RAISING zcx_abapgit_exception,
       create
@@ -93,6 +94,19 @@ CLASS zcl_abapgit_object_sfsw IMPLEMENTATION.
       CATCH cx_pak_invalid_data cx_pak_invalid_state cx_pak_not_authorized.
         zcx_abapgit_exception=>raise( 'Error from CL_SFW_SW=>GET_SWITCH' ).
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD unlock.
+
+    CALL FUNCTION 'DEQUEUE_EEUDB'
+      EXPORTING
+        relid     = 'SW'
+        name      = ms_item-obj_name
+        _synchron = 'X'
+        _scope    = '1'
+        mode_eudb = abap_true.
 
   ENDMETHOD.
 
@@ -190,6 +204,8 @@ CLASS zcl_abapgit_object_sfsw IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error in CL_SFW_SW->SAVE_ALL' ).
     ENDIF.
 
+    unlock( ).
+
     deserialize_longtexts( ii_xml         = io_xml
                            iv_longtext_id = c_longtext_id_sfsw ).
 
@@ -246,7 +262,9 @@ CLASS zcl_abapgit_object_sfsw IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~is_locked.
-    rv_is_locked = abap_false.
+    rv_is_locked = exists_a_lock_entry_for( iv_lock_object = 'EEUDB'
+                                            iv_argument    = ms_item-obj_name
+                                            iv_prefix      = 'SW' ).
   ENDMETHOD.
 
 


### PR DESCRIPTION
After #6517

Objects of the switch framework didn't check for existing locks and were not unlocked after deserializing.

