### PR TITLE
Remove exception when deleting files

### DIFF
--- a/src/cts/zcl_abapgit_transport_objects.clas.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.abap
@@ -14,7 +14,7 @@ CLASS zcl_abapgit_transport_objects DEFINITION
         !is_stage_objects   TYPE zif_abapgit_definitions=>ty_stage_files
         !it_object_statuses TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
 

--- a/src/cts/zcl_abapgit_transport_objects.clas.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.abap
@@ -45,8 +45,9 @@ CLASS zcl_abapgit_transport_objects IMPLEMENTATION.
         CASE ls_object_status-lstate.
           WHEN zif_abapgit_definitions=>c_state-added OR zif_abapgit_definitions=>c_state-modified.
             IF ls_transport_object-delflag = abap_true.
-              zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
-                } should be added/modified, but has deletion flag in transport| ).
+              zcx_abapgit_exception=>raise( |Object { ls_transport_object-object }|
+                && | { ls_transport_object-obj_name } should be added/modified,|
+                && | but has deletion flag in transport| ).
             ENDIF.
 
             READ TABLE is_stage_objects-local
@@ -55,8 +56,8 @@ CLASS zcl_abapgit_transport_objects IMPLEMENTATION.
                        item-obj_type = ls_transport_object-object
                        file-filename = ls_object_status-filename.
             IF sy-subrc <> 0.
-              zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
-                } not found in the local repository files| ).
+              zcx_abapgit_exception=>raise( |Object { ls_transport_object-object }|
+                && | { ls_transport_object-obj_name } not found in the local repository files| ).
             ELSE.
               io_stage->add(
                 iv_path     = ls_local_file-file-path

--- a/src/cts/zcl_abapgit_transport_objects.clas.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.abap
@@ -1,24 +1,24 @@
 CLASS zcl_abapgit_transport_objects DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
 
     METHODS constructor
       IMPORTING
-        !it_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt .
+        it_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt.
     METHODS to_stage
       IMPORTING
-        !io_stage           TYPE REF TO zcl_abapgit_stage
-        !is_stage_objects   TYPE zif_abapgit_definitions=>ty_stage_files
-        !it_object_statuses TYPE zif_abapgit_definitions=>ty_results_tt
+        io_stage           TYPE REF TO zcl_abapgit_stage
+        is_stage_objects   TYPE zif_abapgit_definitions=>ty_stage_files
+        it_object_statuses TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    DATA mt_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt .
+    DATA mt_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt.
 ENDCLASS.
 
 
@@ -45,9 +45,8 @@ CLASS zcl_abapgit_transport_objects IMPLEMENTATION.
         CASE ls_object_status-lstate.
           WHEN zif_abapgit_definitions=>c_state-added OR zif_abapgit_definitions=>c_state-modified.
             IF ls_transport_object-delflag = abap_true.
-              zcx_abapgit_exception=>raise( |Object { ls_transport_object-object }|
-                && | { ls_transport_object-obj_name } should be added/modified,|
-                && | but has deletion flag in transport| ).
+              zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
+                } should be added/modified, but has deletion flag in transport| ).
             ENDIF.
 
             READ TABLE is_stage_objects-local
@@ -56,8 +55,8 @@ CLASS zcl_abapgit_transport_objects IMPLEMENTATION.
                        item-obj_type = ls_transport_object-object
                        file-filename = ls_object_status-filename.
             IF sy-subrc <> 0.
-              zcx_abapgit_exception=>raise( |Object { ls_transport_object-object }|
-                && | { ls_transport_object-obj_name } not found in the local repository files| ).
+              zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
+                } not found in the local repository files| ).
             ELSE.
               io_stage->add(
                 iv_path     = ls_local_file-file-path
@@ -65,17 +64,6 @@ CLASS zcl_abapgit_transport_objects IMPLEMENTATION.
                 iv_data     = ls_local_file-file-data ).
             ENDIF.
           WHEN zif_abapgit_definitions=>c_state-deleted.
-* SUSC, see https://github.com/abapGit/abapGit/issues/2772
-            IF ls_transport_object-delflag = abap_false
-                AND ls_transport_object-object <> 'SUSC'
-                AND ls_transport_object-object <> 'IWOM'
-                AND ls_transport_object-object <> 'IWMO'
-                AND ls_transport_object-object <> 'IWSG'
-                AND ls_transport_object-object <> 'IWSV'.
-              zcx_abapgit_exception=>raise( |Object { ls_transport_object-object }|
-                && | { ls_transport_object-obj_name } should be removed,|
-                && | but has NO deletion flag in transport| ).
-            ENDIF.
             io_stage->rm(
               iv_path     = ls_object_status-path
               iv_filename = ls_object_status-filename ).

--- a/src/cts/zcl_abapgit_transport_objects.clas.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.abap
@@ -1,24 +1,24 @@
 CLASS zcl_abapgit_transport_objects DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC.
+  CREATE PUBLIC .
 
   PUBLIC SECTION.
 
     METHODS constructor
       IMPORTING
-        it_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt.
+        !it_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt .
     METHODS to_stage
       IMPORTING
-        io_stage           TYPE REF TO zcl_abapgit_stage
-        is_stage_objects   TYPE zif_abapgit_definitions=>ty_stage_files
-        it_object_statuses TYPE zif_abapgit_definitions=>ty_results_tt
+        !io_stage           TYPE REF TO zcl_abapgit_stage
+        !is_stage_objects   TYPE zif_abapgit_definitions=>ty_stage_files
+        !it_object_statuses TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    DATA mt_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt.
+    DATA mt_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt .
 ENDCLASS.
 
 

--- a/src/cts/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -1,4 +1,3 @@
-
 CLASS ltcl_transport_objects DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
 
   PRIVATE SECTION.
@@ -10,12 +9,7 @@ CLASS ltcl_transport_objects DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HA
       cant_be_added_with_del_flag    FOR TESTING RAISING cx_static_check,
       cant_be_modified_with_del_flag FOR TESTING RAISING cx_static_check,
       deleted_to_removed_files       FOR TESTING RAISING cx_static_check,
-      should_remove_no_delflag_iwmo FOR TESTING RAISING cx_static_check,
-      should_remove_no_delflag_iwom FOR TESTING RAISING cx_static_check,
-      should_remove_no_delflag_iwsg FOR TESTING RAISING cx_static_check,
-      should_remove_no_delflag_iwsv FOR TESTING RAISING cx_static_check,
-      should_remove_no_delflag_susc FOR TESTING RAISING cx_static_check,
-      shouldnt_remove_no_delflag FOR TESTING RAISING cx_static_check,
+      should_remove_no_delflag FOR TESTING RAISING cx_static_check,
       should_add_all_local_files FOR TESTING RAISING cx_static_check,
       should_delete_all_related  FOR TESTING RAISING cx_static_check,
       setup,
@@ -90,6 +84,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
 
     then_file_should_be_added( ls_local_file ).
   ENDMETHOD.
+
   METHOD modified_to_new_local_files.
     DATA ls_local_file TYPE zif_abapgit_definitions=>ty_file_item.
     given_the_transport_object(
@@ -113,6 +108,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
 
     then_file_should_be_added( ls_local_file ).
   ENDMETHOD.
+
   METHOD should_add_all_local_files.
     "Not only .abap, but also .xml and other includes
     DATA ls_abap_local_file TYPE zif_abapgit_definitions=>ty_file_item.
@@ -153,6 +149,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
     then_file_should_be_added( ls_abap_local_file ).
     then_file_should_be_added( ls_xml_local_file ).
   ENDMETHOD.
+
   METHOD transport_not_in_repository.
     given_the_transport_object(
       iv_obj_name   = 'CL_A_CLASS_NOT_IN_REPO'
@@ -168,7 +165,6 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD object_not_in_local_files.
-
     given_the_transport_object(
       iv_obj_name   = 'CL_FOO'
       iv_obj_type   = 'CLAS' ).
@@ -184,7 +180,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_filename = 'CL_FOO.abap'
       iv_path     = '/path'
       iv_data     = 'data' ).
-    then_it_should_raise_exception( 'Object CLAS CL_FOO not found in the local repository files' ).
+    then_it_should_raise_exception( 'Object CL_FOO not found in the local repository files' ).
   ENDMETHOD.
 
   METHOD cant_be_added_with_del_flag.
@@ -198,7 +194,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_obj_type   = 'CLAS'
       iv_lstate     = zif_abapgit_definitions=>c_state-added ).
 
-    then_it_should_raise_exception( 'Object CLAS CL_FOO should be added/modified, but has deletion flag in transport' ).
+    then_it_should_raise_exception( 'Object CL_FOO should be added/modified, but has deletion flag in transport' ).
   ENDMETHOD.
 
   METHOD cant_be_modified_with_del_flag.
@@ -212,7 +208,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_obj_type   = 'CLAS'
       iv_lstate     = zif_abapgit_definitions=>c_state-modified ).
 
-    then_it_should_raise_exception( 'Object CLAS CL_FOO should be added/modified, but has deletion flag in transport' ).
+    then_it_should_raise_exception( 'Object CL_FOO should be added/modified, but has deletion flag in transport' ).
   ENDMETHOD.
 
   METHOD deleted_to_removed_files.
@@ -267,100 +263,20 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_path     = '/a_path' ).
   ENDMETHOD.
 
-  METHOD should_remove_no_delflag_iwmo.
+  METHOD should_remove_no_delflag.
     given_the_transport_object(
        iv_obj_name   = 'ZFOO'
-       iv_obj_type   = 'IWMO'
-       iv_delflag    = abap_false ).
-
-    given_the_object_status(
-      iv_obj_name   = 'ZFOO'
-      iv_obj_type   = 'IWMO'
-      iv_filename   = 'zfoo.iwmo.xml'
-      iv_path       = '/a_path'
-      iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
-
-    then_it_should_not_raise_excpt( ).
-  ENDMETHOD.
-
-  METHOD should_remove_no_delflag_iwom.
-    given_the_transport_object(
-       iv_obj_name   = 'ZFOO'
-       iv_obj_type   = 'IWOM'
-       iv_delflag    = abap_false ).
-
-    given_the_object_status(
-      iv_obj_name   = 'ZFOO'
-      iv_obj_type   = 'IWOM'
-      iv_filename   = 'zfoo.iwom.xml'
-      iv_path       = '/a_path'
-      iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
-
-    then_it_should_not_raise_excpt( ).
-  ENDMETHOD.
-
-  METHOD should_remove_no_delflag_iwsg.
-    given_the_transport_object(
-       iv_obj_name   = 'ZFOO'
-       iv_obj_type   = 'IWSG'
-       iv_delflag    = abap_false ).
-
-    given_the_object_status(
-      iv_obj_name   = 'ZFOO'
-      iv_obj_type   = 'IWSG'
-      iv_filename   = 'zfoo.iwsg.xml'
-      iv_path       = '/a_path'
-      iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
-
-    then_it_should_not_raise_excpt( ).
-  ENDMETHOD.
-
-  METHOD should_remove_no_delflag_iwsv.
-    given_the_transport_object(
-       iv_obj_name   = 'ZFOO'
-       iv_obj_type   = 'IWSV'
-       iv_delflag    = abap_false ).
-
-    given_the_object_status(
-      iv_obj_name   = 'ZFOO'
-      iv_obj_type   = 'IWSV'
-      iv_filename   = 'zfoo.iwsv.xml'
-      iv_path       = '/a_path'
-      iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
-
-    then_it_should_not_raise_excpt( ).
-  ENDMETHOD.
-
-  METHOD should_remove_no_delflag_susc.
-    given_the_transport_object(
-       iv_obj_name   = 'ZFOO'
-       iv_obj_type   = 'SUSC'
-       iv_delflag    = abap_false ).
-
-    given_the_object_status(
-      iv_obj_name   = 'ZFOO'
-      iv_obj_type   = 'SUSC'
-      iv_filename   = 'zfoo.susc.xml'
-      iv_path       = '/a_path'
-      iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
-
-    then_it_should_not_raise_excpt( ).
-  ENDMETHOD.
-
-  METHOD shouldnt_remove_no_delflag.
-    given_the_transport_object(
-       iv_obj_name   = 'CL_FOO'
        iv_obj_type   = 'CLAS'
        iv_delflag    = abap_false ).
 
     given_the_object_status(
-      iv_obj_name   = 'CL_FOO'
+      iv_obj_name   = 'ZFOO'
       iv_obj_type   = 'CLAS'
-      iv_filename   = 'CL_FOO.abap'
+      iv_filename   = 'zfoo.CLAS.xml'
       iv_path       = '/a_path'
       iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
 
-    then_it_should_raise_exception( 'Object CLAS CL_FOO should be removed, but has NO deletion flag in transport' ).
+    then_it_should_not_raise_excpt( ).
   ENDMETHOD.
 
   METHOD given_the_transport_object.
@@ -429,7 +345,6 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD then_it_should_remove_at_stage.
-
     DATA: lt_staged_objects TYPE zif_abapgit_definitions=>ty_stage_tt.
 
     lt_staged_objects = mo_stage->get_all( ).

--- a/src/cts/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -165,6 +165,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD object_not_in_local_files.
+
     given_the_transport_object(
       iv_obj_name   = 'CL_FOO'
       iv_obj_type   = 'CLAS' ).
@@ -345,6 +346,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD then_it_should_remove_at_stage.
+
     DATA: lt_staged_objects TYPE zif_abapgit_definitions=>ty_stage_tt.
 
     lt_staged_objects = mo_stage->get_all( ).

--- a/src/cts/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -180,7 +180,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_filename = 'CL_FOO.abap'
       iv_path     = '/path'
       iv_data     = 'data' ).
-    then_it_should_raise_exception( 'Object CL_FOO not found in the local repository files' ).
+    then_it_should_raise_exception( 'Object CLAS CL_FOO not found in the local repository files' ).
   ENDMETHOD.
 
   METHOD cant_be_added_with_del_flag.
@@ -194,7 +194,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_obj_type   = 'CLAS'
       iv_lstate     = zif_abapgit_definitions=>c_state-added ).
 
-    then_it_should_raise_exception( 'Object CL_FOO should be added/modified, but has deletion flag in transport' ).
+    then_it_should_raise_exception( 'Object CLAS CL_FOO should be added/modified, but has deletion flag in transport' ).
   ENDMETHOD.
 
   METHOD cant_be_modified_with_del_flag.
@@ -208,7 +208,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_obj_type   = 'CLAS'
       iv_lstate     = zif_abapgit_definitions=>c_state-modified ).
 
-    then_it_should_raise_exception( 'Object CL_FOO should be added/modified, but has deletion flag in transport' ).
+    then_it_should_raise_exception( 'Object CLAS CL_FOO should be added/modified, but has deletion flag in transport' ).
   ENDMETHOD.
 
   METHOD deleted_to_removed_files.


### PR DESCRIPTION
Based on https://github.com/abapGit/abapGit/issues/6710

Remove exception `Object should be removed, but has NO deletion flag in transport`. Straightaway remove objects, since they can be removed from a repo by either deleting them or by moving them to an outside package.