### PR TITLE
Downport: Fix syntax error related to table `ftgl_id`

### DIFF
--- a/src/objects/zcl_abapgit_object_ftgl.clas.abap
+++ b/src/objects/zcl_abapgit_object_ftgl.clas.abap
@@ -64,7 +64,7 @@ CLASS zcl_abapgit_object_ftgl IMPLEMENTATION.
 
   METHOD zif_abapgit_object~changed_by.
 
-    SELECT SINGLE changedby FROM ftgl_id INTO rv_user
+    SELECT SINGLE changedby FROM ('FTGL_ID') INTO rv_user
       WHERE feature_id = ms_item-obj_name AND version = 'A'.
     IF sy-subrc <> 0.
       rv_user = c_user_unknown.


### PR DESCRIPTION
Table `ftgl_id` does not exist in 702