### PR TITLE
remove some use of `tihttpnvp`

### DIFF
--- a/src/ui/core/zcl_abapgit_gui_event.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui_event.clas.abap
@@ -30,9 +30,15 @@ CLASS zcl_abapgit_gui_event DEFINITION
 
     CLASS-DATA gv_non_breaking_space TYPE string .
 
+    TYPES: BEGIN OF ty_name_value,
+             name  TYPE string,
+             value TYPE string,
+           END OF ty_name_value.
+    TYPES ty_name_value_tt TYPE STANDARD TABLE OF ty_name_value WITH DEFAULT KEY.
+
     METHODS fields_to_map
       IMPORTING
-        it_fields            TYPE tihttpnvp
+        it_fields            TYPE ty_name_value_tt
       RETURNING
         VALUE(ro_string_map) TYPE REF TO zcl_abapgit_string_map
       RAISING
@@ -43,19 +49,19 @@ CLASS zcl_abapgit_gui_event DEFINITION
         !it_post_data    TYPE zif_abapgit_html_viewer=>ty_post_data
         !iv_upper_cased  TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rt_fields) TYPE tihttpnvp .
+        VALUE(rt_fields) TYPE ty_name_value_tt .
     CLASS-METHODS parse_fields
       IMPORTING
         !iv_string       TYPE clike
         !iv_upper_cased  TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rt_fields) TYPE tihttpnvp .
+        VALUE(rt_fields) TYPE ty_name_value_tt .
 
     CLASS-METHODS parse_fields_upper_case_name
       IMPORTING
         !iv_string       TYPE clike
       RETURNING
-        VALUE(rt_fields) TYPE tihttpnvp .
+        VALUE(rt_fields) TYPE ty_name_value_tt .
 
     CLASS-METHODS translate_postdata
       IMPORTING
@@ -65,7 +71,7 @@ CLASS zcl_abapgit_gui_event DEFINITION
 
     CLASS-METHODS field_keys_to_upper
       CHANGING
-        !ct_fields TYPE tihttpnvp .
+        !ct_fields TYPE ty_name_value_tt .
     CLASS-METHODS unescape
       IMPORTING
         !iv_string       TYPE string

--- a/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_action_utils.clas.abap
@@ -37,23 +37,29 @@ CLASS zcl_abapgit_html_action_utils DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
 
+    TYPES: BEGIN OF ty_name_value,
+             name  TYPE string,
+             value TYPE string,
+           END OF ty_name_value.
+    TYPES ty_name_value_tt TYPE STANDARD TABLE OF ty_name_value WITH DEFAULT KEY.
+
     CLASS-METHODS add_field
       IMPORTING
         !iv_name  TYPE string
         !ig_field TYPE any
       CHANGING
-        !ct_field TYPE tihttpnvp .
+        !ct_field TYPE ty_name_value_tt .
 
     CLASS-METHODS fields_to_string
       IMPORTING
-        !it_fields       TYPE tihttpnvp
+        !it_fields       TYPE ty_name_value_tt
       RETURNING
         VALUE(rv_string) TYPE string.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
+CLASS zcl_abapgit_html_action_utils IMPLEMENTATION.
 
 
   METHOD add_field.
@@ -82,7 +88,7 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
   METHOD dbkey_encode.
 
-    DATA lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE ty_name_value_tt.
 
     add_field( EXPORTING iv_name = 'TYPE'
                          ig_field = is_key-type CHANGING ct_field = lt_fields ).
@@ -96,7 +102,7 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
   METHOD dir_encode.
 
-    DATA lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE ty_name_value_tt.
     add_field( EXPORTING iv_name = 'PATH'
                          ig_field = iv_path CHANGING ct_field = lt_fields ).
     rv_string = fields_to_string( lt_fields ).
@@ -127,7 +133,7 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
   METHOD file_encode.
 
-    DATA lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE ty_name_value_tt.
 
 
     add_field(
@@ -167,7 +173,7 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
   METHOD jump_encode.
 
-    DATA lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE ty_name_value_tt.
 
 
     add_field( EXPORTING iv_name = 'TYPE'
@@ -187,7 +193,7 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
   METHOD obj_encode.
 
-    DATA lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE ty_name_value_tt.
 
 
     add_field( EXPORTING iv_name = 'KEY'


### PR DESCRIPTION
it is released in ABAP cloud, but its line type is not

for these occurrences theres no need to use a DDIC type, replaced with local type definition

getting rid of 2 shims,
https://github.com/abapGit/testyTest/blob/main/shims/zcl_abapgit_gui_event.prog.abap
https://github.com/abapGit/testyTest/blob/main/shims/zcl_abapgit_html_action_utils.prog.abap