### PR TITLE
zlib performance optimizations

### DIFF
--- a/src/git/zlib/zcl_abapgit_zlib.clas.abap
+++ b/src/git/zlib/zcl_abapgit_zlib.clas.abap
@@ -54,7 +54,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_ZLIB IMPLEMENTATION.
+CLASS zcl_abapgit_zlib IMPLEMENTATION.
 
 
   METHOD copy_out.
@@ -118,7 +118,7 @@ CLASS ZCL_ABAPGIT_ZLIB IMPLEMENTATION.
       lv_symbol = decode( go_lencode ).
 
       IF lv_symbol < 256.
-        lv_x = zcl_abapgit_zlib_convert=>int_to_hex( lv_symbol ).
+        lv_x = lv_symbol.
         CONCATENATE gv_out lv_x INTO gv_out IN BYTE MODE.
       ELSEIF lv_symbol = 256.
         EXIT.

--- a/src/git/zlib/zcl_abapgit_zlib_convert.clas.abap
+++ b/src/git/zlib/zcl_abapgit_zlib_convert.clas.abap
@@ -16,26 +16,25 @@ CLASS zcl_abapgit_zlib_convert DEFINITION
       RETURNING
         VALUE(rv_int) TYPE i.
 
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_zlib_convert IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_ZLIB_CONVERT IMPLEMENTATION.
 
 
   METHOD bits_to_int.
 
-    DATA: lv_c    TYPE c LENGTH 1,
-          lv_bits TYPE string.
+    DATA lv_i      TYPE i.
+    DATA lv_offset TYPE i.
 
-    lv_bits = iv_bits.
-
-    WHILE NOT lv_bits IS INITIAL.
-      lv_c = lv_bits.
-      rv_int = rv_int * 2.
-      rv_int = rv_int + lv_c.
-      lv_bits = lv_bits+1.
-    ENDWHILE.
+    DO strlen( iv_bits ) TIMES.
+      lv_i = iv_bits+lv_offset(1).
+      rv_int = rv_int * 2 + lv_i.
+      lv_offset = lv_offset + 1.
+    ENDDO.
 
   ENDMETHOD.
 
@@ -60,6 +59,4 @@ CLASS zcl_abapgit_zlib_convert IMPLEMENTATION.
     ENDWHILE.
 
   ENDMETHOD.
-
-
 ENDCLASS.

--- a/src/git/zlib/zcl_abapgit_zlib_convert.clas.abap
+++ b/src/git/zlib/zcl_abapgit_zlib_convert.clas.abap
@@ -16,17 +16,11 @@ CLASS zcl_abapgit_zlib_convert DEFINITION
       RETURNING
         VALUE(rv_int) TYPE i.
 
-    CLASS-METHODS int_to_hex
-      IMPORTING
-        !iv_int       TYPE i
-      RETURNING
-        VALUE(rv_hex) TYPE xstring.
-
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_ZLIB_CONVERT IMPLEMENTATION.
+CLASS zcl_abapgit_zlib_convert IMPLEMENTATION.
 
 
   METHOD bits_to_int.
@@ -68,13 +62,4 @@ CLASS ZCL_ABAPGIT_ZLIB_CONVERT IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD int_to_hex.
-
-    DATA: lv_x TYPE x.
-
-
-    lv_x = iv_int.
-    rv_hex = lv_x.
-
-  ENDMETHOD.
 ENDCLASS.

--- a/src/git/zlib/zcl_abapgit_zlib_convert.clas.testclasses.abap
+++ b/src/git/zlib/zcl_abapgit_zlib_convert.clas.testclasses.abap
@@ -10,8 +10,7 @@ CLASS ltcl_test DEFINITION FOR TESTING
     METHODS:
       setup,
       bits_to_int FOR TESTING,
-      hex_to_bits FOR TESTING,
-      int_to_hex FOR TESTING.
+      hex_to_bits FOR TESTING.
 
 ENDCLASS.
 
@@ -43,18 +42,6 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lv_bits
       exp = '0000000100000001' ).
-
-  ENDMETHOD.
-
-  METHOD int_to_hex.
-
-    DATA: lv_hex TYPE xstring.
-
-    lv_hex = mo_cut->int_to_hex( 64 ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = lv_hex
-      exp = '40' ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
two optimizations
1: delete method `zcl_abapgit_zlib_convert=>int_to_hex` it can be done in a single statement
2: optimize `bits_to_int`, two measurements before, two after, marked in red = after,

![image](https://github.com/abapGit/abapGit/assets/5888506/f7afb7a8-7637-4db0-b828-375d5e946b03)
