### PR TITLE
DDLS: deletes remaining TADIR entry during delete

### DIFF
--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -256,6 +256,14 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
 
     corr_insert( iv_package ).
 
+    " rebuild object list to delete remaining TADIR entry
+    CALL FUNCTION 'WB_TREE_UPDATE_OBJECTLIST'
+      EXPORTING
+        p_object_type = 'DF'
+        p_object_name = ms_item-obj_name
+        p_operation   = swbm_c_op_delete
+      EXCEPTIONS
+        OTHERS        = 0.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -261,7 +261,7 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
       EXPORTING
         p_object_type = 'DF'
         p_object_name = ms_item-obj_name
-        p_operation   = swbm_c_op_delete
+        p_operation   = 'DELETE'
       EXCEPTIONS
         OTHERS        = 0.
   ENDMETHOD.


### PR DESCRIPTION
If a DDLS object is locally deleted - e.g. during a pull operation - the corresponding DDLS TADIR entry is not deleted.  
Calling the function `WB_TREE_UPDATE_OBJECTLIST` will remedy this problem.

This is the same approach as implemented in the Object delete logic of ADT
![image](https://github.com/abapGit/abapGit/assets/35834861/1d6f5ad0-99c1-4de8-b8ba-384c6885068d)

Because `corr_insert( )` may recreate the TADIR entry, the function module needs to be called at the end of the delete method.