### PR TITLE
Fix deletion/uninstall when using local settings

### DIFF
--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -856,26 +856,10 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
   METHOD zif_abapgit_repo~get_tadir_objects.
 
-    DATA:
-      lv_ignore_subpackages TYPE abap_bool,
-      lv_only_local_objects TYPE abap_bool.
-
-    IF iv_ignore_subpackages IS SUPPLIED.
-      lv_ignore_subpackages = iv_ignore_subpackages.
-    ELSE.
-      lv_ignore_subpackages = get_local_settings( )-ignore_subpackages.
-    ENDIF.
-
-    IF iv_only_local_objects IS SUPPLIED.
-      lv_only_local_objects = iv_only_local_objects.
-    ELSE.
-      lv_only_local_objects = get_local_settings( )-only_local_objects.
-    ENDIF.
-
     rt_tadir = zcl_abapgit_factory=>get_tadir( )->read(
       iv_package            = get_package( )
-      iv_ignore_subpackages = lv_ignore_subpackages
-      iv_only_local_objects = lv_only_local_objects
+      iv_ignore_subpackages = get_local_settings( )-ignore_subpackages
+      iv_only_local_objects = get_local_settings( )-only_local_objects
       io_dot                = get_dot_abapgit( ) ).
 
   ENDMETHOD.

--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -437,11 +437,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD has_remote_source.
-    rv_yes = boolc( lines( mt_remote ) > 0 ).
-  ENDMETHOD.
-
-
   METHOD normalize_local_settings.
 
     cs_local_settings-labels = zcl_abapgit_repo_labels=>normalize( cs_local_settings-labels ).

--- a/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_checksums.clas.testclasses.abap
@@ -257,6 +257,8 @@ CLASS lcl_repo_mock IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_repo~get_dot_abapgit.
   ENDMETHOD.
+  METHOD zif_abapgit_repo~get_tadir_objects.
+  ENDMETHOD.
   METHOD zif_abapgit_repo_srv~is_repo_installed.
   ENDMETHOD.
   METHOD zif_abapgit_repo_srv~list.

--- a/src/repo/zcl_abapgit_repo_srv.clas.abap
+++ b/src/repo/zcl_abapgit_repo_srv.clas.abap
@@ -656,7 +656,7 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Not authorized' ).
     ENDIF.
 
-    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( ii_repo->get_package( ) ).
+    lt_tadir = lo_repo->get_tadir_objects( ).
 
     TRY.
         zcl_abapgit_objects=>delete( it_tadir  = lt_tadir

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -19,6 +19,15 @@ INTERFACE zif_abapgit_repo
     RETURNING
       VALUE(rs_settings) TYPE zif_abapgit_persistence=>ty_repo-local_settings .
 
+  METHODS get_tadir_objects
+    IMPORTING
+      !iv_ignore_subpackages TYPE abap_bool OPTIONAL
+      !iv_only_local_objects TYPE abap_bool OPTIONAL
+    RETURNING
+      VALUE(rt_tadir)        TYPE zif_abapgit_definitions=>ty_tadir_tt
+    RAISING
+      zcx_abapgit_exception .
+
   METHODS get_files_local_filtered
     IMPORTING
       !ii_obj_filter  TYPE REF TO zif_abapgit_object_filter

--- a/src/repo/zif_abapgit_repo.intf.abap
+++ b/src/repo/zif_abapgit_repo.intf.abap
@@ -20,11 +20,8 @@ INTERFACE zif_abapgit_repo
       VALUE(rs_settings) TYPE zif_abapgit_persistence=>ty_repo-local_settings .
 
   METHODS get_tadir_objects
-    IMPORTING
-      !iv_ignore_subpackages TYPE abap_bool OPTIONAL
-      !iv_only_local_objects TYPE abap_bool OPTIONAL
     RETURNING
-      VALUE(rt_tadir)        TYPE zif_abapgit_definitions=>ty_tadir_tt
+      VALUE(rt_tadir) TYPE zif_abapgit_definitions=>ty_tadir_tt
     RAISING
       zcx_abapgit_exception .
 

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.testclasses.abap
@@ -218,6 +218,10 @@ CLASS ltd_repo IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD zif_abapgit_repo~get_tadir_objects.
+
+  ENDMETHOD.
+
   METHOD zif_abapgit_repo~get_package.
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -77,7 +77,7 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
     DATA ls_tadir LIKE LINE OF lt_tadir.
     DATA ls_row   LIKE LINE OF rt_tadir.
 
-    lt_tadir = mo_repo->get_tadir_objects( iv_only_local_objects = abap_true ).
+    lt_tadir = mo_repo->get_tadir_objects( ).
 
     LOOP AT lt_tadir INTO ls_tadir.
       CLEAR ls_row.

--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -77,9 +77,7 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
     DATA ls_tadir LIKE LINE OF lt_tadir.
     DATA ls_row   LIKE LINE OF rt_tadir.
 
-    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read(
-      iv_package            = mo_repo->get_package( )
-      iv_only_local_objects = abap_true ).
+    lt_tadir = mo_repo->get_tadir_objects( iv_only_local_objects = abap_true ).
 
     LOOP AT lt_tadir INTO ls_tadir.
       CLEAR ls_row.

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -649,7 +649,7 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     lv_repo_name = lo_repo->get_name( ).
 
     lv_package = lo_repo->get_package( ).
-    lt_tadir   = zcl_abapgit_factory=>get_tadir( )->read( lv_package ).
+    lt_tadir   = lo_repo->get_tadir_objects( ).
 
     IF lines( lt_tadir ) > 0.
 


### PR DESCRIPTION
If the local options "ignore subpackages" or "only local objects" are turned on, then deleting all objects or uninstalling the repository will also delete all subpackages and objects included in the subpackages and objects that are not local to the system.

Reproduce issue:

1. Create repo for https://github.com/abapGit-tests/DEVC_main_sub, branch `with_programs`
2. Pull all objects
3. Go to local settings and turn on "ignore subpackages" (sub-package and sub-program show as diffs which is ok)
4. Select "Advanced > Remove Objects" or "Uninstall"
5. Popup shows "4 objects" although the sub-package/program should be ignored
6. Confirm
7. Sub-package and program are deleted

The fix centralizes the tadir object selection and ensures that local settings "ignore subpackages" or "only local objects" are respected when selecting objects.

