### PR TITLE
TABU: Fix deserializing data config

### DIFF
--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -202,6 +202,10 @@ CLASS zcl_abapgit_filename_logic IMPLEMENTATION.
           CHANGING
             cs_item     = cs_item.
       CATCH cx_sy_dyn_call_illegal_class ##NO_HANDLER.
+        " Map data config to TABU object type
+        IF cs_item-obj_type = 'CONF'.
+          cs_item-obj_type = 'TABU'.
+        ENDIF.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -201,7 +201,7 @@ CLASS zcl_abapgit_filename_logic IMPLEMENTATION.
             iv_package  = iv_package
           CHANGING
             cs_item     = cs_item.
-      CATCH cx_sy_dyn_call_illegal_class ##NO_HANDLER.
+      CATCH cx_sy_dyn_call_illegal_class.
         " Map data config to TABU object type
         IF cs_item-obj_type = 'CONF'.
           cs_item-obj_type = 'TABU'.

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.testclasses.abap
@@ -171,6 +171,9 @@ CLASS ltcl_run_checks IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = 'ZTEST=========================VC'
       act = ls_item-obj_name ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_false
+      act = lv_is_xml ).
 
     zcl_abapgit_filename_logic=>file_to_object(
      EXPORTING
@@ -188,10 +191,13 @@ CLASS ltcl_run_checks IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = 'ZMIME_<>_?'
       act = ls_item-obj_name ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_false
+      act = lv_is_xml ).
 
     zcl_abapgit_filename_logic=>file_to_object(
      EXPORTING
-       iv_filename = 'ztest(name).w3mi.data,json'
+       iv_filename = 'ztest(name).w3mi.data.json'
        iv_path     = '/src/'
        iv_devclass = '$PACK'
        io_dot      = mo_dot
@@ -205,6 +211,9 @@ CLASS ltcl_run_checks IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = 'ZTEST(NAME)'
       act = ls_item-obj_name ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_false
+      act = lv_is_xml ).
 
     " AFF file
     zcl_abapgit_filename_logic=>file_to_object(
@@ -227,7 +236,6 @@ CLASS ltcl_run_checks IMPLEMENTATION.
       exp = abap_true
       act = lv_is_json ).
 
-
     " AFF file with namespace
     zcl_abapgit_filename_logic=>file_to_object(
       EXPORTING
@@ -248,6 +256,39 @@ CLASS ltcl_run_checks IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       exp = abap_true
       act = lv_is_json ).
+
+    " Data TABU
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'zdata.tabu.json'
+        iv_path     = '/src/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'TABU'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZDATA'
+      act = ls_item-obj_name ).
+
+    zcl_abapgit_filename_logic=>file_to_object(
+      EXPORTING
+        iv_filename = 'zdata.conf.json'
+        iv_path     = '/src/'
+        iv_devclass = '$PACK'
+        io_dot      = mo_dot
+      IMPORTING
+        es_item     = ls_item ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'TABU'
+      act = ls_item-obj_type ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'ZDATA'
+      act = ls_item-obj_name ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Fixes "CONF Object not supported" due to missing mapping of `xyz.conf.json` files to `TABU`

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/70d79b2c-5488-45f7-9edb-eebbf09bb583)

![image](https://github.com/abapGit/abapGit/assets/59966492/e3fa01c6-e19c-4f0d-910a-687de244a506)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/05d66827-c420-415d-aad6-262035836661)

Added some unit tests