### PR TITLE
refactor XML pretty method

### DIFF
--- a/src/utils/zcl_abapgit_convert.clas.abap
+++ b/src/utils/zcl_abapgit_convert.clas.abap
@@ -36,6 +36,13 @@ CLASS zcl_abapgit_convert DEFINITION
         VALUE(rv_xstring) TYPE xstring
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS xstring_to_string_utf8_bom
+      IMPORTING
+        !iv_xstring      TYPE xstring
+      RETURNING
+        VALUE(rv_string) TYPE string
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS xstring_to_int
       IMPORTING
         !iv_xstring TYPE xstring
@@ -93,7 +100,7 @@ CLASS zcl_abapgit_convert DEFINITION
 
     CLASS-METHODS language_sap2_to_sap1
       IMPORTING
-        im_lang_sap2 TYPE laiso
+        im_lang_sap2        TYPE laiso
       RETURNING
         VALUE(re_lang_sap1) TYPE sy-langu
       EXCEPTIONS
@@ -159,7 +166,7 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
         re_lang_sap2  = rv_spras
       EXCEPTIONS
         no_assignment = 1
-        OTHERS        = 2 ). "#EC CI_SUBRC
+        OTHERS        = 2 ).                              "#EC CI_SUBRC
 
     TRANSLATE rv_spras TO UPPER CASE.
 
@@ -369,6 +376,25 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
     rv_string = lcl_in=>convert(
       iv_data   = lv_data
       iv_length = lv_length ).
+
+  ENDMETHOD.
+
+
+  METHOD xstring_to_string_utf8_bom.
+
+    DATA lv_xstring TYPE xstring.
+
+    IF iv_xstring IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    lv_xstring = iv_xstring.
+    " Add UTF-8 BOM
+    IF xstrlen( lv_xstring ) < 3 OR lv_xstring(3) <> cl_abap_char_utilities=>byte_order_mark_utf8.
+      lv_xstring = cl_abap_char_utilities=>byte_order_mark_utf8 && lv_xstring.
+    ENDIF.
+
+    rv_string = xstring_to_string_utf8( lv_xstring ).
 
   ENDMETHOD.
 

--- a/src/xml/zcl_abapgit_xml_pretty.clas.abap
+++ b/src/xml/zcl_abapgit_xml_pretty.clas.abap
@@ -29,6 +29,8 @@ CLASS ZCL_ABAPGIT_XML_PRETTY IMPLEMENTATION.
           li_stream_factory TYPE REF TO if_ixml_stream_factory,
           li_istream        TYPE REF TO if_ixml_istream,
           li_parser         TYPE REF TO if_ixml_parser,
+          lv_xstring        TYPE xstring,
+          li_encoding       TYPE REF TO if_ixml_encoding,
           li_ostream        TYPE REF TO if_ixml_ostream,
           li_renderer       TYPE REF TO if_ixml_renderer.
 
@@ -39,7 +41,8 @@ CLASS ZCL_ABAPGIT_XML_PRETTY IMPLEMENTATION.
     li_xml_doc = li_ixml->create_document( ).
 
     li_stream_factory = li_ixml->create_stream_factory( ).
-    li_istream        = li_stream_factory->create_istream_string( iv_xml ).
+    li_istream        = li_stream_factory->create_istream_xstring(
+      zcl_abapgit_convert=>string_to_xstring_utf8( iv_xml ) ).
     li_parser         = li_ixml->create_parser( stream_factory = li_stream_factory
                                                 istream        = li_istream
                                                 document       = li_xml_doc ).
@@ -55,14 +58,22 @@ CLASS ZCL_ABAPGIT_XML_PRETTY IMPLEMENTATION.
     li_istream->close( ).
 
 
-    li_ostream  = li_stream_factory->create_ostream_cstring( rv_xml ).
+    li_ostream  = li_stream_factory->create_ostream_xstring( lv_xstring ).
 
+    li_encoding = li_ixml->create_encoding(
+      character_set = 'utf-8'
+      byte_order    = if_ixml_encoding=>co_big_endian ).
+
+    li_xml_doc->set_encoding( li_encoding ).
     li_renderer = li_ixml->create_renderer( ostream  = li_ostream
                                             document = li_xml_doc ).
 
     li_renderer->set_normalizing( boolc( iv_unpretty = abap_false ) ).
 
     li_renderer->render( ).
+
+    rv_xml = zcl_abapgit_convert=>xstring_to_string_utf8_bom( lv_xstring ).
+    REPLACE FIRST OCCURRENCE OF 'utf-8' IN rv_xml WITH 'utf-16'.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
ABAP Cloud only has stream methods with xml, https://abapedia.org/steampunk-2305-api/if_ixml_stream_factory_core.intf.html, this PR replaces the on-prem code to use the xstring method calls

note: this might be a bit dangerous, this method is used in a lot of places?