### PR TITLE
Refactor: GUI buttons and menus

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_buttons.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_buttons.clas.abap
@@ -25,6 +25,8 @@ CLASS zcl_abapgit_gui_buttons DEFINITION
     CLASS-METHODS experimental
       RETURNING VALUE(rv_html_string) TYPE string.
 
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 

--- a/src/ui/lib/zcl_abapgit_gui_buttons.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_buttons.clas.abap
@@ -25,8 +25,6 @@ CLASS zcl_abapgit_gui_buttons DEFINITION
     CLASS-METHODS experimental
       RETURNING VALUE(rv_html_string) TYPE string.
 
-  PROTECTED SECTION.
-  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -35,36 +33,42 @@ CLASS zcl_abapgit_gui_buttons IMPLEMENTATION.
 
 
   METHOD advanced.
-    rv_html_string = `<i class="icon icon-tools-solid"></i>`.
+    rv_html_string = zcl_abapgit_html=>icon(
+      iv_name = 'tools-solid'
+      iv_hint = 'Utilities' ).
   ENDMETHOD.
 
 
   METHOD experimental.
-    rv_html_string = `<i class="icon icon-vial-solid red"></i>`.
+    rv_html_string = zcl_abapgit_html=>icon(
+      iv_name = 'vial-solid/red'
+      iv_hint = 'Experimental Features are Enabled' ).
   ENDMETHOD.
 
 
   METHOD help.
-    rv_html_string = `<i class="icon icon-question-circle-solid"></i>`.
+    rv_html_string = zcl_abapgit_html=>icon(
+      iv_name = 'question-circle-solid'
+      iv_hint = 'Help' ).
   ENDMETHOD.
 
 
   METHOD new_offline.
-    rv_html_string = `<i class="icon icon-plug"></i> New Offline`.
+    rv_html_string = zcl_abapgit_html=>icon( 'plug' ) && ' New Offline'.
   ENDMETHOD.
 
 
   METHOD new_online.
-    rv_html_string = `<i class="icon icon-cloud-upload-alt"></i> New Online`.
+    rv_html_string = zcl_abapgit_html=>icon( 'cloud-upload-alt' ) && ' New Online'.
   ENDMETHOD.
 
 
   METHOD repo_list.
-    rv_html_string = `<i class="icon icon-bars"></i> Repository List`.
+    rv_html_string = zcl_abapgit_html=>icon( 'bars' ) && ' Repository List'.
   ENDMETHOD.
 
 
   METHOD settings.
-    rv_html_string = `<i class="icon icon-cog"></i> Settings`.
+    rv_html_string = zcl_abapgit_html=>icon( 'cog' ) && ' Settings'.
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -50,6 +50,14 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS render_commit_popup
+      IMPORTING
+        !iv_content    TYPE csequence
+        !iv_id         TYPE csequence
+      RETURNING
+        VALUE(ri_html) TYPE REF TO zif_abapgit_html
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS render_error_message_box
       IMPORTING
         !ix_error      TYPE REF TO zcx_abapgit_exception
@@ -167,6 +175,13 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
       RETURNING
         VALUE(ri_html) TYPE REF TO zif_abapgit_html.
 
+    CLASS-METHODS shorten_repo_url
+      IMPORTING
+        iv_full_url         TYPE string
+        iv_max_length       TYPE i DEFAULT 60
+      RETURNING
+        VALUE(rv_shortened) TYPE string.
+
     CLASS-METHODS render_label_list
       IMPORTING
         it_labels           TYPE string_table
@@ -216,13 +231,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         !iv_program_name                  TYPE sy-repid
       RETURNING
         VALUE(rv_normalized_program_name) TYPE string .
-
-    CLASS-METHODS shorten_repo_url
-      IMPORTING
-        iv_full_url         TYPE string
-        iv_max_length       TYPE i DEFAULT 60
-      RETURNING
-        VALUE(rv_shortened) TYPE string.
 
 ENDCLASS.
 
@@ -381,6 +389,24 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       ri_html->add( lv_text ).
     ENDIF.
     ri_html->add( '</span>' ).
+
+  ENDMETHOD.
+
+
+  METHOD render_commit_popup.
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    ri_html->add( '<ul class="hotkeys">' ).
+    ri_html->add( |<li>| && |<span>{ iv_content }</span>| && |</li>| ).
+    ri_html->add( '</ul>' ).
+
+    ri_html = render_infopanel(
+      iv_div_id     = |{ iv_id }|
+      iv_title      = 'Commit details'
+      iv_hide       = abap_true
+      iv_scrollable = abap_false
+      io_content    = ri_html ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -50,14 +50,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS render_commit_popup
-      IMPORTING
-        !iv_content    TYPE csequence
-        !iv_id         TYPE csequence
-      RETURNING
-        VALUE(ri_html) TYPE REF TO zif_abapgit_html
-      RAISING
-        zcx_abapgit_exception .
     CLASS-METHODS render_error_message_box
       IMPORTING
         !ix_error      TYPE REF TO zcx_abapgit_exception
@@ -99,26 +91,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS advanced_submenu
-      RETURNING
-        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar .
-    CLASS-METHODS help_submenu
-      RETURNING
-        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar .
-    CLASS-METHODS back_toolbar
-      RETURNING
-        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar .
-    CLASS-METHODS settings_toolbar
-      IMPORTING
-        !iv_act        TYPE string
-      RETURNING
-        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar .
-    CLASS-METHODS settings_repo_toolbar
-      IMPORTING
-        !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
-        !iv_act        TYPE string
-      RETURNING
-        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar .
     CLASS-METHODS render_branch_name
       IMPORTING
         !iv_branch      TYPE string OPTIONAL
@@ -195,13 +167,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
       RETURNING
         VALUE(ri_html) TYPE REF TO zif_abapgit_html.
 
-    CLASS-METHODS shorten_repo_url
-      IMPORTING
-        iv_full_url         TYPE string
-        iv_max_length       TYPE i DEFAULT 60
-      RETURNING
-        VALUE(rv_shortened) TYPE string.
-
     CLASS-METHODS render_label_list
       IMPORTING
         it_labels           TYPE string_table
@@ -252,55 +217,18 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
       RETURNING
         VALUE(rv_normalized_program_name) TYPE string .
 
+    CLASS-METHODS shorten_repo_url
+      IMPORTING
+        iv_full_url         TYPE string
+        iv_max_length       TYPE i DEFAULT 60
+      RETURNING
+        VALUE(rv_shortened) TYPE string.
+
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
-
-
-  METHOD advanced_submenu.
-
-    DATA lv_supports_ie_devtools TYPE abap_bool.
-
-    lv_supports_ie_devtools = zcl_abapgit_ui_factory=>get_frontend_services( )->is_sapgui_for_windows( ).
-
-    CREATE OBJECT ro_menu.
-
-    ro_menu->add(
-      iv_txt = 'Database Utility'
-      iv_act = zif_abapgit_definitions=>c_action-go_db
-    )->add(
-      iv_txt = 'Package to ZIP'
-      iv_act = zif_abapgit_definitions=>c_action-zip_package
-    )->add(
-      iv_txt = 'Transport to ZIP'
-      iv_act = zif_abapgit_definitions=>c_action-zip_transport
-    )->add(
-      iv_txt = 'Object to Files'
-      iv_act = zif_abapgit_definitions=>c_action-zip_object
-    )->add(
-      iv_txt = 'Debug Info'
-      iv_act = zif_abapgit_definitions=>c_action-go_debuginfo ).
-
-    IF lv_supports_ie_devtools = abap_true.
-      ro_menu->add(
-        iv_txt = 'Open IE DevTools'
-        iv_act = zif_abapgit_definitions=>c_action-ie_devtools ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD back_toolbar.
-
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-back'.
-
-    ro_menu->add(
-      iv_txt = 'Back'
-      iv_act = zif_abapgit_definitions=>c_action-go_back ).
-
-  ENDMETHOD.
 
 
   METHOD class_constructor.
@@ -380,29 +308,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD help_submenu.
-
-    CREATE OBJECT ro_menu.
-
-    ro_menu->add(
-      iv_txt = 'Tutorial'
-      iv_act = zif_abapgit_definitions=>c_action-go_tutorial
-    )->add(
-      iv_txt = 'Documentation'
-      iv_act = zif_abapgit_definitions=>c_action-documentation
-    )->add(
-      iv_txt = 'Explore'
-      iv_act = zif_abapgit_definitions=>c_action-go_explore
-    )->add(
-      iv_txt = 'Changelog'
-      iv_act = zif_abapgit_definitions=>c_action-changelog
-    )->add(
-      iv_txt = 'Hotkeys'
-      iv_act = zif_abapgit_definitions=>c_action-show_hotkeys ).
-
-  ENDMETHOD.
-
-
   METHOD normalize_program_name.
 
     rv_normalized_program_name = substring_before(
@@ -476,24 +381,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
       ri_html->add( lv_text ).
     ENDIF.
     ri_html->add( '</span>' ).
-
-  ENDMETHOD.
-
-
-  METHOD render_commit_popup.
-
-    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-
-    ri_html->add( '<ul class="hotkeys">' ).
-    ri_html->add( |<li>| && |<span>{ iv_content }</span>| && |</li>| ).
-    ri_html->add( '</ul>' ).
-
-    ri_html = render_infopanel(
-      iv_div_id     = |{ iv_id }|
-      iv_title      = 'Commit details'
-      iv_hide       = abap_true
-      iv_scrollable = abap_false
-      io_content    = ri_html ).
 
   ENDMETHOD.
 
@@ -1386,55 +1273,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     ri_html->add( '<div class="dummydiv warning">' ).
     ri_html->add( |{ ri_html->icon( 'exclamation-triangle/yellow' ) } { iv_text }| ).
     ri_html->add( '</div>' ).
-
-  ENDMETHOD.
-
-
-  METHOD settings_repo_toolbar.
-
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-repo-settings'.
-
-    ro_menu->add(
-      iv_txt = 'Repository'
-      iv_act = |{ zif_abapgit_definitions=>c_action-repo_settings }?key={ iv_key }|
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_settings )
-    )->add(
-      iv_txt = 'Local'
-      iv_act = |{ zif_abapgit_definitions=>c_action-repo_local_settings }?key={ iv_key }|
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_local_settings )
-    )->add(
-      iv_txt = 'Remote'
-      iv_act = |{ zif_abapgit_definitions=>c_action-repo_remote_settings }?key={ iv_key }|
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_remote_settings )
-    )->add(
-      iv_txt = 'Background'
-      iv_act = |{ zif_abapgit_definitions=>c_action-repo_background }?key={ iv_key }|
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_background )
-    )->add(
-      iv_txt = 'Stats'
-      iv_act = |{ zif_abapgit_definitions=>c_action-repo_infos }?key={ iv_key }|
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_infos ) ).
-
-    zcl_abapgit_exit=>get_instance( )->enhance_repo_toolbar(
-      io_menu = ro_menu
-      iv_key  = iv_key
-      iv_act  = iv_act ).
-
-  ENDMETHOD.
-
-
-  METHOD settings_toolbar.
-
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-settings'.
-
-    ro_menu->add(
-      iv_txt = 'Global'
-      iv_act = zif_abapgit_definitions=>c_action-go_settings
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-go_settings )
-    )->add(
-      iv_txt = 'Personal'
-      iv_act = zif_abapgit_definitions=>c_action-go_settings_personal
-      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-go_settings_personal ) ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
@@ -30,6 +30,8 @@ CLASS zcl_abapgit_gui_menus DEFINITION
       RETURNING
         VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
 
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 

--- a/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
@@ -30,6 +30,10 @@ CLASS zcl_abapgit_gui_menus DEFINITION
       RETURNING
         VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
 
+    CLASS-METHODS experimental
+      IMPORTING
+        io_menu TYPE REF TO zcl_abapgit_html_toolbar.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -75,6 +79,17 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
     ro_menu->add(
       iv_txt = 'Back'
       iv_act = zif_abapgit_definitions=>c_action-go_back ).
+
+  ENDMETHOD.
+
+
+  METHOD experimental.
+
+    IF zcl_abapgit_persist_factory=>get_settings( )->read( )->get_experimental_features( ) IS NOT INITIAL.
+      io_menu->add(
+        iv_txt = zcl_abapgit_gui_buttons=>experimental( )
+        iv_act = zif_abapgit_definitions=>c_action-go_settings ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
@@ -1,0 +1,150 @@
+CLASS zcl_abapgit_gui_menus DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS advanced
+      RETURNING
+        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
+
+    CLASS-METHODS help
+      RETURNING
+        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
+
+    CLASS-METHODS back
+      RETURNING
+        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
+
+    CLASS-METHODS settings
+      IMPORTING
+        !iv_act        TYPE string
+      RETURNING
+        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
+
+    CLASS-METHODS repo_settings
+      IMPORTING
+        !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
+        !iv_act        TYPE string
+      RETURNING
+        VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
+
+
+  METHOD advanced.
+
+    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-advanced'.
+
+    ro_menu->add(
+      iv_txt = 'Database Utility'
+      iv_act = zif_abapgit_definitions=>c_action-go_db
+    )->add(
+      iv_txt = 'Package to ZIP'
+      iv_act = zif_abapgit_definitions=>c_action-zip_package
+    )->add(
+      iv_txt = 'Transport to ZIP'
+      iv_act = zif_abapgit_definitions=>c_action-zip_transport
+    )->add(
+      iv_txt = 'Object to Files'
+      iv_act = zif_abapgit_definitions=>c_action-zip_object
+    )->add(
+      iv_txt = 'Debug Info'
+      iv_act = zif_abapgit_definitions=>c_action-go_debuginfo ).
+
+    IF zcl_abapgit_ui_factory=>get_frontend_services( )->is_sapgui_for_windows( ) = abap_true.
+      ro_menu->add(
+        iv_txt = 'Open IE DevTools'
+        iv_act = zif_abapgit_definitions=>c_action-ie_devtools ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD back.
+
+    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-back'.
+
+    ro_menu->add(
+      iv_txt = 'Back'
+      iv_act = zif_abapgit_definitions=>c_action-go_back ).
+
+  ENDMETHOD.
+
+
+  METHOD help.
+
+    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-help'.
+
+    ro_menu->add(
+      iv_txt = 'Tutorial'
+      iv_act = zif_abapgit_definitions=>c_action-go_tutorial
+    )->add(
+      iv_txt = 'Documentation'
+      iv_act = zif_abapgit_definitions=>c_action-documentation
+    )->add(
+      iv_txt = 'Explore'
+      iv_act = zif_abapgit_definitions=>c_action-go_explore
+    )->add(
+      iv_txt = 'Changelog'
+      iv_act = zif_abapgit_definitions=>c_action-changelog
+    )->add(
+      iv_txt = 'Hotkeys'
+      iv_act = zif_abapgit_definitions=>c_action-show_hotkeys ).
+
+  ENDMETHOD.
+
+
+  METHOD repo_settings.
+
+    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-repo-settings'.
+
+    ro_menu->add(
+      iv_txt = 'Repository'
+      iv_act = |{ zif_abapgit_definitions=>c_action-repo_settings }?key={ iv_key }|
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_settings )
+    )->add(
+      iv_txt = 'Local'
+      iv_act = |{ zif_abapgit_definitions=>c_action-repo_local_settings }?key={ iv_key }|
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_local_settings )
+    )->add(
+      iv_txt = 'Remote'
+      iv_act = |{ zif_abapgit_definitions=>c_action-repo_remote_settings }?key={ iv_key }|
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_remote_settings )
+    )->add(
+      iv_txt = 'Background'
+      iv_act = |{ zif_abapgit_definitions=>c_action-repo_background }?key={ iv_key }|
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_background )
+    )->add(
+      iv_txt = 'Stats'
+      iv_act = |{ zif_abapgit_definitions=>c_action-repo_infos }?key={ iv_key }|
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-repo_infos ) ).
+
+    zcl_abapgit_exit=>get_instance( )->enhance_repo_toolbar(
+      io_menu = ro_menu
+      iv_key  = iv_key
+      iv_act  = iv_act ).
+
+  ENDMETHOD.
+
+
+  METHOD settings.
+
+    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-settings'.
+
+    ro_menu->add(
+      iv_txt = 'Global'
+      iv_act = zif_abapgit_definitions=>c_action-go_settings
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-go_settings )
+    )->add(
+      iv_txt = 'Personal'
+      iv_act = zif_abapgit_definitions=>c_action-go_settings_personal
+      iv_cur = boolc( iv_act = zif_abapgit_definitions=>c_action-go_settings_personal ) ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_gui_menus.clas.xml
+++ b/src/ui/lib/zcl_abapgit_gui_menus.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_MENUS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI Menus</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -1023,11 +1023,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_txt = zcl_abapgit_gui_buttons=>help( )
       io_sub = zcl_abapgit_gui_menus=>help( ) ).
 
-    IF zcl_abapgit_persist_factory=>get_settings( )->read( )->get_experimental_features( ) IS NOT INITIAL.
-      ro_toolbar->add(
-        iv_txt = zcl_abapgit_gui_buttons=>experimental( )
-        iv_act = zif_abapgit_definitions=>c_action-go_settings ).
-    ENDIF.
+    zcl_abapgit_gui_menus=>experimental( ro_toolbar ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -26,6 +26,7 @@ CLASS zcl_abapgit_gui_page_repo_over DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES:

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -26,7 +26,6 @@ CLASS zcl_abapgit_gui_page_repo_over DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES:
@@ -1018,18 +1017,15 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_act = zif_abapgit_definitions=>c_action-go_settings
     )->add(
       iv_txt = zcl_abapgit_gui_buttons=>advanced( )
-      iv_title = 'Utilities'
-      io_sub = zcl_abapgit_gui_chunk_lib=>advanced_submenu( )
+      io_sub = zcl_abapgit_gui_menus=>advanced( )
     )->add(
       iv_txt = zcl_abapgit_gui_buttons=>help( )
-      iv_title = 'Help'
-      io_sub = zcl_abapgit_gui_chunk_lib=>help_submenu( ) ).
+      io_sub = zcl_abapgit_gui_menus=>help( ) ).
 
     IF zcl_abapgit_persist_factory=>get_settings( )->read( )->get_experimental_features( ) IS NOT INITIAL.
       ro_toolbar->add(
-        iv_txt   = zcl_abapgit_gui_buttons=>experimental( )
-        iv_title = 'Experimental Features are Enabled'
-        iv_act   = zif_abapgit_definitions=>c_action-go_settings ).
+        iv_txt = zcl_abapgit_gui_buttons=>experimental( )
+        iv_act = zif_abapgit_definitions=>c_action-go_settings ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1199,11 +1199,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
       iv_txt = zcl_abapgit_gui_buttons=>help( )
       io_sub = zcl_abapgit_gui_menus=>help( ) ).
 
-    IF zcl_abapgit_persist_factory=>get_settings( )->read( )->get_experimental_features( ) IS NOT INITIAL.
-      ro_toolbar->add(
-        iv_txt = zcl_abapgit_gui_buttons=>experimental( )
-        iv_act = zif_abapgit_definitions=>c_action-go_settings ).
-    ENDIF.
+    zcl_abapgit_gui_menus=>experimental( ro_toolbar ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -38,6 +38,7 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     DATA mo_repo TYPE REF TO zcl_abapgit_repo .

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -38,7 +38,6 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     DATA mo_repo TYPE REF TO zcl_abapgit_repo .
@@ -1197,14 +1196,12 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
       iv_act = zif_abapgit_definitions=>c_action-abapgit_home
     )->add(
       iv_txt = zcl_abapgit_gui_buttons=>help( )
-      iv_title = 'Help'
-      io_sub = zcl_abapgit_gui_chunk_lib=>help_submenu( ) ).
+      io_sub = zcl_abapgit_gui_menus=>help( ) ).
 
     IF zcl_abapgit_persist_factory=>get_settings( )->read( )->get_experimental_features( ) IS NOT INITIAL.
       ro_toolbar->add(
-        iv_txt   = zcl_abapgit_gui_buttons=>experimental( )
-        iv_title = 'Experimental Features are Enabled'
-        iv_act   = zif_abapgit_definitions=>c_action-go_settings ).
+        iv_txt = zcl_abapgit_gui_buttons=>experimental( )
+        iv_act = zif_abapgit_definitions=>c_action-go_settings ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_run_bckg.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_run_bckg.clas.abap
@@ -17,7 +17,6 @@ CLASS zcl_abapgit_gui_page_run_bckg DEFINITION
     METHODS constructor
       RAISING
         zcx_abapgit_exception .
-  PROTECTED SECTION.
   PRIVATE SECTION.
     DATA: mt_text TYPE TABLE OF string.
 
@@ -26,7 +25,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_RUN_BCKG IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_run_bckg IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -44,7 +43,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_RUN_BCKG IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Background Run'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>back_toolbar( )
+      io_page_menu       = zcl_abapgit_gui_menus=>back( )
       ii_child_component = lo_component ).
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_run_bckg.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_run_bckg.clas.abap
@@ -17,6 +17,7 @@ CLASS zcl_abapgit_gui_page_run_bckg DEFINITION
     METHODS constructor
       RAISING
         zcx_abapgit_exception .
+  PROTECTED SECTION.
   PRIVATE SECTION.
     DATA: mt_text TYPE TABLE OF string.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_bckg.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_bckg.clas.abap
@@ -90,7 +90,7 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Background Mode'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_repo_toolbar(
+      io_page_menu       = zcl_abapgit_gui_menus=>repo_settings(
                              iv_key = io_repo->get_key( )
                              iv_act = zif_abapgit_definitions=>c_action-repo_background )
       ii_child_component = lo_component ).

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_glob.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_glob.clas.abap
@@ -18,6 +18,7 @@ CLASS zcl_abapgit_gui_page_sett_glob DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS:

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_glob.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_glob.clas.abap
@@ -18,7 +18,6 @@ CLASS zcl_abapgit_gui_page_sett_glob DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS:
@@ -103,8 +102,7 @@ CLASS zcl_abapgit_gui_page_sett_glob IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Global Settings'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_toolbar(
-                             zif_abapgit_definitions=>c_action-go_settings )
+      io_page_menu       = zcl_abapgit_gui_menus=>settings( zif_abapgit_definitions=>c_action-go_settings )
       ii_child_component = lo_component ).
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_info.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_info.clas.abap
@@ -22,7 +22,6 @@ CLASS zcl_abapgit_gui_page_sett_info DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES:
@@ -137,7 +136,7 @@ CLASS zcl_abapgit_gui_page_sett_info IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Repository Stats'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_repo_toolbar(
+      io_page_menu       = zcl_abapgit_gui_menus=>repo_settings(
                              iv_key = io_repo->get_key( )
                              iv_act = zif_abapgit_definitions=>c_action-repo_infos )
       ii_child_component = lo_component ).

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_info.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_info.clas.abap
@@ -22,6 +22,7 @@ CLASS zcl_abapgit_gui_page_sett_info DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES:

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -22,7 +22,6 @@ CLASS zcl_abapgit_gui_page_sett_locl DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     DATA mo_popup_picklist TYPE REF TO zcl_abapgit_gui_picklist.
@@ -208,7 +207,7 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Local Settings & Checks'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_repo_toolbar(
+      io_page_menu       = zcl_abapgit_gui_menus=>repo_settings(
                              iv_key = io_repo->get_key( )
                              iv_act = zif_abapgit_definitions=>c_action-repo_local_settings )
       ii_child_component = lo_component ).

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -22,6 +22,7 @@ CLASS zcl_abapgit_gui_page_sett_locl DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     DATA mo_popup_picklist TYPE REF TO zcl_abapgit_gui_picklist.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_pers.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_pers.clas.abap
@@ -18,7 +18,6 @@ CLASS zcl_abapgit_gui_page_sett_pers DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS:
@@ -99,8 +98,7 @@ CLASS zcl_abapgit_gui_page_sett_pers IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Personal Settings'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_toolbar(
-        zif_abapgit_definitions=>c_action-go_settings_personal )
+      io_page_menu       = zcl_abapgit_gui_menus=>settings( zif_abapgit_definitions=>c_action-go_settings_personal )
       ii_child_component = lo_component ).
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_pers.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_pers.clas.abap
@@ -18,6 +18,7 @@ CLASS zcl_abapgit_gui_page_sett_pers DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS:

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -22,7 +22,6 @@ CLASS zcl_abapgit_gui_page_sett_remo DEFINITION
         !io_repo TYPE REF TO zcl_abapgit_repo
       RAISING
         zcx_abapgit_exception.
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES:
@@ -368,7 +367,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Remote Settings'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_repo_toolbar(
+      io_page_menu       = zcl_abapgit_gui_menus=>repo_settings(
                              iv_key = io_repo->get_key( )
                              iv_act = zif_abapgit_definitions=>c_action-repo_remote_settings )
       ii_child_component = lo_component ).

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -22,6 +22,7 @@ CLASS zcl_abapgit_gui_page_sett_remo DEFINITION
         !io_repo TYPE REF TO zcl_abapgit_repo
       RAISING
         zcx_abapgit_exception.
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES:

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -22,6 +22,7 @@ CLASS zcl_abapgit_gui_page_sett_repo DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS:

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -22,7 +22,6 @@ CLASS zcl_abapgit_gui_page_sett_repo DEFINITION
       RAISING
         zcx_abapgit_exception .
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS:
@@ -109,7 +108,7 @@ CLASS zcl_abapgit_gui_page_sett_repo IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title      = 'Repository Settings'
-      io_page_menu       = zcl_abapgit_gui_chunk_lib=>settings_repo_toolbar(
+      io_page_menu       = zcl_abapgit_gui_menus=>repo_settings(
                              iv_key = io_repo->get_key( )
                              iv_act = zif_abapgit_definitions=>c_action-repo_settings )
       ii_child_component = lo_component ).

--- a/src/ui/pages/zcl_abapgit_gui_page_tutorial.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_tutorial.clas.abap
@@ -13,7 +13,6 @@ CLASS zcl_abapgit_gui_page_tutorial DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-  PROTECTED SECTION.
 
   PRIVATE SECTION.
 
@@ -25,7 +24,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_TUTORIAL IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_tutorial IMPLEMENTATION.
 
 
   METHOD build_main_menu.
@@ -42,16 +41,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TUTORIAL IMPLEMENTATION.
       iv_txt = zcl_abapgit_gui_buttons=>new_offline( )
       iv_act = zif_abapgit_definitions=>c_action-repo_newoffline
     )->add(
-      iv_txt = zcl_abapgit_gui_buttons=>settings( )
-      iv_act = zif_abapgit_definitions=>c_action-go_settings
-    )->add(
-      iv_txt = zcl_abapgit_gui_buttons=>advanced( )
-      iv_title = 'Utilities'
-      io_sub = zcl_abapgit_gui_chunk_lib=>advanced_submenu( )
-    )->add(
       iv_txt = zcl_abapgit_gui_buttons=>help( )
-      iv_title = 'Help'
-      io_sub = zcl_abapgit_gui_chunk_lib=>help_submenu( ) ).
+      io_sub = zcl_abapgit_gui_menus=>help( ) ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_tutorial.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_tutorial.clas.abap
@@ -13,6 +13,7 @@ CLASS zcl_abapgit_gui_page_tutorial DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+  PROTECTED SECTION.
 
   PRIVATE SECTION.
 


### PR DESCRIPTION
Changes to `zcl_abapgit_chunk_lib` (which was getting rather big):

- Move menus to `zcl_abapgit_gui_menus`

Changes to `zcl_abapgit_gui_buttons`:

- Use `zcl_abapgit_html=>icon` to create icons 

Changes to Tutorial Page:

- Remove the "Utilities" and "Settings" menus since they are irrelevant 

