### PR TITLE
Consolidate offline and online repo view

### DIFF
--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -35,6 +35,8 @@ CLASS zcl_abapgit_repo DEFINITION
       FOR zif_abapgit_repo~refresh .
     ALIASES set_dot_abapgit
       FOR zif_abapgit_repo~set_dot_abapgit .
+    ALIASES has_remote_source
+      FOR zif_abapgit_repo~has_remote_source .
 
     METHODS bind_listener
       IMPORTING
@@ -73,10 +75,6 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rt_objects) TYPE zif_abapgit_definitions=>ty_items_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS has_remote_source
-      ABSTRACT
-      RETURNING
-        VALUE(rv_yes) TYPE abap_bool .
     METHODS refresh_local_object
       IMPORTING
         !iv_obj_type TYPE tadir-object
@@ -436,6 +434,11 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
+  ENDMETHOD.
+
+
+  METHOD has_remote_source.
+    rv_yes = boolc( lines( mt_remote ) > 0 ).
   ENDMETHOD.
 
 

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -247,6 +247,8 @@ CLASS lcl_repo_mock IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_repo_srv~get_repo_from_url.
   ENDMETHOD.
+  METHOD zif_abapgit_repo~has_remote_source.
+  ENDMETHOD.
   METHOD zif_abapgit_repo~is_offline.
   ENDMETHOD.
   METHOD zif_abapgit_repo~deserialize.

--- a/src/repo/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/repo/zcl_abapgit_repo_content_list.clas.abap
@@ -31,11 +31,7 @@ CLASS zcl_abapgit_repo_content_list DEFINITION
     DATA: mo_repo TYPE REF TO zcl_abapgit_repo,
           mi_log  TYPE REF TO zif_abapgit_log.
 
-    METHODS build_repo_items_local_only
-      RETURNING VALUE(rt_repo_items) TYPE zif_abapgit_definitions=>ty_repo_item_tt
-      RAISING   zcx_abapgit_exception.
-
-    METHODS build_repo_items_with_remote
+    METHODS build_repo_items
       RETURNING VALUE(rt_repo_items) TYPE zif_abapgit_definitions=>ty_repo_item_tt
       RAISING   zcx_abapgit_exception.
 
@@ -112,48 +108,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD build_repo_items_local_only.
-
-    DATA: lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt,
-          ls_item  TYPE zif_abapgit_definitions=>ty_item.
-
-    FIELD-SYMBOLS: <ls_repo_item> LIKE LINE OF rt_repo_items,
-                   <ls_tadir>     LIKE LINE OF lt_tadir.
-
-
-    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read(
-      iv_package            = mo_repo->get_package( )
-      iv_ignore_subpackages = mo_repo->get_local_settings( )-ignore_subpackages
-      iv_only_local_objects = mo_repo->get_local_settings( )-only_local_objects
-      io_dot                = mo_repo->get_dot_abapgit( ) ).
-
-    LOOP AT lt_tadir ASSIGNING <ls_tadir>.
-      APPEND INITIAL LINE TO rt_repo_items ASSIGNING <ls_repo_item>.
-      <ls_repo_item>-obj_type  = <ls_tadir>-object.
-      <ls_repo_item>-obj_name  = <ls_tadir>-obj_name.
-      <ls_repo_item>-path      = <ls_tadir>-path.
-      <ls_repo_item>-srcsystem = <ls_tadir>-srcsystem.
-      MOVE-CORRESPONDING <ls_repo_item> TO ls_item.
-      <ls_repo_item>-inactive = boolc( zcl_abapgit_objects=>is_active( ls_item ) = abap_false ).
-      IF <ls_repo_item>-inactive = abap_true.
-        <ls_repo_item>-sortkey = c_sortkey-inactive.
-      ELSE.
-        <ls_repo_item>-sortkey = c_sortkey-default.      " Default sort key
-      ENDIF.
-
-      IF <ls_repo_item>-obj_type IS NOT INITIAL.
-        MOVE-CORRESPONDING <ls_repo_item> TO ls_item.
-        IF zcl_abapgit_objects=>exists( ls_item ) = abap_true.
-          <ls_repo_item>-changed_by = zcl_abapgit_objects=>changed_by( ls_item ).
-        ENDIF.
-        CLEAR ls_item.
-      ENDIF.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD build_repo_items_with_remote.
+  METHOD build_repo_items.
 
     DATA:
       lo_state      TYPE REF TO zcl_abapgit_item_state,
@@ -310,13 +265,18 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
   METHOD list.
 
+    FIELD-SYMBOLS <ls_repo_item> LIKE LINE OF rt_repo_items.
+
     mi_log->clear( ).
 
-    IF mo_repo->has_remote_source( ) = abap_true.
-      rt_repo_items = build_repo_items_with_remote( ).
-      check_repo_size( ).
-    ELSE.
-      rt_repo_items = build_repo_items_local_only( ).
+    rt_repo_items = build_repo_items( ).
+    check_repo_size( ).
+
+    IF mo_repo->has_remote_source( ) = abap_false.
+      " If there's no remote source, ignore the item state
+      LOOP AT rt_repo_items ASSIGNING <ls_repo_item>.
+        CLEAR: <ls_repo_item>-changes, <ls_repo_item>-lstate, <ls_repo_item>-rstate.
+      ENDLOOP.
     ENDIF.
 
     IF iv_by_folders = abap_true.

--- a/src/repo/zcl_abapgit_repo_offline.clas.abap
+++ b/src/repo/zcl_abapgit_repo_offline.clas.abap
@@ -5,9 +5,6 @@ CLASS zcl_abapgit_repo_offline DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-
-    METHODS has_remote_source
-        REDEFINITION .
   PROTECTED SECTION.
 
     METHODS reset_remote
@@ -18,11 +15,6 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_repo_offline IMPLEMENTATION.
-
-
-  METHOD has_remote_source.
-    rv_yes = boolc( lines( mt_remote ) > 0 ).
-  ENDMETHOD.
 
 
   METHOD reset_remote.

--- a/src/repo/zcl_abapgit_repo_online.clas.abap
+++ b/src/repo/zcl_abapgit_repo_online.clas.abap
@@ -37,8 +37,6 @@ CLASS zcl_abapgit_repo_online DEFINITION
         REDEFINITION .
     METHODS zif_abapgit_repo~get_name
         REDEFINITION .
-    METHODS has_remote_source
-        REDEFINITION .
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -145,11 +143,6 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
       set_dot_abapgit( lo_dot_abapgit ).
     ENDIF.
 
-  ENDMETHOD.
-
-
-  METHOD has_remote_source.
-    rv_yes = abap_true.
   ENDMETHOD.
 
 

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -78,4 +78,8 @@ INTERFACE zif_abapgit_repo
     RAISING
       zcx_abapgit_exception .
 
+  METHODS has_remote_source
+    RETURNING
+      VALUE(rv_yes) TYPE abap_bool .
+
 ENDINTERFACE.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -222,6 +222,10 @@ CLASS ltd_repo IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD zif_abapgit_repo~has_remote_source.
+
+  ENDMETHOD.
+
   METHOD zif_abapgit_repo~is_offline.
 
   ENDMETHOD.


### PR DESCRIPTION
The object list of offline and online repos was determined in different ways. Offline had no serializing which had side effects like missing `.abapgit.xml` in the view. 

This change consolidates the logic so offline repos behave the same as online. When you open an offline repo, objects will be serialized. `.abapgit.xml` and `.apack-manifest.xml` will be visible immediately.

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/4aac142b-d345-4341-b0b1-e493423cc929)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/efe239d6-2b46-46b2-bc90-fd519ae05017)


Furthermore, this moves the `has_remote_source` method to `zcl_abapgit_repo`. Only `reset_remote` remains in `zcl_abapgit_repo_offline`. 

Closes #6129