### PR TITLE
cts api: extract methods behind interface

### DIFF
--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -321,9 +321,9 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
 
       IF lv_type_check_result = 'L'.
         LOOP AT lt_tlock ASSIGNING <ls_tlock>
-            WHERE object =  ls_lock_key-obj
-            AND   hikey  >= ls_lock_key-low
-            AND   lokey  <= ls_lock_key-hi.               "#EC PORTABLE
+            WHERE object = ls_lock_key-obj
+            AND hikey >= ls_lock_key-low
+            AND lokey <= ls_lock_key-hi.               "#EC PORTABLE
           lv_request = <ls_tlock>-trkorr.
           EXIT.
         ENDLOOP.
@@ -504,19 +504,16 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
 
     CONSTANTS:
       BEGIN OF c_tr_status,
-        modifiable                   TYPE trstatus VALUE 'D',
-        modifiable_protected         TYPE trstatus VALUE 'L',
-        release_started              TYPE trstatus VALUE 'O',
-        released                     TYPE trstatus VALUE 'R',
-        released_with_import_protect TYPE trstatus VALUE 'N', " Released (with Import Protection for Repaired Objects)
+        modifiable           TYPE trstatus VALUE 'D',
+        modifiable_protected TYPE trstatus VALUE 'L',
       END OF c_tr_status.
 
     DATA ls_request TYPE trwbo_request.
 
     ls_request = zif_abapgit_cts_api~read( iv_transport_request ).
 
-    IF  ls_request-h-trstatus <> c_tr_status-modifiable
-    AND ls_request-h-trstatus <> c_tr_status-modifiable_protected.
+    IF ls_request-h-trstatus <> c_tr_status-modifiable
+        AND ls_request-h-trstatus <> c_tr_status-modifiable_protected.
       " Task/request &1 has already been released
       MESSAGE e064(tk) WITH iv_transport_request INTO zcx_abapgit_exception=>null.
       zcx_abapgit_exception=>raise_t100( ).

--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -478,7 +478,13 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
 
   METHOD zif_abapgit_cts_api~read.
 
-    rs_request-h-trkorr = iv_trkorr.
+    DATA ls_request TYPE trwbo_request.
+    DATA ls_key     LIKE LINE OF ls_request-keys.
+
+    FIELD-SYMBOLS <ls_key> LIKE LINE OF rs_request-keys.
+
+
+    ls_request-h-trkorr = iv_trkorr.
 
     CALL FUNCTION 'TRINT_READ_REQUEST'
       EXPORTING
@@ -490,13 +496,20 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
         iv_read_objs       = abap_true
         iv_read_attributes = abap_true
       CHANGING
-        cs_request         = rs_request
+        cs_request         = ls_request
       EXCEPTIONS
         error_occured      = 1
         OTHERS             = 2.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
+
+* move to output structure
+    rs_request-trstatus = ls_request-h-trstatus.
+    LOOP AT ls_request-keys INTO ls_key.
+      APPEND INITIAL LINE TO rs_request-keys ASSIGNING <ls_key>.
+      MOVE-CORRESPONDING ls_key TO <ls_key>.
+    ENDLOOP.
 
   ENDMETHOD.
 
@@ -508,12 +521,12 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
         modifiable_protected TYPE trstatus VALUE 'L',
       END OF c_tr_status.
 
-    DATA ls_request TYPE trwbo_request.
+    DATA ls_request TYPE zif_abapgit_cts_api=>ty_transport_data.
 
     ls_request = zif_abapgit_cts_api~read( iv_transport_request ).
 
-    IF ls_request-h-trstatus <> c_tr_status-modifiable
-        AND ls_request-h-trstatus <> c_tr_status-modifiable_protected.
+    IF ls_request-trstatus <> c_tr_status-modifiable
+        AND ls_request-trstatus <> c_tr_status-modifiable_protected.
       " Task/request &1 has already been released
       MESSAGE e064(tk) WITH iv_transport_request INTO zcx_abapgit_exception=>null.
       zcx_abapgit_exception=>raise_t100( ).

--- a/src/cts/zcl_abapgit_cts_api.clas.abap
+++ b/src/cts/zcl_abapgit_cts_api.clas.abap
@@ -475,4 +475,53 @@ CLASS zcl_abapgit_cts_api IMPLEMENTATION.
     rv_messages_confirmed = abap_true.
 
   ENDMETHOD.
+
+  METHOD zif_abapgit_cts_api~read.
+
+    rs_request-h-trkorr = iv_trkorr.
+
+    CALL FUNCTION 'TRINT_READ_REQUEST'
+      EXPORTING
+        iv_read_e070       = abap_true
+        iv_read_e07t       = abap_true
+        iv_read_e070c      = abap_true
+        iv_read_e070m      = abap_true
+        iv_read_objs_keys  = abap_true
+        iv_read_objs       = abap_true
+        iv_read_attributes = abap_true
+      CHANGING
+        cs_request         = rs_request
+      EXCEPTIONS
+        error_occured      = 1
+        OTHERS             = 2.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD zif_abapgit_cts_api~validate_transport_request.
+
+    CONSTANTS:
+      BEGIN OF c_tr_status,
+        modifiable                   TYPE trstatus VALUE 'D',
+        modifiable_protected         TYPE trstatus VALUE 'L',
+        release_started              TYPE trstatus VALUE 'O',
+        released                     TYPE trstatus VALUE 'R',
+        released_with_import_protect TYPE trstatus VALUE 'N', " Released (with Import Protection for Repaired Objects)
+      END OF c_tr_status.
+
+    DATA ls_request TYPE trwbo_request.
+
+    ls_request = zif_abapgit_cts_api~read( iv_transport_request ).
+
+    IF  ls_request-h-trstatus <> c_tr_status-modifiable
+    AND ls_request-h-trstatus <> c_tr_status-modifiable_protected.
+      " Task/request &1 has already been released
+      MESSAGE e064(tk) WITH iv_transport_request INTO zcx_abapgit_exception=>null.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/cts/zif_abapgit_cts_api.intf.abap
+++ b/src/cts/zif_abapgit_cts_api.intf.abap
@@ -109,4 +109,18 @@ INTERFACE zif_abapgit_cts_api
     RETURNING
       VALUE(rv_messages_confirmed) TYPE abap_bool .
 
+  METHODS read
+    IMPORTING
+      !iv_trkorr        TYPE trkorr
+    RETURNING
+      VALUE(rs_request) TYPE trwbo_request
+    RAISING
+      zcx_abapgit_exception .
+
+  METHODS validate_transport_request
+    IMPORTING
+      iv_transport_request TYPE trkorr
+    RAISING
+      zcx_abapgit_exception.
+
 ENDINTERFACE.

--- a/src/cts/zif_abapgit_cts_api.intf.abap
+++ b/src/cts/zif_abapgit_cts_api.intf.abap
@@ -109,11 +109,22 @@ INTERFACE zif_abapgit_cts_api
     RETURNING
       VALUE(rv_messages_confirmed) TYPE abap_bool .
 
+  TYPES: BEGIN OF ty_transport_key,
+           object  TYPE e071k-object,
+           objname TYPE e071k-objname,
+           tabkey  TYPE e071k-tabkey,
+         END OF ty_transport_key.
+
+  TYPES: BEGIN OF ty_transport_data,
+           trstatus TYPE e070-trstatus,
+           keys     TYPE STANDARD TABLE OF ty_transport_key WITH DEFAULT KEY,
+         END OF ty_transport_data.
+
   METHODS read
     IMPORTING
       !iv_trkorr        TYPE trkorr
     RETURNING
-      VALUE(rs_request) TYPE trwbo_request
+      VALUE(rs_request) TYPE ty_transport_data
     RAISING
       zcx_abapgit_exception .
 

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -112,7 +112,7 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
     READ TABLE lt_trkorr INDEX 1 INTO ls_trkorr.
     ASSERT sy-subrc = 0.
 
-    ls_request = zcl_abapgit_transport=>read( ls_trkorr ).
+    ls_request = zcl_abapgit_factory=>get_cts_api( )->read( ls_trkorr ).
 
     IF lines( ls_request-keys ) = 0.
       zcx_abapgit_exception=>raise( |No keys found, select task| ).

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -112,7 +112,7 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
     READ TABLE lt_trkorr INDEX 1 INTO ls_trkorr.
     ASSERT sy-subrc = 0.
 
-    ls_request = zcl_abapgit_factory=>get_cts_api( )->read( ls_trkorr ).
+    ls_request = zcl_abapgit_factory=>get_cts_api( )->read( ls_trkorr-trkorr ).
 
     IF lines( ls_request-keys ) = 0.
       zcx_abapgit_exception=>raise( |No keys found, select task| ).

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -98,7 +98,7 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
     DATA lt_trkorr  TYPE trwbo_request_headers.
     DATA ls_trkorr  LIKE LINE OF lt_trkorr.
-    DATA ls_request TYPE trwbo_request.
+    DATA ls_request TYPE zif_abapgit_cts_api=>ty_transport_data.
     DATA ls_key     LIKE LINE OF ls_request-keys.
     DATA lv_where   TYPE string.
     DATA ls_config  TYPE zif_abapgit_data_config=>ty_config.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -419,7 +419,7 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
     lv_transport_request = io_form_data->get( c_id-transport_request ).
     IF lv_transport_request IS NOT INITIAL.
       TRY.
-          zcl_abapgit_transport=>validate_transport_request( lv_transport_request ).
+          zcl_abapgit_factory=>get_cts_api( )->validate_transport_request( lv_transport_request ).
         CATCH zcx_abapgit_exception INTO lx_error.
           ro_validation_log->set(
             iv_key = c_id-transport_request
@@ -430,7 +430,7 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
     lv_customizing_request = io_form_data->get( c_id-customizing_request ).
     IF lv_customizing_request IS NOT INITIAL.
       TRY.
-          zcl_abapgit_transport=>validate_transport_request( lv_customizing_request ).
+          zcl_abapgit_factory=>get_cts_api( )->validate_transport_request( lv_customizing_request ).
         CATCH zcx_abapgit_exception INTO lx_error.
           ro_validation_log->set(
             iv_key = c_id-customizing_request


### PR DESCRIPTION
moving 2 methods from `zcl_abapgit_transport` to cts intf and class