### PR TITLE
Repo List: Make labels clickable

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -761,8 +761,9 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
     IF mt_all_labels IS NOT INITIAL.
       ii_html->td(
         iv_content = zcl_abapgit_gui_chunk_lib=>render_label_list(
-          it_labels = is_repo-labels
-          io_label_colors = mo_label_colors )
+          it_labels           = is_repo-labels
+          io_label_colors     = mo_label_colors
+          iv_clickable_action = c_action-label_filter )
         iv_class   = 'labels' ).
     ENDIF.
 


### PR DESCRIPTION
Clicking a label in the list of repos filters the list accordingly

![image](https://github.com/abapGit/abapGit/assets/59966492/da5342d2-c247-487a-ba2e-dc7ca14aa3bf)
