### PR TITLE
Do a syntax check before accessing version constant

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_base.clas.abap
@@ -355,4 +355,10 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
     DELETE FROM seosubcotx WHERE clsname = is_key-clsname."#EC CI_SUBRC
     INSERT seosubcotx FROM TABLE lt_descriptions.         "#EC CI_SUBRC
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~syntax_check.
+    ASSERT 0 = 1. "Subclass responsibility
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -27,6 +27,8 @@ CLASS zcl_abapgit_oo_class DEFINITION
         REDEFINITION .
     METHODS zif_abapgit_oo_object_fnc~exists
         REDEFINITION .
+    METHODS zif_abapgit_oo_object_fnc~syntax_check
+        REDEFINITION .
   PROTECTED SECTION.
 
     TYPES:
@@ -968,4 +970,31 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
     lv_cp = cl_oo_classname_service=>get_classpool_name( iv_class_name ).
     READ TEXTPOOL lv_cp INTO rt_text_pool LANGUAGE iv_language. "#EC CI_READ_REP
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~syntax_check.
+    DATA:
+      ls_clskey      TYPE seoclskey,
+      lv_syntaxerror TYPE seox_boolean.
+
+    ls_clskey-clsname = to_upper( iv_object_name ).
+
+    CALL FUNCTION 'SEO_CLASS_CHECK_CLASSPOOL'
+      EXPORTING
+        clskey                       = ls_clskey
+        suppress_error_popup         = abap_true
+      IMPORTING
+        syntaxerror                  = lv_syntaxerror
+      EXCEPTIONS
+        _internal_class_not_existing = 1
+        OTHERS                       = 2.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+    IF lv_syntaxerror = abap_true.
+      zcx_abapgit_exception=>raise( |Class { ls_clskey-clsname } has syntax errors | ).
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -975,7 +975,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~syntax_check.
     DATA:
       ls_clskey      TYPE seoclskey,
-      lv_syntaxerror TYPE seox_boolean.
+      lv_syntaxerror TYPE abap_bool.
 
     ls_clskey-clsname = to_upper( iv_object_name ).
 

--- a/src/objects/oo/zcl_abapgit_oo_factory.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_factory.clas.abap
@@ -6,10 +6,19 @@ CLASS zcl_abapgit_oo_factory DEFINITION PUBLIC.
         IMPORTING
           iv_object_type                   TYPE tadir-object
         RETURNING
-          VALUE(ri_object_oriented_object) TYPE REF TO zif_abapgit_oo_object_fnc.
-  PRIVATE SECTION.
+          VALUE(ri_object_oriented_object) TYPE REF TO zif_abapgit_oo_object_fnc,
 
+      make_by_name
+        IMPORTING
+          iv_object_name                   TYPE seoclsname
+        RETURNING
+          VALUE(ri_object_oriented_object) TYPE REF TO zif_abapgit_oo_object_fnc
+        RAISING
+          zcx_abapgit_exception.
+
+  PRIVATE SECTION.
     CLASS-DATA gi_object_oriented_object TYPE REF TO zif_abapgit_oo_object_fnc .
+
 ENDCLASS.
 
 
@@ -27,5 +36,31 @@ CLASS zcl_abapgit_oo_factory IMPLEMENTATION.
     ELSEIF iv_object_type = 'INTF'.
       CREATE OBJECT ri_object_oriented_object TYPE zcl_abapgit_oo_interface.
     ENDIF.
+  ENDMETHOD.
+
+
+  METHOD make_by_name.
+
+    DATA:
+      li_interface   TYPE REF TO zif_abapgit_oo_object_fnc,
+      li_class       TYPE REF TO zif_abapgit_oo_object_fnc,
+      ls_object_name TYPE seoclskey.
+
+    ls_object_name-clsname = to_upper( iv_object_name ).
+
+    CREATE OBJECT li_class TYPE zcl_abapgit_oo_class.
+    IF li_class->exists( ls_object_name ) = abap_true.
+      ri_object_oriented_object = li_class.
+      RETURN.
+    ENDIF.
+
+    CREATE OBJECT li_interface TYPE zcl_abapgit_oo_interface.
+    IF li_interface->exists( ls_object_name ) = abap_true.
+      ri_object_oriented_object = li_interface.
+      RETURN.
+    ENDIF.
+
+    zcx_abapgit_exception=>raise( |{ iv_object_name } is neither a class nor an interface| ).
+
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -17,6 +17,8 @@ CLASS zcl_abapgit_oo_interface DEFINITION
         REDEFINITION .
     METHODS zif_abapgit_oo_object_fnc~exists
         REDEFINITION .
+    METHODS zif_abapgit_oo_object_fnc~syntax_check
+        REDEFINITION .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -339,4 +341,24 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
       rs_interface_properties-r3release,
       rs_interface_properties-version.
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~syntax_check.
+    DATA:
+      ls_intkey      TYPE seoclskey,
+      lv_syntaxerror TYPE seox_boolean.
+
+    ls_intkey-clsname = to_upper( iv_object_name ).
+
+    CALL FUNCTION 'SEO_INTERFACE_CHECK_POOL'
+      EXPORTING
+        intkey               = ls_intkey
+        suppress_error_popup = abap_true
+      IMPORTING
+        syntaxerror          = lv_syntaxerror.
+    IF lv_syntaxerror = abap_true.
+      zcx_abapgit_exception=>raise( |Interface { ls_intkey-clsname } has syntax errors | ).
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -355,7 +355,13 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
         intkey               = ls_intkey
         suppress_error_popup = abap_true
       IMPORTING
-        syntaxerror          = lv_syntaxerror.
+        syntaxerror          = lv_syntaxerror
+      EXCEPTIONS
+        OTHERS               = 1.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
     IF lv_syntaxerror = abap_true.
       zcx_abapgit_exception=>raise( |Interface { ls_intkey-clsname } has syntax errors | ).
     ENDIF.

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -346,7 +346,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~syntax_check.
     DATA:
       ls_intkey      TYPE seoclskey,
-      lv_syntaxerror TYPE seox_boolean.
+      lv_syntaxerror TYPE abap_bool.
 
     ls_intkey-clsname = to_upper( iv_object_name ).
 

--- a/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
@@ -187,5 +187,10 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
       IMPORTING
         iv_object_name       TYPE seoclsname
       RETURNING
-        VALUE(rt_attributes) TYPE ty_obj_attribute_tt.
+        VALUE(rt_attributes) TYPE ty_obj_attribute_tt,
+    syntax_check
+      IMPORTING
+        iv_object_name                TYPE seoclsname
+      RAISING
+        zcx_abapgit_exception.
 ENDINTERFACE.

--- a/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
@@ -104,6 +104,9 @@ CLASS lth_oo_object_fnc IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~update_descriptions_sub.
   ENDMETHOD.
 
+  METHOD zif_abapgit_oo_object_fnc~syntax_check.
+  ENDMETHOD.
+
 ENDCLASS.
 
 

--- a/src/repo/utils/zcl_abapgit_version.clas.abap
+++ b/src/repo/utils/zcl_abapgit_version.clas.abap
@@ -251,7 +251,7 @@ CLASS zcl_abapgit_version IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_version_constant_value.
-    DATA: lv_version_class     TYPE string,
+    DATA: lv_version_class     TYPE seoclsname,
           lv_version_component TYPE string.
     FIELD-SYMBOLS: <lv_version> TYPE string.
 
@@ -263,6 +263,10 @@ CLASS zcl_abapgit_version IMPLEMENTATION.
     IF sy-subrc <> 0 OR lv_version_class IS INITIAL OR lv_version_component IS INITIAL.
       zcx_abapgit_exception=>raise( 'Version constant cannot be parsed' ).
     ENDIF.
+
+    " You should remember that accessing a class or an interface with syntax errors
+    " gives us a shortdump. Therefore we do a syntax check here.
+    zcl_abapgit_oo_factory=>make_by_name( lv_version_class )->syntax_check( lv_version_class ).
 
     ASSIGN (lv_version_class)=>(lv_version_component) TO <lv_version>.
     IF sy-subrc = 0.


### PR DESCRIPTION
If the class or interface of the version constant has syntax errors (e.g. due to a cancelled pull) abapGit dumps when opening the repo and it cannot be repaired with abapGit means.
![grafik](https://github.com/abapGit/abapGit/assets/17437789/edb42145-847c-4c59-9099-19f0115614bf)
![grafik](https://github.com/abapGit/abapGit/assets/17437789/44bff9c3-2180-4269-ac49-77b392696eff)

This change introduces a syntax check before accessing the constant.
![grafik](https://github.com/abapGit/abapGit/assets/17437789/29fb4299-f06d-427f-a0ce-5bc4768bc522)
