### PR TITLE
CMPT: Fix missing transport entry on deletion

### DIFF
--- a/src/objects/zcl_abapgit_object_cmpt.clas.abap
+++ b/src/objects/zcl_abapgit_object_cmpt.clas.abap
@@ -84,6 +84,8 @@ CLASS zcl_abapgit_object_cmpt IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |Error deleting CMPT { ms_item-obj_name }| ).
     ENDIF.
 
+    corr_insert( iv_package ).
+
     tadir_delete( ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_cmpt.clas.abap
+++ b/src/objects/zcl_abapgit_object_cmpt.clas.abap
@@ -86,8 +86,6 @@ CLASS zcl_abapgit_object_cmpt IMPLEMENTATION.
 
     corr_insert( iv_package ).
 
-    tadir_delete( ).
-
   ENDMETHOD.
 
 


### PR DESCRIPTION
Object needs to be added to transport when deleted

https://github.com/abapGit-tests/CMPT

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/a017d5db-6a0d-4b32-9adb-e24e06adf9a4)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/ee33395a-e914-4254-9ff3-99ef68f8c2a5)
