### PR TITLE
JavaGUI: remove trailing null workaround

### DIFF
--- a/src/ui/core/zcl_abapgit_gui_event.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.abap
@@ -214,7 +214,6 @@ CLASS zcl_abapgit_gui_event IMPLEMENTATION.
     WHILE ls_last_line IS INITIAL.
       lv_last_line_index = lines( lt_post_data ).
       READ TABLE lt_post_data INTO ls_last_line INDEX lv_last_line_index.
-      "Avoid trailing null values (see isssue #4832)
       DELETE lt_post_data INDEX lv_last_line_index.
     ENDWHILE.
 

--- a/src/ui/core/zcl_abapgit_gui_event.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.abap
@@ -215,11 +215,6 @@ CLASS zcl_abapgit_gui_event IMPLEMENTATION.
       lv_last_line_index = lines( lt_post_data ).
       READ TABLE lt_post_data INTO ls_last_line INDEX lv_last_line_index.
       "Avoid trailing null values (see isssue #4832)
-      "todo, keep until SAP GUI for Java is fixed (remove on 2022-12-31)
-      ls_last_line = replace( val  = ls_last_line
-                              sub  = zcl_abapgit_git_utils=>get_null( )
-                              with = space
-                              occ  = 0 ).
       DELETE lt_post_data INDEX lv_last_line_index.
     ENDWHILE.
 


### PR DESCRIPTION
this removes the workaround introduced in https://github.com/abapGit/abapGit/pull/4903

note, this will also decouple UI/CORE package from GIT package, https://abaplint.app/stats/abapGit/abapGit/package_coupling?folder=/src/ui/core