### PR TITLE
new pull page: bugfix pull deletions

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_pull.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_pull.clas.abap
@@ -63,7 +63,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_pull IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_PULL IMPLEMENTATION.
 
 
   METHOD choose_transport_request.

--- a/src/ui/pages/zcl_abapgit_gui_page_pull.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_pull.clas.abap
@@ -63,7 +63,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_PULL IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_pull IMPLEMENTATION.
 
 
   METHOD choose_transport_request.
@@ -165,7 +165,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PULL IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
 
-    DATA lo_log TYPE REF TO zcl_abapgit_log.
     DATA lv_value TYPE string.
 
     FIELD-SYMBOLS <ls_overwrite> LIKE LINE OF ms_checks-overwrite.
@@ -192,10 +191,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PULL IMPLEMENTATION.
         ENDLOOP.
 
 * todo, show log?
-        CREATE OBJECT lo_log.
-        mo_repo->deserialize(
+        zcl_abapgit_services_repo=>real_deserialize(
           is_checks = ms_checks
-          ii_log    = lo_log ).
+          io_repo   = mo_repo ).
 
         rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
     ENDCASE.

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -128,7 +128,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
 
   METHOD activate_objects.

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -128,7 +128,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD activate_objects.


### PR DESCRIPTION
method `delete_unnecessary_objects` in services_repo class handles deletions(the logic is malplaced?)

anyhow, split the `gui_deserialize` into two parts, one new that can be reused from the new pull page