### PR TITLE
Fix filename for export to ZIP

### DIFF
--- a/src/utils/zcl_abapgit_zip.clas.abap
+++ b/src/utils/zcl_abapgit_zip.clas.abap
@@ -210,7 +210,7 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
     lv_package_escaped = iv_package.
     REPLACE ALL OCCURRENCES OF '/' IN lv_package_escaped WITH '#'.
-    lv_default = |{ lv_package_escaped }_{ sy-datlo }_{ sy-timlo }|.
+    lv_default = |{ lv_package_escaped }_{ sy-datlo }_{ sy-timlo }.zip|.
 
     lv_zip_xstring = export(
      is_local_settings = ls_local_settings


### PR DESCRIPTION
Add extension for non-Windows platforms (SAP GUI for Windows adds extension automatically).

Closes #6658 