### PR TITLE
Fix ABAP language version check

### DIFF
--- a/src/utils/zcl_abapgit_abap_language_vers.clas.abap
+++ b/src/utils/zcl_abapgit_abap_language_vers.clas.abap
@@ -78,7 +78,7 @@ CLASS zcl_abapgit_abap_language_vers IMPLEMENTATION.
   METHOD check_abap_language_version.
 
     " Check if ABAP language version matches repository setting
-    IF iv_abap_language_version <> is_item-abap_language_version.
+    IF is_item-abap_language_version IS NOT INITIAL AND iv_abap_language_version <> is_item-abap_language_version.
       zcx_abapgit_exception=>raise(
         |Object { is_item-obj_type } { is_item-obj_name } has { get_description( iv_abap_language_version ) }| &&
         | but repository is set to { get_description( is_item-abap_language_version ) }| ).

--- a/src/utils/zcl_abapgit_abap_language_vers.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_abap_language_vers.clas.testclasses.abap
@@ -465,11 +465,11 @@ CLASS ltcl_abap_language_version IMPLEMENTATION.
 
     ls_item-obj_type              = 'CLAS'.
     ls_item-obj_name              = 'ZCL_FOO_BAR'.
-    ls_item-abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version-standard.
+    ls_item-abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version_src-standard.
 
     TRY.
         zcl_abapgit_abap_language_vers=>check_abap_language_version(
-          iv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version-cloud_development
+          iv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version_src-cloud_development
           is_item                  = ls_item ).
         cl_abap_unit_assert=>fail( ).
       CATCH zcx_abapgit_exception ##NO_HANDLER.

--- a/src/utils/zcl_abapgit_zip.clas.abap
+++ b/src/utils/zcl_abapgit_zip.clas.abap
@@ -155,6 +155,7 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
 
     ls_files_item-item-obj_type = ls_tadir-object.
     ls_files_item-item-obj_name = ls_tadir-obj_name.
+    ls_files_item-item-abap_language_version = '*'. "any
 
     ls_files_item = zcl_abapgit_objects=>serialize(
       is_item        = ls_files_item-item


### PR DESCRIPTION
Closes #6691

PS: Also fixes export of objects to include the ABAP language version of the object