### PR TITLE
BG: Ensure auth buffer is cleared even in error case

### DIFF
--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -147,13 +147,12 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
           lo_repo->refresh(
             iv_drop_cache = abap_true
             iv_drop_log   = abap_false ).
-
-          " Clear auth buffer to allow different user/password per repository in background mode
-          zcl_abapgit_login_manager=>clear( ).
-
         CATCH zcx_abapgit_exception INTO lx_error.
           li_log->add_exception( lx_error ).
       ENDTRY.
+
+      " Clear auth buffer to allow different user/password per repository in background mode
+      zcl_abapgit_login_manager=>clear( ).
 
       zcl_abapgit_log_viewer=>write_log( li_log ).
     ENDLOOP.


### PR DESCRIPTION
I noticed this during the review of #6736.

I'm not sure _exactly_ why the auth buffer must be cleared, but this change ensures that it is cleared even if there is an error when processing or refreshing the repository.