### PR TITLE
Fix APACK for namespaces

### DIFF
--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -199,6 +199,15 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
                seometarel~refclsname = zif_abapgit_apack_definitions=>c_apack_interface_sap
          ORDER BY clsname devclass.
 
+      SELECT seometarel~clsname tadir~devclass FROM seometarel "#EC CI_NOORDER
+         INNER JOIN tadir ON seometarel~clsname = tadir~obj_name "#EC CI_BUFFJOIN
+         APPENDING TABLE lt_manifest_implementation
+         WHERE tadir~pgmid = 'R3TR' AND
+               tadir~object = 'CLAS' AND
+               seometarel~version = '1' AND
+               seometarel~refclsname LIKE zif_abapgit_apack_definitions=>c_apack_interface_nspc
+         ORDER BY clsname devclass.
+
       LOOP AT lt_packages INTO lv_package.
         READ TABLE lt_manifest_implementation INTO ls_manifest_implementation WITH KEY devclass = lv_package.
         IF sy-subrc = 0.

--- a/src/apack/zif_abapgit_apack_definitions.intf.abap
+++ b/src/apack/zif_abapgit_apack_definitions.intf.abap
@@ -27,7 +27,7 @@ INTERFACE zif_abapgit_apack_definitions PUBLIC .
     BEGIN OF ty_descriptor.
       INCLUDE TYPE ty_descriptor_wo_dependencies.
   TYPES:
-    dependencies TYPE ty_dependencies,
+      dependencies TYPE ty_dependencies,
     END OF ty_descriptor,
 
     ty_descriptors TYPE STANDARD TABLE OF ty_descriptor WITH NON-UNIQUE DEFAULT KEY.
@@ -36,4 +36,5 @@ INTERFACE zif_abapgit_apack_definitions PUBLIC .
   CONSTANTS c_repository_type_abapgit TYPE ty_repository_type VALUE 'abapGit' ##NO_TEXT.
   CONSTANTS c_apack_interface_sap TYPE seoclsname VALUE 'IF_APACK_MANIFEST' ##NO_TEXT.
   CONSTANTS c_apack_interface_cust TYPE seoclsname VALUE 'ZIF_APACK_MANIFEST' ##NO_TEXT.
+  CONSTANTS c_apack_interface_nspc TYPE seoclsname VALUE '/%/IF_APACK_MANIFEST' ##NO_TEXT.
 ENDINTERFACE.


### PR DESCRIPTION
You can now use `/namespace/if_apack_manifest` (copy of `if_apack_manifest` or `zif_apack_manifest`) to define the APACK details in a namespaced project.

Closes #5363