### PR TITLE
Implement `changed_by` for several objects

### DIFF
--- a/src/objects/zcl_abapgit_object_asfc.clas.abap
+++ b/src/objects/zcl_abapgit_object_asfc.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_asfc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cus0.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus0.clas.abap
@@ -21,7 +21,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
+CLASS zcl_abapgit_object_cus0 IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -35,7 +35,17 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+
+    DATA ls_header TYPE ty_img_activity-header.
+
+    CALL FUNCTION 'S_CUS_IMG_ACTIVITY_READ'
+      EXPORTING
+        img_activity        = mv_img_activity
+      IMPORTING
+        img_activity_header = ls_header.
+
+    rv_user = ls_header-luser.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cus1.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus1.clas.abap
@@ -46,7 +46,17 @@ CLASS zcl_abapgit_object_cus1 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+
+    DATA ls_header TYPE ty_customzing_activity-activity_header.
+
+    CALL FUNCTION 'S_CUS_ACTIVITY_READ'
+      EXPORTING
+        activity        = mv_customizing_activity
+      IMPORTING
+        activity_header = ls_header.
+
+    rv_user = ls_header-luser.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_cus2.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus2.clas.abap
@@ -46,7 +46,17 @@ CLASS zcl_abapgit_object_cus2 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+
+    DATA ls_header TYPE ty_customizing_attribute-header.
+
+    CALL FUNCTION 'S_CUS_ATTRIBUTES_READ'
+      EXPORTING
+        img_attribute    = mv_img_attribute
+      IMPORTING
+        attribute_header = ls_header.
+
+    rv_user = ls_header-luser.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dial.clas.abap
+++ b/src/objects/zcl_abapgit_object_dial.clas.abap
@@ -24,9 +24,7 @@ CLASS zcl_abapgit_object_dial IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-
-    rv_user = c_user_unknown.
-
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ftgl.clas.abap
+++ b/src/objects/zcl_abapgit_object_ftgl.clas.abap
@@ -86,7 +86,7 @@ CLASS zcl_abapgit_object_ftgl IMPLEMENTATION.
 
     IF lv_return_code <> 0.
       zcx_abapgit_exception=>raise( |Cannot delete feature toggle { mv_toggle_id }. |
-                                 && |Error {  sy-subrc } from cl_feature_toggle_object=>delete| ).
+                                 && |Error { sy-subrc } from cl_feature_toggle_object=>delete| ).
     ENDIF.
 
     corr_insert( iv_package ).

--- a/src/objects/zcl_abapgit_object_ftgl.clas.abap
+++ b/src/objects/zcl_abapgit_object_ftgl.clas.abap
@@ -63,7 +63,13 @@ CLASS zcl_abapgit_object_ftgl IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+
+    SELECT SINGLE changedby FROM ftgl_id INTO rv_user
+      WHERE feature_id = ms_item-obj_name AND version = 'A'.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iamu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iamu.clas.abap
@@ -259,9 +259,7 @@ CLASS zcl_abapgit_object_iamu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-
-    rv_user = c_user_unknown.
-
+    rv_user = read( )-attributes-chname.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iarp.clas.abap
+++ b/src/objects/zcl_abapgit_object_iarp.clas.abap
@@ -301,7 +301,13 @@ CLASS zcl_abapgit_object_iarp IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown. " todo
+
+    DATA ls_attributes TYPE w3resoattr.
+
+    read( IMPORTING es_attributes = ls_attributes ).
+
+    rv_user = ls_attributes-chname.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iatu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iatu.clas.abap
@@ -302,7 +302,13 @@ CLASS zcl_abapgit_object_iatu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown. " todo
+
+    DATA ls_attributes TYPE w3tempattr.
+
+    read( IMPORTING es_attr = ls_attributes ).
+
+    rv_user = ls_attributes-chname.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iaxu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iaxu.clas.abap
@@ -205,7 +205,7 @@ CLASS zcl_abapgit_object_iaxu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown. " todo
+    rv_user = read( )-chname.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_jobd.clas.abap
+++ b/src/objects/zcl_abapgit_object_jobd.clas.abap
@@ -16,7 +16,35 @@ CLASS zcl_abapgit_object_jobd IMPLEMENTATION.
 
   METHOD zif_abapgit_object~changed_by.
 
-    rv_user = c_user_unknown.
+    DATA: lr_job_definition TYPE REF TO data,
+          lo_job_definition TYPE REF TO object,
+          lv_name           TYPE ty_jd_name.
+
+    FIELD-SYMBOLS: <lg_job_definition> TYPE any,
+                   <lg_field>          TYPE any.
+
+    lv_name = ms_item-obj_name.
+
+    TRY.
+        CREATE DATA lr_job_definition TYPE ('CL_JR_JOB_DEFINITION=>TY_JOB_DEFINITION').
+        ASSIGN lr_job_definition->* TO <lg_job_definition>.
+        ASSERT sy-subrc = 0.
+
+        CREATE OBJECT lo_job_definition TYPE ('CL_JR_JOB_DEFINITION')
+          EXPORTING
+            im_jd_name = lv_name.
+
+        CALL METHOD lo_job_definition->('GET_JD_ATTRIBUTES')
+          IMPORTING
+            ex_jd_attributes = <lg_job_definition>.
+
+        ASSIGN COMPONENT 'CHANGED_BY' OF STRUCTURE <lg_job_definition> TO <lg_field>.
+        IF sy-subrc = 0.
+          rv_user = <lg_field>.
+        ENDIF.
+
+      CATCH cx_root ##NO_HANDLER.
+    ENDTRY.
 
   ENDMETHOD.
 
@@ -210,6 +238,9 @@ CLASS zcl_abapgit_object_jobd IMPLEMENTATION.
         CLEAR <lg_field>.
 
         ASSIGN COMPONENT 'CREATED_TIME' OF STRUCTURE <lg_job_definition> TO <lg_field>.
+        CLEAR <lg_field>.
+
+        ASSIGN COMPONENT 'CHANGED_BY' OF STRUCTURE <lg_job_definition> TO <lg_field>.
         CLEAR <lg_field>.
 
         ASSIGN COMPONENT 'CHANGED_DATE' OF STRUCTURE <lg_job_definition> TO <lg_field>.

--- a/src/objects/zcl_abapgit_object_pers.clas.abap
+++ b/src/objects/zcl_abapgit_object_pers.clas.abap
@@ -69,7 +69,13 @@ CLASS zcl_abapgit_object_pers IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+
+    SELECT SINGLE author FROM spers_reg INTO rv_user
+      WHERE pers_key = ms_item-obj_name.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_prag.clas.abap
+++ b/src/objects/zcl_abapgit_object_prag.clas.abap
@@ -20,9 +20,7 @@ CLASS zcl_abapgit_object_prag IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-
-    rv_user = c_user_unknown.
-
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_shi5.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi5.clas.abap
@@ -37,7 +37,7 @@ CLASS zcl_abapgit_object_shi5 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_shi8.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi8.clas.abap
@@ -29,7 +29,7 @@ CLASS zcl_abapgit_object_shi8 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sppf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sppf.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_sppf IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sqsc.clas.abap
+++ b/src/objects/zcl_abapgit_object_sqsc.clas.abap
@@ -166,7 +166,20 @@ CLASS zcl_abapgit_object_sqsc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+
+    DATA lx_error TYPE REF TO cx_root.
+
+    TRY.
+        CALL METHOD mo_proxy->('IF_DBPROC_PROXY_UI~READ_FROM_SOURCE')
+          EXPORTING
+            if_version     = 'A'
+          IMPORTING
+            ef_change_user = rv_user.
+
+      CATCH cx_root INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
+    ENDTRY.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_sucu.clas.abap
+++ b/src/objects/zcl_abapgit_object_sucu.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_sucu IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown.
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_susc.clas.abap
+++ b/src/objects/zcl_abapgit_object_susc.clas.abap
@@ -121,7 +121,7 @@ CLASS zcl_abapgit_object_susc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown. " todo
+    rv_user = c_user_unknown. " not stored by SAP
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_suso.clas.abap
+++ b/src/objects/zcl_abapgit_object_suso.clas.abap
@@ -178,7 +178,11 @@ CLASS zcl_abapgit_object_suso IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = c_user_unknown. " todo
+    SELECT SINGLE modifier FROM tobjvor INTO rv_user
+      WHERE objct = mv_objectname.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
   ENDMETHOD.
 
 


### PR DESCRIPTION
I went through all object types and added `changed_by` where possible. I also added a comment if the user is not stored.

For `JOBD` it contains a small correction to clear the `changed_by` field at serialization.