### PR TITLE
Extract calls to FM FUNCTION_EXISTS

### DIFF
--- a/src/objects/core/zcl_abapgit_function_module.clas.abap
+++ b/src/objects/core/zcl_abapgit_function_module.clas.abap
@@ -1,0 +1,27 @@
+CLASS zcl_abapgit_function_module DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    INTERFACES:
+      zif_abapgit_function_module.
+
+ENDCLASS.
+
+
+CLASS zcl_abapgit_function_module IMPLEMENTATION.
+
+  METHOD zif_abapgit_function_module~function_exists.
+
+    CALL FUNCTION 'FUNCTION_EXISTS'
+      EXPORTING
+        funcname           = iv_function_module_name
+      EXCEPTIONS
+        function_not_exist = 1
+        OTHERS             = 2.
+    rv_exists = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/core/zcl_abapgit_function_module.clas.abap
+++ b/src/objects/core/zcl_abapgit_function_module.clas.abap
@@ -14,7 +14,7 @@ CLASS zcl_abapgit_function_module IMPLEMENTATION.
 
   METHOD zif_abapgit_function_module~function_exists.
 
-    DATA: lv_function_module_name TYPE rs38l-name.
+    DATA: lv_function_module_name TYPE c LENGTH 30.
 
     lv_function_module_name = iv_function_module_name.
 

--- a/src/objects/core/zcl_abapgit_function_module.clas.abap
+++ b/src/objects/core/zcl_abapgit_function_module.clas.abap
@@ -14,9 +14,13 @@ CLASS zcl_abapgit_function_module IMPLEMENTATION.
 
   METHOD zif_abapgit_function_module~function_exists.
 
+    DATA: lv_function_module_name TYPE rs38l-name.
+
+    lv_function_module_name = iv_function_module_name.
+
     CALL FUNCTION 'FUNCTION_EXISTS'
       EXPORTING
-        funcname           = iv_function_module_name
+        funcname           = lv_function_module_name
       EXCEPTIONS
         function_not_exist = 1
         OTHERS             = 2.

--- a/src/objects/core/zcl_abapgit_function_module.clas.xml
+++ b/src/objects/core/zcl_abapgit_function_module.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_FUNCTION_MODULE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Function Module</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -624,13 +624,7 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
 
   METHOD use_new_activation_logic.
 
-    CALL FUNCTION 'FUNCTION_EXISTS'
-      EXPORTING
-        funcname           = 'DD_MASS_ACT_C3'
-      EXCEPTIONS
-        function_not_exist = 1
-        OTHERS             = 2.
-    IF sy-subrc = 0.
+    IF zcl_abapgit_factory=>get_function_module( )->function_exists( 'DD_MASS_ACT_C3' ) = abap_true.
       rv_use_new_activation_logic = abap_true.
     ENDIF.
 

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -324,13 +324,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
     ELSEIF mv_group IS NOT INITIAL.
       " The function module below should always exist here as is_merged evaluated to false above. It does however
       " not exist in the transpiled version which then causes unit tests to fail. Therefore the check needs to stay.
-      CALL FUNCTION 'FUNCTION_EXISTS'
-        EXPORTING
-          funcname           = 'Z_ABAPGIT_SERIALIZE_PARALLEL'
-        EXCEPTIONS
-          function_not_exist = 1
-          OTHERS             = 2.
-      IF sy-subrc <> 0.
+      IF zcl_abapgit_factory=>get_function_module( )->function_exists( 'Z_ABAPGIT_SERIALIZE_PARALLEL' ) = abap_false.
         gv_max_processes = 1.
       ELSE.
         CALL FUNCTION 'SPBT_INITIALIZE'

--- a/src/objects/core/zif_abapgit_function_module.intf.abap
+++ b/src/objects/core/zif_abapgit_function_module.intf.abap
@@ -4,7 +4,7 @@ INTERFACE zif_abapgit_function_module
   METHODS:
     function_exists
       IMPORTING
-        iv_function_module_name TYPE rs38l-name
+        iv_function_module_name TYPE clike
       RETURNING
         VALUE(rv_exists)        TYPE abap_bool.
 

--- a/src/objects/core/zif_abapgit_function_module.intf.abap
+++ b/src/objects/core/zif_abapgit_function_module.intf.abap
@@ -1,0 +1,11 @@
+INTERFACE zif_abapgit_function_module
+  PUBLIC.
+
+  METHODS:
+    function_exists
+      IMPORTING
+        iv_function_module_name TYPE rs38l-name
+      RETURNING
+        VALUE(rv_exists)        TYPE abap_bool.
+
+ENDINTERFACE.

--- a/src/objects/core/zif_abapgit_function_module.intf.xml
+++ b/src/objects/core/zif_abapgit_function_module.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_FUNCTION_MODULE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Function Module</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/zcl_abapgit_object_auth.clas.abap
+++ b/src/objects/zcl_abapgit_object_auth.clas.abap
@@ -146,13 +146,7 @@ CLASS zcl_abapgit_object_auth IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~jump.
-    CALL FUNCTION 'FUNCTION_EXISTS'
-      EXPORTING
-        funcname           = 'SU20_MAINTAIN_SNGL'
-      EXCEPTIONS
-        function_not_exist = 1
-        OTHERS             = 2.
-    IF sy-subrc = 0.
+    IF zcl_abapgit_factory=>get_function_module( )->function_exists( 'SU20_MAINTAIN_SNGL' ) = abap_true.
       " this function module does not exist in 740
       CALL FUNCTION 'SU20_MAINTAIN_SNGL'
         EXPORTING

--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -73,13 +73,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
       lv_function = |CONVERSION_EXIT_{ cv_exit }_INPUT|.
 
       " If exit function does not exist, remove it
-      CALL FUNCTION 'FUNCTION_EXISTS'
-        EXPORTING
-          funcname           = lv_function
-        EXCEPTIONS
-          function_not_exist = 1
-          OTHERS             = 2.
-      IF sy-subrc <> 0.
+      IF zcl_abapgit_factory=>get_function_module( )->function_exists( lv_function ) = abap_false.
         cv_exit = ''.
       ENDIF.
     ENDIF.

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -247,14 +247,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
         CONTINUE. "with next function module
       ENDIF.
 
-      CALL FUNCTION 'FUNCTION_EXISTS'
-        EXPORTING
-          funcname           = <ls_func>-funcname
-        IMPORTING
-          include            = lv_include
-        EXCEPTIONS
-          function_not_exist = 1.
-      IF sy-subrc = 0.
+      IF zcl_abapgit_factory=>get_function_module( )->function_exists( <ls_func>-funcname ) = abap_true.
 * delete the function module to make sure the parameters are updated
 * havent found a nice way to update the paramters
         CALL FUNCTION 'FUNCTION_DELETE'

--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -33,18 +33,11 @@ CLASS zcl_abapgit_object_shlp IMPLEMENTATION.
 
     CONSTANTS lc_standard_exit TYPE dd30v-selmexit VALUE 'RS_DD_SELMEXIT'.
 
-    IF cv_exit IS NOT INITIAL.
+    IF cv_exit IS NOT INITIAL
+    AND zcl_abapgit_factory=>get_function_module( )->function_exists( cv_exit ) = abap_false.
       " If exit function does not exist, replace it with standard SAP function
       " which exists in 7.02 and higher
-      CALL FUNCTION 'FUNCTION_EXISTS'
-        EXPORTING
-          funcname           = cv_exit
-        EXCEPTIONS
-          function_not_exist = 1
-          OTHERS             = 2.
-      IF sy-subrc <> 0.
-        cv_exit = lc_standard_exit.
-      ENDIF.
+      cv_exit = lc_standard_exit.
     ENDIF.
 
   ENDMETHOD.

--- a/src/persist/zcl_abapgit_persistence_db.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_db.clas.abap
@@ -141,13 +141,7 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_DB IMPLEMENTATION.
   METHOD get_update_function.
     IF mv_update_function IS INITIAL.
       mv_update_function = 'CALL_V1_PING'.
-      CALL FUNCTION 'FUNCTION_EXISTS'
-        EXPORTING
-          funcname = mv_update_function
-        EXCEPTIONS
-          OTHERS   = 2.
-
-      IF sy-subrc <> 0.
+      IF zcl_abapgit_factory=>get_function_module( )->function_exists( mv_update_function ) = abap_false.
         mv_update_function = 'BANK_OBJ_WORKL_RELEASE_LOCKS'.
       ENDIF.
     ENDIF.

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -607,13 +607,7 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
 
   METHOD zif_abapgit_popups~popup_to_create_package.
-    CALL FUNCTION 'FUNCTION_EXISTS'
-      EXPORTING
-        funcname           = 'PB_POPUP_PACKAGE_CREATE'
-      EXCEPTIONS
-        function_not_exist = 1
-        OTHERS             = 2.
-    IF sy-subrc = 1.
+    IF zcl_abapgit_factory=>get_function_module( )->function_exists( 'PB_POPUP_PACKAGE_CREATE' ) = abap_false.
 * looks like the function module used does not exist on all
 * versions since 702, so show an error
       zcx_abapgit_exception=>raise( 'Your system does not support automatic creation of packages.' &&

--- a/src/zcl_abapgit_factory.clas.abap
+++ b/src/zcl_abapgit_factory.clas.abap
@@ -44,6 +44,9 @@ CLASS zcl_abapgit_factory DEFINITION
     CLASS-METHODS get_sap_report
       RETURNING
         VALUE(ri_report) TYPE REF TO zif_abapgit_sap_report.
+    CLASS-METHODS: get_function_module
+        RETURNING
+          VALUE(ri_function_module) TYPE REF TO zif_abapgit_function_module.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -75,6 +78,7 @@ CLASS zcl_abapgit_factory DEFINITION
     CLASS-DATA gi_lxe_texts TYPE REF TO zif_abapgit_lxe_texts .
     CLASS-DATA gi_sap_namespace TYPE REF TO zif_abapgit_sap_namespace .
     CLASS-DATA gi_sap_report TYPE REF TO zif_abapgit_sap_report.
+    CLASS-DATA gi_function_module TYPE REF TO zif_abapgit_function_module.
 ENDCLASS.
 
 
@@ -223,4 +227,16 @@ CLASS zcl_abapgit_factory IMPLEMENTATION.
     ri_tadir = gi_tadir.
 
   ENDMETHOD.
+
+
+  METHOD get_function_module.
+
+    IF gi_function_module IS INITIAL.
+      CREATE OBJECT gi_function_module TYPE zcl_abapgit_function_module.
+    ENDIF.
+
+    ri_function_module = gi_function_module.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_abapgit_injector.clas.abap
+++ b/src/zcl_abapgit_injector.clas.abap
@@ -39,6 +39,9 @@ CLASS zcl_abapgit_injector DEFINITION
     CLASS-METHODS set_sap_report
       IMPORTING
         !ii_report TYPE REF TO zif_abapgit_sap_report.
+    CLASS-METHODS set_function_module
+      IMPORTING
+        ii_function_module TYPE REF TO zif_abapgit_function_module.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -140,4 +143,12 @@ CLASS zcl_abapgit_injector IMPLEMENTATION.
   METHOD set_tadir.
     zcl_abapgit_factory=>gi_tadir = ii_tadir.
   ENDMETHOD.
+
+
+  METHOD set_function_module.
+
+    zcl_abapgit_factory=>gi_function_module = ii_function_module.
+
+  ENDMETHOD.
+
 ENDCLASS.


### PR DESCRIPTION
Extract calls to function module `FUNCTION_EXISTS` and use interface `ZIF_ABAPGIT_FUNCTION_MODULE`. Allows mocking for unit tests. E.g. [here](https://github.com/abapGit/abapGit/blob/bd0394ee207a8c657c119232f25eea81ca9e16c2/src/objects/core/zcl_abapgit_serialize.clas.abap#L302)