### PR TITLE
Update zcl_abapgit_gui_page_repo_view.clas.abap

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -486,7 +486,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                      iv_act = |{ zif_abapgit_definitions=>c_action-repo_refresh }?key={ mv_key }|
                      iv_opt = zif_abapgit_html=>c_html_opt-strong ).
 
-    ro_toolbar->add( iv_txt   = 'Settings'
+    ro_toolbar->add( iv_txt   = 'Repository Settings'
                      iv_act   = |{ zif_abapgit_definitions=>c_action-repo_settings }?key={ mv_key }|
                      iv_opt   = zif_abapgit_html=>c_html_opt-strong
                      iv_title = `Repository Settings` ).


### PR DESCRIPTION
![Repository - Repository Settings](https://github.com/abapGit/abapGit/assets/36721657/79a080c7-ec31-41a7-9f10-13d1a5f1877f)


The purpose here is to avoid confusion with "Global Settings" if we just display "Settings", and also to keep consistency with other pull requests that address #6758.