### PR TITLE
Refactor: Naming of class constants

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -268,8 +268,9 @@
       "ignoreInterfaces": false,
       "statics": "^G._.*$",
       "ignoreLocal": false,
-      "constants": "",
-      "instance": "^M._.*$"
+      "constants": "^C_.*$",
+      "instance": "^M._.*$",
+      "exclude": ["zif_abapgit_objects"]
     },
     "cloud_types": true,
     "colon_missing_space": true,

--- a/abaplint.json
+++ b/abaplint.json
@@ -270,7 +270,7 @@
       "ignoreLocal": false,
       "constants": "^C_.*$",
       "instance": "^M._.*$",
-      "exclude": ["zif_abapgit_objects"]
+      "exclude": ["zif_abapgit_objects", "/json/"]
     },
     "cloud_types": true,
     "colon_missing_space": true,

--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -25,12 +25,36 @@ CLASS zcl_abapgit_background DEFINITION
     CLASS-METHODS dequeue.
   PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS gc_enq_type TYPE c LENGTH 12 VALUE 'BACKGROUND'.
+    CONSTANTS c_enq_type TYPE c LENGTH 12 VALUE 'BACKGROUND'.
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_background IMPLEMENTATION.
+
+
+  METHOD dequeue.
+    CALL FUNCTION 'DEQUEUE_EZABAPGIT'
+      EXPORTING
+        type = c_enq_type.
+  ENDMETHOD.
+
+
+  METHOD enqueue.
+    CALL FUNCTION 'ENQUEUE_EZABAPGIT'
+      EXPORTING
+        mode_zabapgit  = 'E'
+        type           = c_enq_type
+        _scope         = '3'
+      EXCEPTIONS
+        foreign_lock   = 1
+        system_failure = 2
+        OTHERS         = 3.
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+  ENDMETHOD.
 
 
   METHOD list_methods.
@@ -136,27 +160,4 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
     dequeue( ).
 
   ENDMETHOD.
-
-  METHOD enqueue.
-    CALL FUNCTION 'ENQUEUE_EZABAPGIT'
-      EXPORTING
-        mode_zabapgit  = 'E'
-        type           = gc_enq_type
-        _scope         = '3'
-      EXCEPTIONS
-        foreign_lock   = 1
-        system_failure = 2
-        OTHERS         = 3.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-  ENDMETHOD.
-
-  METHOD dequeue.
-    CALL FUNCTION 'DEQUEUE_EZABAPGIT'
-      EXPORTING
-        type = gc_enq_type.
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/aff/zcl_abapgit_object_evtb.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_evtb.clas.abap
@@ -10,26 +10,28 @@ CLASS zcl_abapgit_object_evtb DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
     CONSTANTS:
-    co_table_name TYPE tabname VALUE 'EVTB_HEADER'.
+      c_table_name TYPE tabname VALUE 'EVTB_HEADER'.
 ENDCLASS.
+
 
 
 CLASS zcl_abapgit_object_evtb IMPLEMENTATION.
 
+
   METHOD zif_abapgit_object~changed_by.
 
-    DATA: lv_user                TYPE string,
-          lx_error               TYPE REF TO cx_root.
+    DATA: lv_user  TYPE string,
+          lx_error TYPE REF TO cx_root.
 
     TRY.
 
         SELECT SINGLE changed_by INTO lv_user
-            FROM (co_table_name)
+            FROM (c_table_name)
             WHERE evtb_name = ms_item-obj_name AND version = 'I'.
 
         IF lv_user IS INITIAL.
           SELECT SINGLE changed_by INTO lv_user
-            FROM (co_table_name)
+            FROM (c_table_name)
             WHERE evtb_name = ms_item-obj_name AND version = 'A'.
         ENDIF.
 
@@ -40,6 +42,4 @@ CLASS zcl_abapgit_object_evtb IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
-
 ENDCLASS.
-

--- a/src/objects/aff/zcl_abapgit_object_nont.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_nont.clas.abap
@@ -6,13 +6,16 @@ CLASS zcl_abapgit_object_nont DEFINITION
   PUBLIC SECTION.
     METHODS zif_abapgit_object~changed_by REDEFINITION.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS co_table_name TYPE tabname VALUE 'NONT_HEADER'.
+    CONSTANTS c_table_name TYPE tabname VALUE 'NONT_HEADER'.
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_object_nont IMPLEMENTATION.
+
+
   METHOD zif_abapgit_object~changed_by.
     DATA: lv_user  TYPE string,
           lx_error TYPE REF TO cx_root.
@@ -20,12 +23,12 @@ CLASS zcl_abapgit_object_nont IMPLEMENTATION.
     TRY.
 
         SELECT SINGLE changed_by INTO lv_user
-            FROM (co_table_name)
+            FROM (c_table_name)
             WHERE nont_name = ms_item-obj_name AND version = 'I'.
 
         IF lv_user IS INITIAL.
           SELECT SINGLE changed_by INTO lv_user
-            FROM (co_table_name)
+            FROM (c_table_name)
             WHERE nont_name = ms_item-obj_name AND version = 'A'.
         ENDIF.
 

--- a/src/objects/aff/zcl_abapgit_object_ront.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_ront.clas.abap
@@ -6,13 +6,16 @@ CLASS zcl_abapgit_object_ront DEFINITION
   PUBLIC SECTION.
     METHODS zif_abapgit_object~changed_by REDEFINITION.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS co_table_name TYPE tabname VALUE 'RONT_HEADER'.
+    CONSTANTS c_table_name TYPE tabname VALUE 'RONT_HEADER'.
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_object_ront IMPLEMENTATION.
+
+
   METHOD zif_abapgit_object~changed_by.
     DATA: lv_user  TYPE string,
           lx_error TYPE REF TO cx_root.
@@ -20,12 +23,12 @@ CLASS zcl_abapgit_object_ront IMPLEMENTATION.
     TRY.
 
         SELECT SINGLE changed_by INTO lv_user
-            FROM (co_table_name)
+            FROM (c_table_name)
             WHERE ront_name = ms_item-obj_name AND version = 'I'.
 
         IF lv_user IS INITIAL.
           SELECT SINGLE changed_by INTO lv_user
-            FROM (co_table_name)
+            FROM (c_table_name)
             WHERE ront_name = ms_item-obj_name AND version = 'A'.
         ENDIF.
 

--- a/src/objects/ecatt/zcl_abapgit_ecatt_helper.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_helper.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_ecatt_helper DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
     CONSTANTS:
-      co_xml TYPE i VALUE 1. " downport of if_apl_ecatt_xml=>co_xml
+      c_xml TYPE i VALUE 1. " downport of if_apl_ecatt_xml=>co_xml
 
 ENDCLASS.
 
@@ -85,7 +85,7 @@ CLASS zcl_abapgit_ecatt_helper IMPLEMENTATION.
     TRY.
         CALL METHOD cl_apl_ecatt_xml=>('CREATE') " doesn't exist in 702
           EXPORTING
-            im_type = co_xml
+            im_type = c_xml
           RECEIVING
             re_xml  = lo_xml.
 
@@ -114,7 +114,7 @@ CLASS zcl_abapgit_ecatt_helper IMPLEMENTATION.
 
     CALL METHOD cl_apl_ecatt_xml=>('CREATE') " doesn't exist in 702
       EXPORTING
-        im_type = co_xml
+        im_type = c_xml
       RECEIVING
         re_xml  = lo_xml.
 

--- a/src/objects/zcl_abapgit_object_apis.clas.abap
+++ b/src/objects/zcl_abapgit_object_apis.clas.abap
@@ -18,14 +18,14 @@ CLASS zcl_abapgit_object_apis DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS gc_model TYPE string VALUE 'ARS_S_API_ABAPGIT'.
+    CONSTANTS c_model TYPE string VALUE 'ARS_S_API_ABAPGIT'.
     DATA mo_handler TYPE REF TO object.
     METHODS initialize.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_APIS IMPLEMENTATION.
+CLASS zcl_abapgit_object_apis IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -36,7 +36,7 @@ CLASS ZCL_ABAPGIT_OBJECT_APIS IMPLEMENTATION.
                         iv_language = iv_language ).
 
     TRY.
-        CREATE DATA lr_data TYPE (gc_model).
+        CREATE DATA lr_data TYPE (c_model).
       CATCH cx_sy_create_error.
         zcx_abapgit_exception=>raise( |APIS not supported by your NW release| ).
     ENDTRY.
@@ -110,7 +110,7 @@ CLASS ZCL_ABAPGIT_OBJECT_APIS IMPLEMENTATION.
     FIELD-SYMBOLS <lv_simple> TYPE simple.
 
 
-    CREATE DATA lr_data TYPE (gc_model).
+    CREATE DATA lr_data TYPE (c_model).
     ASSIGN lr_data->* TO <ls_data>.
     CREATE DATA lr_data TYPE ('IF_ARS_STATE_DB_ACCESS=>TY_S_HEADER').
     ASSIGN lr_data->* TO <ls_header>.
@@ -237,7 +237,7 @@ CLASS ZCL_ABAPGIT_OBJECT_APIS IMPLEMENTATION.
     DATA lr_data TYPE REF TO data.
     FIELD-SYMBOLS <ls_data> TYPE any.
 
-    CREATE DATA lr_data TYPE (gc_model).
+    CREATE DATA lr_data TYPE (c_model).
     ASSIGN lr_data->* TO <ls_data>.
 
     initialize( ).

--- a/src/objects/zcl_abapgit_object_ecatt_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_ecatt_super.clas.abap
@@ -39,11 +39,11 @@ CLASS zcl_abapgit_object_ecatt_super DEFINITION
       END OF ty_last_changed.
 
     CONSTANTS:
-      BEGIN OF co_name,
+      BEGIN OF c_name,
         version  TYPE string VALUE 'VERSION' ##NO_TEXT,
         versions TYPE string VALUE 'VERSIONS' ##NO_TEXT,
-      END OF co_name,
-      co_default_version TYPE etobj_ver VALUE '1' ##NO_TEXT.
+      END OF c_name,
+      c_default_version TYPE etobj_ver VALUE '1' ##NO_TEXT.
 
     CLASS-METHODS:
       is_change_more_recent_than
@@ -392,7 +392,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
 
     clear_elements( CHANGING ci_document = li_document ).
 
-    li_node = li_document->create_element( co_name-version ).
+    li_node = li_document->create_element( c_name-version ).
     li_node->append_child( li_document->get_root_element( ) ).
 
     ci_node->append_child( li_node ).
@@ -405,7 +405,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
     DATA: li_versions_node TYPE REF TO if_ixml_element.
     FIELD-SYMBOLS: <ls_version_info> LIKE LINE OF it_version_info.
 
-    li_versions_node = ci_document->create_element( co_name-versions ).
+    li_versions_node = ci_document->create_element( c_name-versions ).
 
     IF lines( it_version_info ) > 0.
 
@@ -423,7 +423,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
 
       serialize_version(
         EXPORTING
-          iv_version = co_default_version
+          iv_version = c_default_version
         CHANGING
           ci_node    = li_versions_node ).
 
@@ -493,7 +493,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
                                             im_name                = mv_object_name
                                             " we have to supply a version, so let's use the default version
                                             " and delete them all
-                                            im_version             = co_default_version
+                                            im_version             = c_default_version
                                             im_delete_all_versions = abap_true ).
 
       CATCH cx_ecatt_apl INTO lx_error.
@@ -514,7 +514,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
     li_document = io_xml->get_raw( ).
 
     li_versions = li_document->get_elements_by_tag_name( depth = 0
-                                                         name  = co_name-version ).
+                                                         name  = c_name-version ).
 
     li_version_iterator = li_versions->create_iterator( ).
 
@@ -541,7 +541,7 @@ CLASS zcl_abapgit_object_ecatt_super IMPLEMENTATION.
 
     TRY.
         rv_bool = cl_apl_ecatt_object=>existence_check_object( im_name               = mv_object_name
-                                                               im_version            = co_default_version
+                                                               im_version            = c_default_version
                                                                im_obj_type           = lv_object_type
                                                                im_exists_any_version = abap_true ).
 

--- a/src/objects/zcl_abapgit_object_srvd.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvd.clas.abap
@@ -198,7 +198,7 @@ CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
     ENDIF.
 
     CREATE OBJECT ro_object_data TYPE ('CL_SRVD_WB_OBJECT_DATA').
-    ro_object_data->set_data( p_data = <lg_data>  ).
+    ro_object_data->set_data( p_data = <lg_data> ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_srvd.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvd.clas.abap
@@ -16,8 +16,8 @@ CLASS zcl_abapgit_object_srvd DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
     DATA mv_service_definition_key TYPE seu_objkey .
     DATA mr_service_definition TYPE REF TO data .
-    CONSTANTS mc_source_file TYPE string VALUE 'srvdsrv' ##NO_TEXT.
-    CONSTANTS mc_xml_parent_name TYPE string VALUE 'SRVD' ##NO_TEXT.
+    CONSTANTS c_source_file TYPE string VALUE 'srvdsrv' ##NO_TEXT.
+    CONSTANTS c_xml_parent_name TYPE string VALUE 'SRVD' ##NO_TEXT.
     DATA mo_object_operator TYPE REF TO object .
 
     METHODS clear_fields
@@ -183,7 +183,7 @@ CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
 
     io_xml->read(
       EXPORTING
-        iv_name = mc_xml_parent_name
+        iv_name = c_xml_parent_name
       CHANGING
         cg_data = <ls_metadata> ).
 
@@ -192,7 +192,7 @@ CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
     ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <lg_data> TO <lv_source>.
     ASSERT sy-subrc = 0.
 
-    <lv_source> = zif_abapgit_object~mo_files->read_string( mc_source_file ).
+    <lv_source> = zif_abapgit_object~mo_files->read_string( c_source_file ).
     IF <lv_source> IS INITIAL.
       <lv_source> = zif_abapgit_object~mo_files->read_string( 'assrvd' ).
     ENDIF.
@@ -557,11 +557,11 @@ CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
         lv_source = <lv_source>.
 
         io_xml->add(
-          iv_name = mc_xml_parent_name
+          iv_name = c_xml_parent_name
           ig_data = <lv_metadata> ).
 
         zif_abapgit_object~mo_files->add_string(
-          iv_ext    = mc_source_file
+          iv_ext    = c_source_file
           iv_string = lv_source ).
 
       CATCH cx_root INTO lx_error.

--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -9,7 +9,7 @@ CLASS zcl_abapgit_object_ssfo DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
       ty_string_range TYPE RANGE OF string .
 
     CLASS-DATA gt_range_node_codes TYPE ty_string_range .
-    CONSTANTS attrib_abapgit_leadig_spaces TYPE string VALUE 'abapgit-leadig-spaces' ##NO_TEXT.
+    CONSTANTS c_attrib_abapgit_leadig_spaces TYPE string VALUE 'abapgit-leadig-spaces' ##NO_TEXT.
 
     METHODS fix_ids
       IMPORTING
@@ -175,7 +175,7 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
                                     CHANGING  cv_within_code_section = cv_within_code_section ).
 
 * for downwards compatibility, this code can be removed sometime in the future
-        lv_leading_spaces = li_element->get_attribute_ns( name = attrib_abapgit_leadig_spaces ).
+        lv_leading_spaces = li_element->get_attribute_ns( name = c_attrib_abapgit_leadig_spaces ).
 
         lv_coding_line = li_element->get_value( ).
         IF strlen( lv_coding_line ) >= 1 AND lv_coding_line(1) <> | |.

--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -175,7 +175,7 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
                                     CHANGING  cv_within_code_section = cv_within_code_section ).
 
 * for downwards compatibility, this code can be removed sometime in the future
-        lv_leading_spaces = li_element->get_attribute_ns( name = c_attrib_abapgit_leadig_spaces ).
+        lv_leading_spaces = li_element->get_attribute_ns( c_attrib_abapgit_leadig_spaces ).
 
         lv_coding_line = li_element->get_value( ).
         IF strlen( lv_coding_line ) >= 1 AND lv_coding_line(1) <> | |.

--- a/src/objects/zcl_abapgit_object_susc.clas.abap
+++ b/src/objects/zcl_abapgit_object_susc.clas.abap
@@ -4,7 +4,7 @@ CLASS zcl_abapgit_object_susc DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     INTERFACES zif_abapgit_object.
   PROTECTED SECTION.
 
-    CONSTANTS transobjecttype_class TYPE c LENGTH 1 VALUE 'C' ##NO_TEXT.
+    CONSTANTS c_transobjecttype_class TYPE c LENGTH 1 VALUE 'C' ##NO_TEXT.
 
     METHODS has_authorization
       IMPORTING
@@ -88,7 +88,7 @@ CLASS zcl_abapgit_object_susc IMPLEMENTATION.
     CALL FUNCTION 'SUSR_COMMEDITCHECK'
       EXPORTING
         objectname       = lv_tr_object_name
-        transobjecttype  = transobjecttype_class
+        transobjecttype  = c_transobjecttype_class
       IMPORTING
         return_from_korr = lv_tr_return.
 
@@ -173,7 +173,7 @@ CLASS zcl_abapgit_object_susc IMPLEMENTATION.
     CALL FUNCTION 'SUSR_COMMEDITCHECK'
       EXPORTING
         objectname      = lv_objectname
-        transobjecttype = transobjecttype_class.
+        transobjecttype = c_transobjecttype_class.
 
     INSERT tobc FROM ls_tobc.                             "#EC CI_SUBRC
 * ignore sy-subrc as all fields are key fields

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -247,8 +247,7 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
 
   METHOD go_home.
 
-    DATA: ls_stack LIKE LINE OF mt_stack,
-          lv_mode  TYPE tabname.
+    DATA ls_stack LIKE LINE OF mt_stack.
 
     IF mi_router IS BOUND.
       CLEAR: mt_stack, mt_event_handlers.
@@ -413,7 +412,7 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
     ENDIF.
 
     li_html = mi_cur_page->render( ).
-    lv_html = li_html->render( iv_no_indent_jscss = abap_true ).
+    lv_html = li_html->render( abap_true ).
 
     IF mi_html_processor IS BOUND.
       lv_html = mi_html_processor->process(

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -115,7 +115,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
+CLASS zcl_abapgit_gui IMPLEMENTATION.
 
 
   METHOD back.
@@ -325,7 +325,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         ENDCASE.
 
       CATCH zcx_abapgit_cancel ##NO_HANDLER.
-        " Do nothing = gc_event_state-no_more_act
+        " Do nothing = c_event_state-no_more_act
       CATCH zcx_abapgit_exception INTO lx_exception.
         handle_error( lx_exception ).
     ENDTRY.
@@ -454,7 +454,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
       ENDLOOP.
     ENDIF.
 
-    ls_event-eventid    = mi_html_viewer->m_id_sapevent.
+    ls_event-eventid    = mi_html_viewer->c_id_sapevent.
     ls_event-appl_event = abap_true.
     APPEND ls_event TO lt_events.
 

--- a/src/ui/core/zcl_abapgit_html_viewer_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_html_viewer_gui.clas.abap
@@ -42,7 +42,7 @@ CLASS zcl_abapgit_html_viewer_gui IMPLEMENTATION.
         query_table_disabled = iv_disable_query_table
         parent               = io_container.
 
-    ls_event-eventid    = zif_abapgit_html_viewer=>m_id_sapevent.
+    ls_event-eventid    = zif_abapgit_html_viewer=>c_id_sapevent.
     ls_event-appl_event = abap_true.
     APPEND ls_event TO lt_events.
 

--- a/src/ui/core/zif_abapgit_html_viewer.intf.abap
+++ b/src/ui/core/zif_abapgit_html_viewer.intf.abap
@@ -14,7 +14,7 @@ INTERFACE zif_abapgit_html_viewer
   TYPES:
     ty_query_table TYPE STANDARD TABLE OF ty_name_value WITH DEFAULT KEY .
 
-  CONSTANTS m_id_sapevent TYPE i VALUE 1 ##NO_TEXT.
+  CONSTANTS c_id_sapevent TYPE i VALUE 1 ##NO_TEXT.
 
   EVENTS sapevent
     EXPORTING

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -415,9 +415,9 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
     LOOP AT mt_diff ASSIGNING <ls_diff>
                     USING KEY new_num
                     WHERE old     = is_diff_old-old
-                    AND   new     = is_diff_old-new
-                    AND   new_num = is_diff_old-new_num
-                    AND   old_num = is_diff_old-old_num.
+                      AND new     = is_diff_old-new
+                      AND new_num = is_diff_old-new_num
+                      AND old_num = is_diff_old-old_num.
 
       <ls_diff>-patch_flag = iv_patch_flag.
       EXIT.

--- a/src/utils/zcl_abapgit_diff.clas.abap
+++ b/src/utils/zcl_abapgit_diff.clas.abap
@@ -3,7 +3,7 @@ CLASS zcl_abapgit_diff DEFINITION
   CREATE PUBLIC.
 
   PUBLIC SECTION.
-    CONSTANTS co_starting_beacon TYPE i VALUE 1.
+    CONSTANTS c_starting_beacon TYPE i VALUE 1.
 
 * assumes data is UTF8 based with newlines
     METHODS constructor
@@ -352,7 +352,7 @@ CLASS zcl_abapgit_diff IMPLEMENTATION.
 
   METHOD map_beacons.
 
-    DATA: lv_beacon_idx  TYPE i VALUE co_starting_beacon,
+    DATA: lv_beacon_idx  TYPE i VALUE c_starting_beacon,
           lv_offs        TYPE i,
           lv_beacon_str  TYPE string,
           lv_beacon_2lev TYPE string,

--- a/src/utils/zcl_abapgit_diff.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_diff.clas.testclasses.abap
@@ -18,7 +18,7 @@ CLASS ltcl_diff DEFINITION FOR TESTING
                              iv_old_num TYPE zif_abapgit_definitions=>ty_diff-old_num
                              iv_old     TYPE zif_abapgit_definitions=>ty_diff-old
                              iv_beacon  TYPE zif_abapgit_definitions=>ty_diff-beacon
-                               DEFAULT zcl_abapgit_diff=>co_starting_beacon.
+                               DEFAULT zcl_abapgit_diff=>c_starting_beacon.
 
     METHODS: setup.
 


### PR DESCRIPTION
Setting rule to use `c_...` for naming of class constants.

```json
    "class_attribute_names": {
      "constants": "^C_.+$",
```

Exceptions: `zif_abapgit_objects->gc_step_id` and `/json/`

Ref https://github.com/abapGit/abapGit/pull/4945