### PR TITLE
debug page: open external links in new window

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -145,7 +145,8 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
     ri_html->add( '<br><div>' ).
     ri_html->add_a(
       iv_txt = 'Contribution guidelines for abapGit'
-      iv_act = 'https://github.com/abapGit/abapGit/blob/main/CONTRIBUTING.md'
+      iv_act = |{ zif_abapgit_definitions=>c_action-url
+        }?url=https://github.com/abapGit/abapGit/blob/main/CONTRIBUTING.md|
       iv_typ = zif_abapgit_html=>c_action_type-url ).
     ri_html->add( '</div>' ).
 
@@ -297,7 +298,7 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
     rv_html = rv_html && li_html->a(
       iv_txt = 'Complete list of object types supported by abapGit'
-      iv_act = 'https://docs.abapgit.org/ref-supported.html'
+      iv_act = |{ zif_abapgit_definitions=>c_action-url }?url=https://docs.abapgit.org/ref-supported.html|
       iv_typ = zif_abapgit_html=>c_action_type-url ).
 
     rv_html = rv_html && |<br><br>Supported object types in <strong>this</strong> system:<br><br>|.


### PR DESCRIPTION
There might be some settings which allows showing it properly inline, but not necessary, just open in new window

![image](https://github.com/abapGit/abapGit/assets/5888506/c8c993b6-9bdd-430d-bdc9-d2baa1a47ca5)
