### PR TITLE
Add "Ignore" option for ABAP Language Version

### DIFF
--- a/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
@@ -617,7 +617,10 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
           RECEIVING
             result = lv_json_as_xstring.
 
-        lv_json_as_xstring_wo_alv = remove_abap_language_version( lv_json_as_xstring ).
+        " Only remove ABAP language version if repository is set to ignore it
+        IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+          lv_json_as_xstring_wo_alv = remove_abap_language_version( lv_json_as_xstring ).
+        ENDIF.
 
         zif_abapgit_object~mo_files->add_raw(
           iv_ext  = 'json'

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -100,7 +100,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
     " Used during serializing of objects
     IF ms_item-abap_language_version <> zcl_abapgit_abap_language_vers=>c_any_abap_language_version.
-      " ABAP language is defined in repo setting so there's no need to serialize it
+      " ABAP language version is defined in repo setting so there's no need to serialize it
       CLEAR cv_abap_language_version.
     ENDIF.
 
@@ -302,7 +302,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
     " Used during deserializing of objects
     IF ms_item-abap_language_version <> zcl_abapgit_abap_language_vers=>c_any_abap_language_version.
-      " ABAP language is defined in repo setting so set it accordingly
+      " ABAP language version is defined in repo setting so set it accordingly
       cv_abap_language_version = ms_item-abap_language_version.
     ENDIF.
 

--- a/src/repo/zif_abapgit_dot_abapgit.intf.abap
+++ b/src/repo/zif_abapgit_dot_abapgit.intf.abap
@@ -34,7 +34,8 @@ INTERFACE zif_abapgit_dot_abapgit PUBLIC.
       standard          TYPE string VALUE 'standard',
       key_user          TYPE string VALUE 'keyUser',
       cloud_development TYPE string VALUE 'cloudDevelopment',
-      undefined         TYPE string VALUE 'undefined',
+      ignore            TYPE string VALUE 'ignore',
+      undefined         TYPE string VALUE 'undefined', " any
     END OF c_abap_language_version.
 
 ENDINTERFACE.

--- a/src/ui/pages/zcl_abapgit_gui_page_addofflin.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_addofflin.clas.abap
@@ -165,6 +165,9 @@ CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
         iv_label       = 'Any'
         iv_value       = ''
       )->option(
+        iv_label       = 'Ignore'
+        iv_value       = zif_abapgit_dot_abapgit=>c_abap_language_version-ignore
+      )->option(
         iv_label       = 'Standard'
         iv_value       = zif_abapgit_dot_abapgit=>c_abap_language_version-standard
       )->option(

--- a/src/ui/pages/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_addonline.clas.abap
@@ -180,6 +180,9 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
         iv_label       = 'Any'
         iv_value       = ''
       )->option(
+        iv_label       = 'Ignore'
+        iv_value       = zif_abapgit_dot_abapgit=>c_abap_language_version-ignore
+      )->option(
         iv_label       = 'Standard'
         iv_value       = zif_abapgit_dot_abapgit=>c_abap_language_version-standard
       )->option(

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -210,6 +210,9 @@ CLASS zcl_abapgit_gui_page_sett_repo IMPLEMENTATION.
         iv_label       = 'Any (Object-specific ABAP Language Version)'
         iv_value       = ''
       )->option(
+        iv_label       = 'Ignore (ABAP Language Version not serialized)'
+        iv_value       = zif_abapgit_dot_abapgit=>c_abap_language_version-ignore
+      )->option(
         iv_label       = 'Standard ABAP'
         iv_value       = zif_abapgit_dot_abapgit=>c_abap_language_version-standard
       )->option(

--- a/src/utils/zcl_abapgit_abap_language_vers.clas.abap
+++ b/src/utils/zcl_abapgit_abap_language_vers.clas.abap
@@ -5,8 +5,10 @@ CLASS zcl_abapgit_abap_language_vers DEFINITION
 
   PUBLIC SECTION.
 
-    CONSTANTS c_any_abap_language_version TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version VALUE '*'.
-    CONSTANTS c_feature_flag TYPE string VALUE 'ALAV'.
+    CONSTANTS:
+      c_any_abap_language_version TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version VALUE '*',
+      c_no_abap_language_version  TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version VALUE '-',
+      c_feature_flag              TYPE string VALUE 'ALAV'.
 
     METHODS constructor
       IMPORTING
@@ -191,6 +193,8 @@ CLASS zcl_abapgit_abap_language_vers IMPLEMENTATION.
         rv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version_src-key_user.
       WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-cloud_development.
         rv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version_src-cloud_development.
+      WHEN c_no_abap_language_version.
+        rv_abap_language_version = c_no_abap_language_version.
       WHEN OTHERS. " undefined or feature off
         rv_abap_language_version = c_any_abap_language_version.
     ENDCASE.


### PR DESCRIPTION
Introduce new mode that will ignore the ABAP Language Version when serializing objects ("Lars Mode").

Ref #6154