### PR TITLE
CUS2: Add missing tadir and transport entries

### DIFF
--- a/src/objects/zcl_abapgit_object_cus2.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus2.clas.abap
@@ -32,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CUS2 IMPLEMENTATION.
+CLASS zcl_abapgit_object_cus2 IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -91,6 +91,8 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS2 IMPLEMENTATION.
     IF ls_message-msgty <> 'S'.
       zcx_abapgit_exception=>raise( |error from deserialize CUS2 { mv_img_attribute } S_CUS_ATTRIBUTES_SAVE| ).
     ENDIF.
+
+    corr_insert( iv_package ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_cus2.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus2.clas.abap
@@ -94,6 +94,8 @@ CLASS zcl_abapgit_object_cus2 IMPLEMENTATION.
 
     corr_insert( iv_package ).
 
+    tadir_insert( iv_package ).
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Object was not added to `tadir` and transports