### PR TITLE
Fix abapGit popups external call

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_popups.clas.locals_imp.abap
@@ -765,7 +765,8 @@ CLASS lcl_object_descision_list IMPLEMENTATION.
     lt_func_list = lo_functions->get_functions( ).
     LOOP AT lt_func_list INTO ls_func.
       lv_fn = ls_func-r_function->get_name( ).
-      IF lv_fn = 'OK' OR lv_fn = 'CANCEL'.
+      IF lv_fn = 'OK'   OR lv_fn = 'CANCEL'
+      OR lv_fn = 'O.K.' OR lv_fn = 'EABR'.
         ls_func-r_function->set_visible( abap_true ).
       ELSEIF iv_object_list = abap_true.
         ls_func-r_function->set_visible( abap_true ).


### PR DESCRIPTION
If abapGit popups are called outside abapGit toolbar buttons are sometimes missing, because status `102` or `110` of `SAPMSVIM` is used.
![image](https://github.com/abapGit/abapGit/assets/17437789/84dfa9e7-a768-45a0-ae9f-885c5f32fef5)

E.g. `zcl_abapgit_ui_factory=>get_popups( )->popup_to_select_from_list`

before
![image](https://github.com/abapGit/abapGit/assets/17437789/0d22203c-f58a-4730-8a18-6a2da3609a95)

after
![image](https://github.com/abapGit/abapGit/assets/17437789/70c2bf3c-ab37-4365-86d9-7da930965cca)


