### PR TITLE
packages: remove `scompkdtln` from public scope

### DIFF
--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -170,18 +170,19 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
 
     DATA: lv_length               TYPE i,
           lv_parent               TYPE devclass,
-          ls_package              TYPE scompkdtln,
+          ls_package              TYPE zif_abapgit_sap_package=>ty_create,
           lv_new                  TYPE string,
           lv_path                 TYPE string,
           lv_absolute_name        TYPE string,
           lv_folder_logic         TYPE string,
           lt_unique_package_names TYPE HASHED TABLE OF devclass WITH UNIQUE KEY table_line.
 
-    lv_length  = strlen( io_dot->get_starting_folder( ) ).
+    lv_length = strlen( io_dot->get_starting_folder( ) ).
     IF lv_length > strlen( iv_path ).
 * treat as not existing locally
       RETURN.
     ENDIF.
+
     lv_path    = iv_path+lv_length.
     lv_parent  = iv_top.
     rv_package = iv_top.

--- a/src/objects/sap/zcl_abapgit_sap_package.clas.abap
+++ b/src/objects/sap/zcl_abapgit_sap_package.clas.abap
@@ -66,7 +66,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
 
     DATA: lv_err     TYPE string,
           li_package TYPE REF TO if_package,
-          ls_package LIKE is_package.
+          ls_package TYPE scompkdtln.
 
 
     ASSERT NOT is_package-devclass IS INITIAL.
@@ -86,7 +86,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    ls_package = is_package.
+    MOVE-CORRESPONDING is_package TO ls_package.
 
     " Set software component to 'HOME' if none is set at this point.
     " Otherwise SOFTWARE_COMPONENT_INVALID will be raised.
@@ -173,7 +173,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
   METHOD zif_abapgit_sap_package~create_child.
 
     DATA: li_parent TYPE REF TO if_package,
-          ls_child  TYPE scompkdtln.
+          ls_child  TYPE zif_abapgit_sap_package=>ty_create.
 
 
     cl_package_factory=>load_package(
@@ -206,7 +206,7 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
 
   METHOD zif_abapgit_sap_package~create_local.
 
-    DATA: ls_package TYPE scompkdtln.
+    DATA: ls_package TYPE zif_abapgit_sap_package=>ty_create.
 
 
     ls_package-devclass  = mv_package.

--- a/src/objects/sap/zif_abapgit_sap_package.intf.abap
+++ b/src/objects/sap/zif_abapgit_sap_package.intf.abap
@@ -5,12 +5,22 @@ INTERFACE zif_abapgit_sap_package
   TYPES:
     ty_devclass_tt TYPE STANDARD TABLE OF devclass WITH DEFAULT KEY .
 
+  TYPES: BEGIN OF ty_create,
+           devclass  TYPE devclass,
+           dlvunit   TYPE tdevc-dlvunit,
+           component TYPE c LENGTH 20,
+           ctext     TYPE c LENGTH 60,
+           parentcl  TYPE devclass,
+           pdevclass TYPE c LENGTH 4,
+           as4user   TYPE usnam,
+         END OF ty_create.
+
   METHODS validate_name
     RAISING
       zcx_abapgit_exception .
   METHODS create
     IMPORTING
-      !is_package TYPE scompkdtln
+      !is_package TYPE ty_create
     RAISING
       zcx_abapgit_exception .
   METHODS create_local

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -112,7 +112,7 @@ CLASS zcl_abapgit_services_repo DEFINITION
         zcx_abapgit_exception .
     CLASS-METHODS raise_error_if_package_exists
       IMPORTING
-        iv_devclass TYPE scompkdtln-devclass
+        iv_devclass TYPE devclass
       RAISING
         zcx_abapgit_exception.
     CLASS-METHODS check_for_restart
@@ -256,7 +256,7 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
   METHOD create_package.
 
-    DATA ls_package_data TYPE scompkdtln.
+    DATA ls_package_data TYPE zif_abapgit_sap_package=>ty_create.
     DATA lv_create       TYPE abap_bool.
     DATA li_popup        TYPE REF TO zif_abapgit_popups.
 

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -608,6 +608,9 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
 
   METHOD zif_abapgit_popups~popup_to_create_package.
+
+    DATA ls_data TYPE scompkdtln.
+
     IF zcl_abapgit_factory=>get_function_module( )->function_exists( 'PB_POPUP_PACKAGE_CREATE' ) = abap_false.
 * looks like the function module used does not exist on all
 * versions since 702, so show an error
@@ -617,10 +620,11 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     CALL FUNCTION 'PB_POPUP_PACKAGE_CREATE'
       CHANGING
-        p_object_data    = es_package_data
+        p_object_data    = ls_data
       EXCEPTIONS
         action_cancelled = 1.
     ev_create = boolc( sy-subrc = 0 ).
+    MOVE-CORRESPONDING ls_data TO es_package_data.
   ENDMETHOD.
 
 

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -89,7 +89,7 @@ INTERFACE zif_abapgit_popups
       zcx_abapgit_exception .
   METHODS popup_to_create_package
     EXPORTING
-      !es_package_data TYPE scompkdtln
+      !es_package_data TYPE zif_abapgit_sap_package=>ty_create
       !ev_create       TYPE abap_bool
     RAISING
       zcx_abapgit_exception .


### PR DESCRIPTION
new type `zif_abapgit_sap_package=>ty_create` added

this will help replacing the package popup with a page(when we get that far)

plus more ABAP cloud + open-abap compatible