### PR TITLE
Fix text field when switching to offline

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -38,6 +38,11 @@ CLASS zcl_abapgit_gui_page_sett_remo DEFINITION
         switched_origin TYPE zif_abapgit_persistence=>ty_repo-switched_origin,
       END OF ty_remote_settings.
     CONSTANTS:
+      BEGIN OF c_repo_type,
+        online  TYPE string VALUE 'Online Repository',
+        offline TYPE string VALUE 'Offline Repository',
+      END OF c_repo_type.
+    CONSTANTS:
       BEGIN OF c_head_types,
         branch       TYPE ty_head_type VALUE 'B',
         tag          TYPE ty_head_type VALUE 'T',
@@ -616,9 +621,9 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
     CREATE OBJECT ro_form_data.
 
     IF ms_settings_snapshot-offline = abap_true.
-      lv_type = 'Offline repository'.
+      lv_type = c_repo_type-offline.
     ELSE.
-      lv_type = 'Online repository'.
+      lv_type = c_repo_type-online.
     ENDIF.
 
     ro_form_data->set(
@@ -751,11 +756,13 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       IF lv_url CP 'http*'.
         lv_url = zcl_abapgit_url=>name( lv_url ).
         mo_form_data->set(
-          iv_key = c_id-url
-          iv_val = lv_url ).
-      ENDIF.
-
+      mo_form_data->set(
+        iv_key = c_id-repo_type
+        iv_val = c_repo_type-offline ).
     ELSE.
+      mo_form_data->set(
+        iv_key = c_id-repo_type
+        iv_val = c_repo_type-online ).
       IF mv_offline_switch_saved_url IS NOT INITIAL.
         mo_form_data->set(
           iv_key = c_id-url

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -756,6 +756,9 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
       IF lv_url CP 'http*'.
         lv_url = zcl_abapgit_url=>name( lv_url ).
         mo_form_data->set(
+          iv_key = c_id-url
+          iv_val = lv_url ).
+      ENDIF.
       mo_form_data->set(
         iv_key = c_id-repo_type
         iv_val = c_repo_type-offline ).


### PR DESCRIPTION
Fixes text when switching a repository from online to offline in settings

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/16b028f2-da26-4a0a-8649-caec4a68769e)

Click "switch to offline"

![image](https://github.com/abapGit/abapGit/assets/59966492/7a20da47-78de-480d-b8be-8c2063177b7c)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/3b7e1a69-722b-45dd-8ffa-7e3d2b7d99e8)
