### PR TITLE
Improve unit test page

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1163,6 +1163,11 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     ls_hotkey_action-hotkey = |c|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
+    ls_hotkey_action-description   = |Run Unit Tests|.
+    ls_hotkey_action-action = c_actions-go_unit.
+    ls_hotkey_action-hotkey = |t|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
     ls_hotkey_action-description   = |Run Code Inspector|.
     ls_hotkey_action-action = zif_abapgit_definitions=>c_action-repo_code_inspector.
     ls_hotkey_action-hotkey = |i|.

--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -273,7 +273,6 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
     DATA lo_result         TYPE REF TO object.
     DATA lv_program_ndx    TYPE i.
     DATA lv_class_ndx      TYPE i.
-    DATA lv_method_ndx     TYPE i.
     DATA lv_text           TYPE string.
     DATA lv_count          TYPE i.
     DATA lv_params         TYPE string.

--- a/src/utils/zcl_abapgit_timer.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_timer.clas.testclasses.abap
@@ -1,7 +1,10 @@
 CLASS ltcl_timer DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
 
+    DATA mv_disabled TYPE abap_bool.
+
     METHODS:
+      setup,
       check_result
         IMPORTING
           iv_result TYPE string
@@ -14,6 +17,13 @@ CLASS ltcl_timer DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 ENDCLASS.
 
 CLASS ltcl_timer IMPLEMENTATION.
+
+  METHOD setup.
+    DATA lv_skip TYPE c LENGTH 30.
+    GET PARAMETER ID 'TSE' FIELD lv_skip.
+    mv_disabled = boolc( sy-sysid = 'ABC' OR lv_skip CS 'SKIP_TIMER' ).
+  ENDMETHOD.
+
 
   METHOD check_result.
 
@@ -29,8 +39,7 @@ CLASS ltcl_timer IMPLEMENTATION.
 
     DATA lo_timer TYPE REF TO zcl_abapgit_timer.
 
-    IF sy-sysid = 'ABC'.
-* dont run on open-abap, the NodeJS garbage collector can run any time, causing flaky test
+    IF mv_disabled = abap_true.
       RETURN.
     ENDIF.
 
@@ -48,8 +57,7 @@ CLASS ltcl_timer IMPLEMENTATION.
 
     DATA lo_timer TYPE REF TO zcl_abapgit_timer.
 
-    IF sy-sysid = 'ABC'.
-* dont run on open-abap, the NodeJS garbage collector can run any time, causing flaky test
+    IF mv_disabled = abap_true.
       RETURN.
     ENDIF.
 
@@ -77,8 +85,7 @@ CLASS ltcl_timer IMPLEMENTATION.
 
     DATA lo_timer TYPE REF TO zcl_abapgit_timer.
 
-    IF sy-sysid = 'ABC'.
-* dont run on open-abap, the NodeJS garbage collector can run any time, causing flaky test
+    IF mv_disabled = abap_true.
       RETURN.
     ENDIF.
 


### PR DESCRIPTION
- Add `t` hotkey for triggering unit tests

- Display runtime of test methods in milliseconds. Greater than 100 ms is shown in red.

![image](https://github.com/abapGit/abapGit/assets/59966492/e289e055-4843-48a1-aa35-4224795cc3e9)

- `zcl_abapgit_timer` needs ~50% of total runtime of AG unit tests. You can now skip this test class with user parameter `TSE = SKIP_TIMER`. This will reduce runtime to about 3 sec.

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/de228187-0726-465d-9405-05247a5e93ac)

![image](https://github.com/abapGit/abapGit/assets/59966492/b33f067d-5a02-4ddd-8a10-73ed2f455c7d)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/35da8ac7-384f-491e-844e-bfae38f1b592)

- Refactor `render` method to make it shorter

