### PR TITLE
Fix dump restoring abapGit backup

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_db.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_db.clas.abap
@@ -276,7 +276,12 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
       lv_filename = <ls_zipfile>-name.
       REPLACE '.xml' IN lv_filename WITH ''.
       REPLACE '.txt' IN lv_filename WITH ''.
-      SPLIT lv_filename AT '_' INTO ls_data-type ls_data-value.
+      IF lv_filename CP 'REPO_CS*'.
+        ls_data-type  = lv_filename(7).
+        ls_data-value = lv_filename+8(*).
+      ELSE.
+        SPLIT lv_filename AT '_' INTO ls_data-type ls_data-value.
+      ENDIF.
 
       " Validate DB key
       TRY.


### PR DESCRIPTION
Fixes restoring a backup that contains checksums.

Note: The issue existed ever since #5328 and is unrelated to #6617