### PR TITLE
Show object type in activation log

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -392,6 +392,8 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
         ls_item-obj_name = <ls_message>-object_text+5(*).
       ELSE.
         ls_item-obj_name = <ls_message>-show_req->object_name.
+        SELECT SINGLE tadir FROM euobjedit INTO ls_item-obj_type
+          WHERE type = <ls_message>-show_req->object_type.
       ENDIF.
       LOOP AT <ls_message>-mtext ASSIGNING <lv_msg>.
         ii_log->add_error(


### PR DESCRIPTION
Fill in the object type for errors in the activation log

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/533fbd0a-b3e4-4a46-afb4-29018e70af40)

After (different state of project):

![image](https://github.com/abapGit/abapGit/assets/59966492/db4906ee-edf7-4081-bec4-7a1b64fdc571)
