### PR TITLE
Check for ABAP language version during serialize

### DIFF
--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -87,7 +87,9 @@ CLASS zcl_abapgit_objects_super DEFINITION
         !cv_abap_language_version TYPE uccheck.
     METHODS clear_abap_language_version
       CHANGING
-        !cv_abap_language_version TYPE uccheck.
+        !cv_abap_language_version TYPE uccheck
+      RAISING
+        zcx_abapgit_exception .
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -99,9 +101,14 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
   METHOD clear_abap_language_version.
 
     " Used during serializing of objects
-    IF ms_item-abap_language_version <> zcl_abapgit_abap_language_vers=>c_any_abap_language_version.
-      " ABAP language version is defined in repo setting so there's no need to serialize it
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      " Ignore ABAP language version
       CLEAR cv_abap_language_version.
+    ELSEIF ms_item-abap_language_version <> zcl_abapgit_abap_language_vers=>c_any_abap_language_version.
+      " Check if ABAP language version matches repository setting
+      zcl_abapgit_abap_language_vers=>check_abap_language_version(
+        iv_abap_language_version = cv_abap_language_version
+        is_item                  = ms_item ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -84,7 +84,9 @@ CLASS zcl_abapgit_objects_super DEFINITION
         zcx_abapgit_exception .
     METHODS set_abap_language_version
       CHANGING
-        !cv_abap_language_version TYPE uccheck.
+        !cv_abap_language_version TYPE uccheck
+      RAISING
+        zcx_abapgit_exception .
     METHODS clear_abap_language_version
       CHANGING
         !cv_abap_language_version TYPE uccheck
@@ -308,9 +310,14 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
   METHOD set_abap_language_version.
 
     " Used during deserializing of objects
-    IF ms_item-abap_language_version <> zcl_abapgit_abap_language_vers=>c_any_abap_language_version.
-      " ABAP language version is defined in repo setting so set it accordingly
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      " ABAP language version is derived from object type and target package (see zcl_abapgit_objects->deserialize)
       cv_abap_language_version = ms_item-abap_language_version.
+    ELSEIF ms_item-abap_language_version <> zcl_abapgit_abap_language_vers=>c_any_abap_language_version.
+      " Check if ABAP language version matches repository setting
+      zcl_abapgit_abap_language_vers=>check_abap_language_version(
+        iv_abap_language_version = cv_abap_language_version
+        is_item                  = ms_item ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
If the repository is set to a specific ABAP language version (standard, key user, cloud), objects that do not match the setting will raise an error message.

If the ABAP language version is undefined or ignored, there's no check/error.

Also more tests and fixes.

Ref #6154 

Examples:

![image](https://github.com/abapGit/abapGit/assets/59966492/124b5546-0c3b-4d7a-b891-51a7313ee41c)

![image](https://github.com/abapGit/abapGit/assets/59966492/740e213d-2579-42f8-beaa-ab6d8ae1e878)
