### PR TITLE
move method `get_transport_layer` to private

### DIFF
--- a/src/objects/core/zcl_abapgit_dependencies.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_dependencies.clas.testclasses.abap
@@ -83,10 +83,6 @@ CLASS ltcl_sap_package IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_sap_package~get_transport_layer. "##needed
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_sap_package~list_superpackages. "##needed
 
   ENDMETHOD.

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.testclasses.abap
@@ -104,10 +104,6 @@ CLASS ltcl_folder_logic_package IMPLEMENTATION.
     RETURN.
   ENDMETHOD.
 
-  METHOD zif_abapgit_sap_package~get_transport_layer.
-    RETURN.
-  ENDMETHOD.
-
   METHOD zif_abapgit_sap_package~create.
     RETURN.
   ENDMETHOD.
@@ -196,10 +192,6 @@ CLASS ltcl_folder_logic IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_sap_package~get_transport_type.
-    RETURN.
-  ENDMETHOD.
-
-  METHOD zif_abapgit_sap_package~get_transport_layer.
     RETURN.
   ENDMETHOD.
 
@@ -417,10 +409,6 @@ CLASS ltcl_folder_logic_namespaces IMPLEMENTATION.
     RETURN.
   ENDMETHOD.
 
-  METHOD zif_abapgit_sap_package~get_transport_layer.
-    RETURN.
-  ENDMETHOD.
-
   METHOD zif_abapgit_sap_package~create.
     RETURN.
   ENDMETHOD.
@@ -557,10 +545,6 @@ CLASS ltcl_folder_logic_no_parent IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_sap_package~get_transport_type.
-    RETURN.
-  ENDMETHOD.
-
-  METHOD zif_abapgit_sap_package~get_transport_layer.
     RETURN.
   ENDMETHOD.
 

--- a/src/objects/sap/zcl_abapgit_sap_package.clas.abap
+++ b/src/objects/sap/zcl_abapgit_sap_package.clas.abap
@@ -14,6 +14,12 @@ CLASS zcl_abapgit_sap_package DEFINITION
   PRIVATE SECTION.
     DATA: mv_package TYPE devclass.
 
+    METHODS get_transport_layer
+      RETURNING
+        VALUE(rv_transport_layer) TYPE devlayer
+      RAISING
+        zcx_abapgit_exception .
+
 ENDCLASS.
 
 
@@ -90,7 +96,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
 
     " For transportable packages, get default transport and layer
     IF ls_package-devclass(1) <> '$' AND ls_package-pdevclass IS INITIAL.
-      ls_package-pdevclass = zif_abapgit_sap_package~get_transport_layer( ).
+      ls_package-pdevclass = get_transport_layer( ).
     ENDIF.
 
     cl_package_factory=>create_new_package(
@@ -230,7 +236,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_sap_package~get_transport_layer.
+  METHOD get_transport_layer.
 
     " Get default transport layer
     CALL FUNCTION 'TR_GET_TRANSPORT_TARGET'

--- a/src/objects/sap/zif_abapgit_sap_package.intf.abap
+++ b/src/objects/sap/zif_abapgit_sap_package.intf.abap
@@ -57,9 +57,4 @@ INTERFACE zif_abapgit_sap_package
       VALUE(rs_transport_type) TYPE zif_abapgit_definitions=>ty_transport_type
     RAISING
       zcx_abapgit_exception .
-  METHODS get_transport_layer
-    RETURNING
-      VALUE(rv_transport_layer) TYPE devlayer
-    RAISING
-      zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/objects/sap/zif_abapgit_sap_package.intf.abap
+++ b/src/objects/sap/zif_abapgit_sap_package.intf.abap
@@ -26,7 +26,7 @@ INTERFACE zif_abapgit_sap_package
       zcx_abapgit_exception .
   METHODS read_parent
     RETURNING
-      VALUE(rv_parentcl) TYPE tdevc-parentcl
+      VALUE(rv_parentcl) TYPE devclass
     RAISING
       zcx_abapgit_exception .
   METHODS read_description

--- a/src/repo/zcl_abapgit_repo_status.clas.testclasses.abap
+++ b/src/repo/zcl_abapgit_repo_status.clas.testclasses.abap
@@ -109,10 +109,6 @@ CLASS ltcl_run_checks IMPLEMENTATION.
     RETURN.
   ENDMETHOD.
 
-  METHOD zif_abapgit_sap_package~get_transport_layer.
-    RETURN.
-  ENDMETHOD.
-
   METHOD zif_abapgit_sap_package~create.
     RETURN.
   ENDMETHOD.

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.testclasses.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.testclasses.abap
@@ -320,10 +320,6 @@ CLASS ltcl_sap_package_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_sap_package~get_transport_layer.
-
-  ENDMETHOD.
-
   METHOD zif_abapgit_sap_package~list_subpackages.
 
   ENDMETHOD.


### PR DESCRIPTION
looks like it doesnt need to be public

plus this is one less concept/data element in public interfaces, I cannot find the transport layer as a concept in ABAP Cloud, https://abapedia.org/steampunk-2305-api/