### PR TITLE
user exit: include settings parameters in change_tadir()

### DIFF
--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -250,7 +250,7 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
             EXPORTING
               iv_package            = iv_package
               ii_log                = ii_log
-              is_dot_data           = is_dot_data
+              is_dot_abapgit        = is_dot_abapgit
               iv_ignore_subpackages = iv_ignore_subpackages
               iv_only_local_objects = iv_only_local_objects
             CHANGING

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -250,7 +250,7 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
             EXPORTING
               iv_package            = iv_package
               ii_log                = ii_log
-              is_dot_data           = io_dot->get_data( )
+              is_dot_data           = is_dot_data
               iv_ignore_subpackages = iv_ignore_subpackages
               iv_only_local_objects = iv_only_local_objects
             CHANGING

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
+CLASS zcl_abapgit_exit IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -250,7 +250,7 @@ CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
             EXPORTING
               iv_package            = iv_package
               ii_log                = ii_log
-              io_dot                = io_dot
+              is_dot_data           = io_dot->get_data( )
               iv_ignore_subpackages = iv_ignore_subpackages
               iv_only_local_objects = iv_only_local_objects
             CHANGING

--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_exit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -248,10 +248,13 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
       TRY.
           gi_exit->change_tadir(
             EXPORTING
-              iv_package = iv_package
-              ii_log     = ii_log
+              iv_package            = iv_package
+              ii_log                = ii_log
+              io_dot                = io_dot
+              iv_ignore_subpackages = iv_ignore_subpackages
+              iv_only_local_objects = iv_only_local_objects
             CHANGING
-              ct_tadir   = ct_tadir ).
+              ct_tadir              = ct_tadir ).
         CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
       ENDTRY.
     ENDIF.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -18,9 +18,9 @@ INTERFACE zif_abapgit_exit
 
   METHODS adjust_display_commit_url
     IMPORTING
-      !iv_repo_url TYPE csequence
-      !iv_repo_name TYPE csequence
-      !iv_repo_key TYPE csequence
+      !iv_repo_url    TYPE csequence
+      !iv_repo_name   TYPE csequence
+      !iv_repo_key    TYPE csequence
       !iv_commit_hash TYPE zif_abapgit_git_definitions=>ty_sha1
     CHANGING
       !cv_display_url TYPE csequence
@@ -28,8 +28,8 @@ INTERFACE zif_abapgit_exit
       zcx_abapgit_exception .
   METHODS adjust_display_filename
     IMPORTING
-      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-      !iv_filename TYPE string
+      !is_repo_meta      TYPE zif_abapgit_persistence=>ty_repo
+      !iv_filename       TYPE string
     RETURNING
       VALUE(rv_filename) TYPE string .
   METHODS allow_sap_objects
@@ -40,22 +40,22 @@ INTERFACE zif_abapgit_exit
       !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt .
   METHODS change_max_parallel_processes
     IMPORTING
-      !iv_package TYPE devclass
+      !iv_package       TYPE devclass
     CHANGING
       !cv_max_processes TYPE i .
   METHODS change_proxy_authentication
     IMPORTING
-      !iv_repo_url TYPE csequence
+      !iv_repo_url             TYPE csequence
     CHANGING
       !cv_proxy_authentication TYPE abap_bool .
   METHODS change_proxy_port
     IMPORTING
-      !iv_repo_url TYPE csequence
+      !iv_repo_url   TYPE csequence
     CHANGING
       !cv_proxy_port TYPE string .
   METHODS change_proxy_url
     IMPORTING
-      !iv_repo_url TYPE csequence
+      !iv_repo_url  TYPE csequence
     CHANGING
       !cv_proxy_url TYPE string .
   METHODS change_rfc_server_group
@@ -69,24 +69,24 @@ INTERFACE zif_abapgit_exit
       !ct_types TYPE ty_object_types .
   METHODS change_tadir
     IMPORTING
-      !iv_package TYPE devclass
-      !ii_log TYPE REF TO zif_abapgit_log
-      !is_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
+      !iv_package            TYPE devclass
+      !ii_log                TYPE REF TO zif_abapgit_log
+      !is_dot_abapgit        TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
       !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
       !iv_only_local_objects TYPE abap_bool DEFAULT abap_false
     CHANGING
-      !ct_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt .
+      !ct_tadir              TYPE zif_abapgit_definitions=>ty_tadir_tt .
   METHODS create_http_client
     IMPORTING
-      !iv_url TYPE string
+      !iv_url          TYPE string
     RETURNING
       VALUE(ri_client) TYPE REF TO if_http_client
     RAISING
       zcx_abapgit_exception .
   METHODS custom_serialize_abap_clif
     IMPORTING
-      !is_class_key TYPE ty_class_key
-      !it_source TYPE zif_abapgit_definitions=>ty_string_tt OPTIONAL
+      !is_class_key    TYPE ty_class_key
+      !it_source       TYPE zif_abapgit_definitions=>ty_string_tt OPTIONAL
     RETURNING
       VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
     RAISING
@@ -94,21 +94,21 @@ INTERFACE zif_abapgit_exit
   METHODS deserialize_postprocess
     IMPORTING
       !is_step TYPE zif_abapgit_objects=>ty_step_data
-      !ii_log TYPE REF TO zif_abapgit_log .
+      !ii_log  TYPE REF TO zif_abapgit_log .
   METHODS determine_transport_request
     IMPORTING
-      !io_repo TYPE REF TO zcl_abapgit_repo
-      !iv_transport_type TYPE zif_abapgit_definitions=>ty_transport_type
+      !io_repo              TYPE REF TO zcl_abapgit_repo
+      !iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
     CHANGING
       !cv_transport_request TYPE trkorr .
   METHODS enhance_repo_toolbar
     IMPORTING
       !io_menu TYPE REF TO zcl_abapgit_html_toolbar
-      !iv_key TYPE zif_abapgit_persistence=>ty_value
-      !iv_act TYPE string .
+      !iv_key  TYPE zif_abapgit_persistence=>ty_value
+      !iv_act  TYPE string .
   METHODS get_ci_tests
     IMPORTING
-      !iv_object TYPE tadir-object
+      !iv_object   TYPE tadir-object
     CHANGING
       !ct_ci_repos TYPE ty_ci_repos .
   METHODS get_ssl_id
@@ -116,11 +116,11 @@ INTERFACE zif_abapgit_exit
       VALUE(rv_ssl_id) TYPE ssfapplssl .
   METHODS http_client
     IMPORTING
-      !iv_url TYPE string
+      !iv_url    TYPE string
       !ii_client TYPE REF TO if_http_client .
   METHODS on_event
     IMPORTING
-      !ii_event TYPE REF TO zif_abapgit_gui_event
+      !ii_event         TYPE REF TO zif_abapgit_gui_event
     RETURNING
       VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
     RAISING
@@ -129,21 +129,21 @@ INTERFACE zif_abapgit_exit
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
     CHANGING
-      !ct_local TYPE zif_abapgit_definitions=>ty_files_item_tt
-      !ct_remote TYPE zif_abapgit_git_definitions=>ty_files_tt
+      !ct_local     TYPE zif_abapgit_definitions=>ty_files_item_tt
+      !ct_remote    TYPE zif_abapgit_git_definitions=>ty_files_tt
     RAISING
       zcx_abapgit_exception .
   METHODS serialize_postprocess
     IMPORTING
       !iv_package TYPE devclass
-      !ii_log TYPE REF TO zif_abapgit_log
+      !ii_log     TYPE REF TO zif_abapgit_log
     CHANGING
-      !ct_files TYPE zif_abapgit_definitions=>ty_files_item_tt .
+      !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt .
   METHODS validate_before_push
     IMPORTING
       !is_comment TYPE zif_abapgit_git_definitions=>ty_comment
-      !io_stage TYPE REF TO zcl_abapgit_stage
-      !io_repo TYPE REF TO zcl_abapgit_repo_online
+      !io_stage   TYPE REF TO zcl_abapgit_stage
+      !io_repo    TYPE REF TO zcl_abapgit_repo_online
     RAISING
       zcx_abapgit_exception .
   METHODS wall_message_list
@@ -152,5 +152,5 @@ INTERFACE zif_abapgit_exit
   METHODS wall_message_repo
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-      !ii_html TYPE REF TO zif_abapgit_html .
+      !ii_html      TYPE REF TO zif_abapgit_html .
 ENDINTERFACE.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -1,156 +1,156 @@
-interface ZIF_ABAPGIT_EXIT
-  public .
+INTERFACE zif_abapgit_exit
+  PUBLIC .
 
 
-  types:
+  TYPES:
     BEGIN OF ty_ci_repo,
       name      TYPE string,
       clone_url TYPE string,
     END OF ty_ci_repo .
-  types:
+  TYPES:
     ty_ci_repos TYPE TABLE OF ty_ci_repo .
-  types:
+  TYPES:
     ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY .
-  types:
+  TYPES:
     BEGIN OF ty_class_key,
       clsname TYPE abap_classname,
     END OF ty_class_key .
 
-  methods ADJUST_DISPLAY_COMMIT_URL
-    importing
-      !IV_REPO_URL type CSEQUENCE
-      !IV_REPO_NAME type CSEQUENCE
-      !IV_REPO_KEY type CSEQUENCE
-      !IV_COMMIT_HASH type ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_SHA1
-    changing
-      !CV_DISPLAY_URL type CSEQUENCE
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods ADJUST_DISPLAY_FILENAME
-    importing
-      !IS_REPO_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
-      !IV_FILENAME type STRING
-    returning
-      value(RV_FILENAME) type STRING .
-  methods ALLOW_SAP_OBJECTS
-    returning
-      value(RV_ALLOWED) type ABAP_BOOL .
-  methods CHANGE_LOCAL_HOST
-    changing
-      !CT_HOSTS type ZIF_ABAPGIT_DEFINITIONS=>TY_STRING_TT .
-  methods CHANGE_MAX_PARALLEL_PROCESSES
-    importing
-      !IV_PACKAGE type DEVCLASS
-    changing
-      !CV_MAX_PROCESSES type I .
-  methods CHANGE_PROXY_AUTHENTICATION
-    importing
-      !IV_REPO_URL type CSEQUENCE
-    changing
-      !CV_PROXY_AUTHENTICATION type ABAP_BOOL .
-  methods CHANGE_PROXY_PORT
-    importing
-      !IV_REPO_URL type CSEQUENCE
-    changing
-      !CV_PROXY_PORT type STRING .
-  methods CHANGE_PROXY_URL
-    importing
-      !IV_REPO_URL type CSEQUENCE
-    changing
-      !CV_PROXY_URL type STRING .
-  methods CHANGE_RFC_SERVER_GROUP
-    changing
-      !CV_GROUP type RZLLI_APCL .
-  methods CHANGE_SUPPORTED_DATA_OBJECTS
-    changing
-      !CT_OBJECTS type ZIF_ABAPGIT_DATA_SUPPORTER=>TY_OBJECTS .
-  methods CHANGE_SUPPORTED_OBJECT_TYPES
-    changing
-      !CT_TYPES type TY_OBJECT_TYPES .
-  methods CHANGE_TADIR
-    importing
-      !IV_PACKAGE type DEVCLASS
-      !II_LOG type ref to ZIF_ABAPGIT_LOG
-      !IO_DOT type ref to ZCL_ABAPGIT_DOT_ABAPGIT
-      !IV_IGNORE_SUBPACKAGES type ABAP_BOOL default ABAP_FALSE
-      !IV_ONLY_LOCAL_OBJECTS type ABAP_BOOL default ABAP_FALSE
-    changing
-      !CT_TADIR type ZIF_ABAPGIT_DEFINITIONS=>TY_TADIR_TT .
-  methods CREATE_HTTP_CLIENT
-    importing
-      !IV_URL type STRING
-    returning
-      value(RI_CLIENT) type ref to IF_HTTP_CLIENT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods CUSTOM_SERIALIZE_ABAP_CLIF
-    importing
-      !IS_CLASS_KEY type TY_CLASS_KEY
-      !IT_SOURCE type ZIF_ABAPGIT_DEFINITIONS=>TY_STRING_TT optional
-    returning
-      value(RT_SOURCE) type ZIF_ABAPGIT_DEFINITIONS=>TY_STRING_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods DESERIALIZE_POSTPROCESS
-    importing
-      !IS_STEP type ZIF_ABAPGIT_OBJECTS=>TY_STEP_DATA
-      !II_LOG type ref to ZIF_ABAPGIT_LOG .
-  methods DETERMINE_TRANSPORT_REQUEST
-    importing
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO
-      !IV_TRANSPORT_TYPE type ZIF_ABAPGIT_DEFINITIONS=>TY_TRANSPORT_TYPE
-    changing
-      !CV_TRANSPORT_REQUEST type TRKORR .
-  methods ENHANCE_REPO_TOOLBAR
-    importing
-      !IO_MENU type ref to ZCL_ABAPGIT_HTML_TOOLBAR
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_VALUE
-      !IV_ACT type STRING .
-  methods GET_CI_TESTS
-    importing
-      !IV_OBJECT type TADIR-OBJECT
-    changing
-      !CT_CI_REPOS type TY_CI_REPOS .
-  methods GET_SSL_ID
-    returning
-      value(RV_SSL_ID) type SSFAPPLSSL .
-  methods HTTP_CLIENT
-    importing
-      !IV_URL type STRING
-      !II_CLIENT type ref to IF_HTTP_CLIENT .
-  methods ON_EVENT
-    importing
-      !II_EVENT type ref to ZIF_ABAPGIT_GUI_EVENT
-    returning
-      value(RS_HANDLED) type ZIF_ABAPGIT_GUI_EVENT_HANDLER=>TY_HANDLING_RESULT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods PRE_CALCULATE_REPO_STATUS
-    importing
-      !IS_REPO_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
-    changing
-      !CT_LOCAL type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT
-      !CT_REMOTE type ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_FILES_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods SERIALIZE_POSTPROCESS
-    importing
-      !IV_PACKAGE type DEVCLASS
-      !II_LOG type ref to ZIF_ABAPGIT_LOG
-    changing
-      !CT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT .
-  methods VALIDATE_BEFORE_PUSH
-    importing
-      !IS_COMMENT type ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_COMMENT
-      !IO_STAGE type ref to ZCL_ABAPGIT_STAGE
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO_ONLINE
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods WALL_MESSAGE_LIST
-    importing
-      !II_HTML type ref to ZIF_ABAPGIT_HTML .
-  methods WALL_MESSAGE_REPO
-    importing
-      !IS_REPO_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
-      !II_HTML type ref to ZIF_ABAPGIT_HTML .
-endinterface.
+  METHODS adjust_display_commit_url
+    IMPORTING
+      !iv_repo_url TYPE csequence
+      !iv_repo_name TYPE csequence
+      !iv_repo_key TYPE csequence
+      !iv_commit_hash TYPE zif_abapgit_git_definitions=>ty_sha1
+    CHANGING
+      !cv_display_url TYPE csequence
+    RAISING
+      zcx_abapgit_exception .
+  METHODS adjust_display_filename
+    IMPORTING
+      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+      !iv_filename TYPE string
+    RETURNING
+      VALUE(rv_filename) TYPE string .
+  METHODS allow_sap_objects
+    RETURNING
+      VALUE(rv_allowed) TYPE abap_bool .
+  METHODS change_local_host
+    CHANGING
+      !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt .
+  METHODS change_max_parallel_processes
+    IMPORTING
+      !iv_package TYPE devclass
+    CHANGING
+      !cv_max_processes TYPE i .
+  METHODS change_proxy_authentication
+    IMPORTING
+      !iv_repo_url TYPE csequence
+    CHANGING
+      !cv_proxy_authentication TYPE abap_bool .
+  METHODS change_proxy_port
+    IMPORTING
+      !iv_repo_url TYPE csequence
+    CHANGING
+      !cv_proxy_port TYPE string .
+  METHODS change_proxy_url
+    IMPORTING
+      !iv_repo_url TYPE csequence
+    CHANGING
+      !cv_proxy_url TYPE string .
+  METHODS change_rfc_server_group
+    CHANGING
+      !cv_group TYPE rzlli_apcl .
+  METHODS change_supported_data_objects
+    CHANGING
+      !ct_objects TYPE zif_abapgit_data_supporter=>ty_objects .
+  METHODS change_supported_object_types
+    CHANGING
+      !ct_types TYPE ty_object_types .
+  METHODS change_tadir
+    IMPORTING
+      !iv_package TYPE devclass
+      !ii_log TYPE REF TO zif_abapgit_log
+      !io_dot TYPE REF TO zcl_abapgit_dot_abapgit
+      !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
+      !iv_only_local_objects TYPE abap_bool DEFAULT abap_false
+    CHANGING
+      !ct_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt .
+  METHODS create_http_client
+    IMPORTING
+      !iv_url TYPE string
+    RETURNING
+      VALUE(ri_client) TYPE REF TO if_http_client
+    RAISING
+      zcx_abapgit_exception .
+  METHODS custom_serialize_abap_clif
+    IMPORTING
+      !is_class_key TYPE ty_class_key
+      !it_source TYPE zif_abapgit_definitions=>ty_string_tt OPTIONAL
+    RETURNING
+      VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
+    RAISING
+      zcx_abapgit_exception .
+  METHODS deserialize_postprocess
+    IMPORTING
+      !is_step TYPE zif_abapgit_objects=>ty_step_data
+      !ii_log TYPE REF TO zif_abapgit_log .
+  METHODS determine_transport_request
+    IMPORTING
+      !io_repo TYPE REF TO zcl_abapgit_repo
+      !iv_transport_type TYPE zif_abapgit_definitions=>ty_transport_type
+    CHANGING
+      !cv_transport_request TYPE trkorr .
+  METHODS enhance_repo_toolbar
+    IMPORTING
+      !io_menu TYPE REF TO zcl_abapgit_html_toolbar
+      !iv_key TYPE zif_abapgit_persistence=>ty_value
+      !iv_act TYPE string .
+  METHODS get_ci_tests
+    IMPORTING
+      !iv_object TYPE tadir-object
+    CHANGING
+      !ct_ci_repos TYPE ty_ci_repos .
+  METHODS get_ssl_id
+    RETURNING
+      VALUE(rv_ssl_id) TYPE ssfapplssl .
+  METHODS http_client
+    IMPORTING
+      !iv_url TYPE string
+      !ii_client TYPE REF TO if_http_client .
+  METHODS on_event
+    IMPORTING
+      !ii_event TYPE REF TO zif_abapgit_gui_event
+    RETURNING
+      VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
+    RAISING
+      zcx_abapgit_exception .
+  METHODS pre_calculate_repo_status
+    IMPORTING
+      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+    CHANGING
+      !ct_local TYPE zif_abapgit_definitions=>ty_files_item_tt
+      !ct_remote TYPE zif_abapgit_git_definitions=>ty_files_tt
+    RAISING
+      zcx_abapgit_exception .
+  METHODS serialize_postprocess
+    IMPORTING
+      !iv_package TYPE devclass
+      !ii_log TYPE REF TO zif_abapgit_log
+    CHANGING
+      !ct_files TYPE zif_abapgit_definitions=>ty_files_item_tt .
+  METHODS validate_before_push
+    IMPORTING
+      !is_comment TYPE zif_abapgit_git_definitions=>ty_comment
+      !io_stage TYPE REF TO zcl_abapgit_stage
+      !io_repo TYPE REF TO zcl_abapgit_repo_online
+    RAISING
+      zcx_abapgit_exception .
+  METHODS wall_message_list
+    IMPORTING
+      !ii_html TYPE REF TO zif_abapgit_html .
+  METHODS wall_message_repo
+    IMPORTING
+      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+      !ii_html TYPE REF TO zif_abapgit_html .
+ENDINTERFACE.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -71,7 +71,7 @@ INTERFACE zif_abapgit_exit
     IMPORTING
       !iv_package TYPE devclass
       !ii_log TYPE REF TO zif_abapgit_log
-      !io_dot TYPE REF TO zcl_abapgit_dot_abapgit
+      !is_dot_data TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
       !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
       !iv_only_local_objects TYPE abap_bool DEFAULT abap_false
     CHANGING

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -1,20 +1,19 @@
-INTERFACE zif_abapgit_exit
-  PUBLIC .
+INTERFACE zif_abapgit_exit PUBLIC.
 
 
   TYPES:
     BEGIN OF ty_ci_repo,
       name      TYPE string,
       clone_url TYPE string,
-    END OF ty_ci_repo .
+    END OF ty_ci_repo.
   TYPES:
-    ty_ci_repos TYPE TABLE OF ty_ci_repo .
+    ty_ci_repos TYPE TABLE OF ty_ci_repo.
   TYPES:
-    ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY .
+    ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY.
   TYPES:
     BEGIN OF ty_class_key,
       clsname TYPE abap_classname,
-    END OF ty_class_key .
+    END OF ty_class_key.
 
   METHODS adjust_display_commit_url
     IMPORTING
@@ -25,48 +24,48 @@ INTERFACE zif_abapgit_exit
     CHANGING
       !cv_display_url TYPE csequence
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS adjust_display_filename
     IMPORTING
       !is_repo_meta      TYPE zif_abapgit_persistence=>ty_repo
       !iv_filename       TYPE string
     RETURNING
-      VALUE(rv_filename) TYPE string .
+      VALUE(rv_filename) TYPE string.
   METHODS allow_sap_objects
     RETURNING
-      VALUE(rv_allowed) TYPE abap_bool .
+      VALUE(rv_allowed) TYPE abap_bool.
   METHODS change_local_host
     CHANGING
-      !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt .
+      !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt.
   METHODS change_max_parallel_processes
     IMPORTING
       !iv_package       TYPE devclass
     CHANGING
-      !cv_max_processes TYPE i .
+      !cv_max_processes TYPE i.
   METHODS change_proxy_authentication
     IMPORTING
       !iv_repo_url             TYPE csequence
     CHANGING
-      !cv_proxy_authentication TYPE abap_bool .
+      !cv_proxy_authentication TYPE abap_bool.
   METHODS change_proxy_port
     IMPORTING
       !iv_repo_url   TYPE csequence
     CHANGING
-      !cv_proxy_port TYPE string .
+      !cv_proxy_port TYPE string.
   METHODS change_proxy_url
     IMPORTING
       !iv_repo_url  TYPE csequence
     CHANGING
-      !cv_proxy_url TYPE string .
+      !cv_proxy_url TYPE string.
   METHODS change_rfc_server_group
     CHANGING
-      !cv_group TYPE rzlli_apcl .
+      !cv_group TYPE rzlli_apcl.
   METHODS change_supported_data_objects
     CHANGING
-      !ct_objects TYPE zif_abapgit_data_supporter=>ty_objects .
+      !ct_objects TYPE zif_abapgit_data_supporter=>ty_objects.
   METHODS change_supported_object_types
     CHANGING
-      !ct_types TYPE ty_object_types .
+      !ct_types TYPE ty_object_types.
   METHODS change_tadir
     IMPORTING
       !iv_package            TYPE devclass
@@ -75,14 +74,14 @@ INTERFACE zif_abapgit_exit
       !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
       !iv_only_local_objects TYPE abap_bool DEFAULT abap_false
     CHANGING
-      !ct_tadir              TYPE zif_abapgit_definitions=>ty_tadir_tt .
+      !ct_tadir              TYPE zif_abapgit_definitions=>ty_tadir_tt.
   METHODS create_http_client
     IMPORTING
       !iv_url          TYPE string
     RETURNING
       VALUE(ri_client) TYPE REF TO if_http_client
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS custom_serialize_abap_clif
     IMPORTING
       !is_class_key    TYPE ty_class_key
@@ -90,41 +89,41 @@ INTERFACE zif_abapgit_exit
     RETURNING
       VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS deserialize_postprocess
     IMPORTING
       !is_step TYPE zif_abapgit_objects=>ty_step_data
-      !ii_log  TYPE REF TO zif_abapgit_log .
+      !ii_log  TYPE REF TO zif_abapgit_log.
   METHODS determine_transport_request
     IMPORTING
       !io_repo              TYPE REF TO zcl_abapgit_repo
       !iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
     CHANGING
-      !cv_transport_request TYPE trkorr .
+      !cv_transport_request TYPE trkorr.
   METHODS enhance_repo_toolbar
     IMPORTING
       !io_menu TYPE REF TO zcl_abapgit_html_toolbar
       !iv_key  TYPE zif_abapgit_persistence=>ty_value
-      !iv_act  TYPE string .
+      !iv_act  TYPE string.
   METHODS get_ci_tests
     IMPORTING
       !iv_object   TYPE tadir-object
     CHANGING
-      !ct_ci_repos TYPE ty_ci_repos .
+      !ct_ci_repos TYPE ty_ci_repos.
   METHODS get_ssl_id
     RETURNING
-      VALUE(rv_ssl_id) TYPE ssfapplssl .
+      VALUE(rv_ssl_id) TYPE ssfapplssl.
   METHODS http_client
     IMPORTING
       !iv_url    TYPE string
-      !ii_client TYPE REF TO if_http_client .
+      !ii_client TYPE REF TO if_http_client.
   METHODS on_event
     IMPORTING
       !ii_event         TYPE REF TO zif_abapgit_gui_event
     RETURNING
       VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS pre_calculate_repo_status
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
@@ -132,25 +131,25 @@ INTERFACE zif_abapgit_exit
       !ct_local     TYPE zif_abapgit_definitions=>ty_files_item_tt
       !ct_remote    TYPE zif_abapgit_git_definitions=>ty_files_tt
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS serialize_postprocess
     IMPORTING
       !iv_package TYPE devclass
       !ii_log     TYPE REF TO zif_abapgit_log
     CHANGING
-      !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt .
+      !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt.
   METHODS validate_before_push
     IMPORTING
       !is_comment TYPE zif_abapgit_git_definitions=>ty_comment
       !io_stage   TYPE REF TO zcl_abapgit_stage
       !io_repo    TYPE REF TO zcl_abapgit_repo_online
     RAISING
-      zcx_abapgit_exception .
+      zcx_abapgit_exception.
   METHODS wall_message_list
     IMPORTING
-      !ii_html TYPE REF TO zif_abapgit_html .
+      !ii_html TYPE REF TO zif_abapgit_html.
   METHODS wall_message_repo
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-      !ii_html      TYPE REF TO zif_abapgit_html .
+      !ii_html      TYPE REF TO zif_abapgit_html.
 ENDINTERFACE.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -1,177 +1,156 @@
-INTERFACE zif_abapgit_exit PUBLIC.
+interface ZIF_ABAPGIT_EXIT
+  public .
 
-  TYPES:
+
+  types:
     BEGIN OF ty_ci_repo,
       name      TYPE string,
       clone_url TYPE string,
-    END OF ty_ci_repo.
-  TYPES:
-    ty_ci_repos TYPE TABLE OF ty_ci_repo.
-  TYPES:
-    ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY.
-  TYPES:
+    END OF ty_ci_repo .
+  types:
+    ty_ci_repos TYPE TABLE OF ty_ci_repo .
+  types:
+    ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY .
+  types:
     BEGIN OF ty_class_key,
       clsname TYPE abap_classname,
-    END OF ty_class_key.
+    END OF ty_class_key .
 
-  METHODS adjust_display_commit_url
-    IMPORTING
-      !iv_repo_url    TYPE csequence
-      !iv_repo_name   TYPE csequence
-      !iv_repo_key    TYPE csequence
-      !iv_commit_hash TYPE zif_abapgit_git_definitions=>ty_sha1
-    CHANGING
-      !cv_display_url TYPE csequence
-    RAISING
-      zcx_abapgit_exception.
-
-  METHODS adjust_display_filename
-    IMPORTING
-      !is_repo_meta      TYPE zif_abapgit_persistence=>ty_repo
-      !iv_filename       TYPE string
-    RETURNING
-      VALUE(rv_filename) TYPE string.
-
-  METHODS allow_sap_objects
-    RETURNING
-      VALUE(rv_allowed) TYPE abap_bool.
-
-  METHODS change_local_host
-    CHANGING
-      !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt.
-
-  METHODS change_max_parallel_processes
-    IMPORTING
-      iv_package       TYPE devclass
-    CHANGING
-      cv_max_processes TYPE i.
-
-  METHODS change_proxy_authentication
-    IMPORTING
-      !iv_repo_url             TYPE csequence
-    CHANGING
-      !cv_proxy_authentication TYPE abap_bool.
-
-  METHODS change_proxy_port
-    IMPORTING
-      !iv_repo_url   TYPE csequence
-    CHANGING
-      !cv_proxy_port TYPE string.
-
-  METHODS change_proxy_url
-    IMPORTING
-      !iv_repo_url  TYPE csequence
-    CHANGING
-      !cv_proxy_url TYPE string.
-
-  METHODS change_rfc_server_group
-    CHANGING
-      cv_group TYPE rzlli_apcl.
-
-  METHODS change_supported_data_objects
-    CHANGING
-      !ct_objects TYPE zif_abapgit_data_supporter=>ty_objects.
-
-  METHODS change_supported_object_types
-    CHANGING
-      !ct_types TYPE ty_object_types.
-
-  METHODS change_tadir
-    IMPORTING
-      !iv_package TYPE devclass
-      !ii_log     TYPE REF TO zif_abapgit_log
-    CHANGING
-      !ct_tadir   TYPE zif_abapgit_definitions=>ty_tadir_tt.
-
-  METHODS create_http_client
-    IMPORTING
-      !iv_url          TYPE string
-    RETURNING
-      VALUE(ri_client) TYPE REF TO if_http_client
-    RAISING
-      zcx_abapgit_exception.
-
-  METHODS custom_serialize_abap_clif
-    IMPORTING
-      !is_class_key    TYPE ty_class_key
-      !it_source       TYPE zif_abapgit_definitions=>ty_string_tt OPTIONAL
-    RETURNING
-      VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
-    RAISING
-      zcx_abapgit_exception.
-
-  METHODS deserialize_postprocess
-    IMPORTING
-      !is_step TYPE zif_abapgit_objects=>ty_step_data
-      !ii_log  TYPE REF TO zif_abapgit_log.
-
-  METHODS determine_transport_request
-    IMPORTING
-      !io_repo              TYPE REF TO zcl_abapgit_repo
-      !iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
-    CHANGING
-      !cv_transport_request TYPE trkorr.
-
-  METHODS enhance_repo_toolbar
-    IMPORTING
-      !io_menu TYPE REF TO zcl_abapgit_html_toolbar
-      !iv_key  TYPE zif_abapgit_persistence=>ty_value
-      !iv_act  TYPE string.
-
-  METHODS get_ci_tests
-    IMPORTING
-      !iv_object   TYPE tadir-object
-    CHANGING
-      !ct_ci_repos TYPE ty_ci_repos.
-
-  METHODS get_ssl_id
-    RETURNING
-      VALUE(rv_ssl_id) TYPE ssfapplssl.
-
-  METHODS http_client
-    IMPORTING
-      !iv_url    TYPE string
-      !ii_client TYPE REF TO if_http_client.
-
-  METHODS on_event
-    IMPORTING
-      !ii_event         TYPE REF TO zif_abapgit_gui_event
-    RETURNING
-      VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
-    RAISING
-      zcx_abapgit_exception.
-
-  METHODS pre_calculate_repo_status
-    IMPORTING
-      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-    CHANGING
-      !ct_local     TYPE zif_abapgit_definitions=>ty_files_item_tt
-      !ct_remote    TYPE zif_abapgit_git_definitions=>ty_files_tt
-    RAISING
-      zcx_abapgit_exception.
-
-  METHODS serialize_postprocess
-    IMPORTING
-      !iv_package TYPE devclass
-      !ii_log     TYPE REF TO zif_abapgit_log
-    CHANGING
-      !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt.
-
-  METHODS validate_before_push
-    IMPORTING
-      !is_comment TYPE zif_abapgit_git_definitions=>ty_comment
-      !io_stage   TYPE REF TO zcl_abapgit_stage
-      !io_repo    TYPE REF TO zcl_abapgit_repo_online
-    RAISING
-      zcx_abapgit_exception.
-
-  METHODS wall_message_list
-    IMPORTING
-      !ii_html TYPE REF TO zif_abapgit_html.
-
-  METHODS wall_message_repo
-    IMPORTING
-      !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
-      !ii_html      TYPE REF TO zif_abapgit_html.
-
-ENDINTERFACE.
+  methods ADJUST_DISPLAY_COMMIT_URL
+    importing
+      !IV_REPO_URL type CSEQUENCE
+      !IV_REPO_NAME type CSEQUENCE
+      !IV_REPO_KEY type CSEQUENCE
+      !IV_COMMIT_HASH type ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_SHA1
+    changing
+      !CV_DISPLAY_URL type CSEQUENCE
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods ADJUST_DISPLAY_FILENAME
+    importing
+      !IS_REPO_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
+      !IV_FILENAME type STRING
+    returning
+      value(RV_FILENAME) type STRING .
+  methods ALLOW_SAP_OBJECTS
+    returning
+      value(RV_ALLOWED) type ABAP_BOOL .
+  methods CHANGE_LOCAL_HOST
+    changing
+      !CT_HOSTS type ZIF_ABAPGIT_DEFINITIONS=>TY_STRING_TT .
+  methods CHANGE_MAX_PARALLEL_PROCESSES
+    importing
+      !IV_PACKAGE type DEVCLASS
+    changing
+      !CV_MAX_PROCESSES type I .
+  methods CHANGE_PROXY_AUTHENTICATION
+    importing
+      !IV_REPO_URL type CSEQUENCE
+    changing
+      !CV_PROXY_AUTHENTICATION type ABAP_BOOL .
+  methods CHANGE_PROXY_PORT
+    importing
+      !IV_REPO_URL type CSEQUENCE
+    changing
+      !CV_PROXY_PORT type STRING .
+  methods CHANGE_PROXY_URL
+    importing
+      !IV_REPO_URL type CSEQUENCE
+    changing
+      !CV_PROXY_URL type STRING .
+  methods CHANGE_RFC_SERVER_GROUP
+    changing
+      !CV_GROUP type RZLLI_APCL .
+  methods CHANGE_SUPPORTED_DATA_OBJECTS
+    changing
+      !CT_OBJECTS type ZIF_ABAPGIT_DATA_SUPPORTER=>TY_OBJECTS .
+  methods CHANGE_SUPPORTED_OBJECT_TYPES
+    changing
+      !CT_TYPES type TY_OBJECT_TYPES .
+  methods CHANGE_TADIR
+    importing
+      !IV_PACKAGE type DEVCLASS
+      !II_LOG type ref to ZIF_ABAPGIT_LOG
+      !IO_DOT type ref to ZCL_ABAPGIT_DOT_ABAPGIT
+      !IV_IGNORE_SUBPACKAGES type ABAP_BOOL default ABAP_FALSE
+      !IV_ONLY_LOCAL_OBJECTS type ABAP_BOOL default ABAP_FALSE
+    changing
+      !CT_TADIR type ZIF_ABAPGIT_DEFINITIONS=>TY_TADIR_TT .
+  methods CREATE_HTTP_CLIENT
+    importing
+      !IV_URL type STRING
+    returning
+      value(RI_CLIENT) type ref to IF_HTTP_CLIENT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods CUSTOM_SERIALIZE_ABAP_CLIF
+    importing
+      !IS_CLASS_KEY type TY_CLASS_KEY
+      !IT_SOURCE type ZIF_ABAPGIT_DEFINITIONS=>TY_STRING_TT optional
+    returning
+      value(RT_SOURCE) type ZIF_ABAPGIT_DEFINITIONS=>TY_STRING_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods DESERIALIZE_POSTPROCESS
+    importing
+      !IS_STEP type ZIF_ABAPGIT_OBJECTS=>TY_STEP_DATA
+      !II_LOG type ref to ZIF_ABAPGIT_LOG .
+  methods DETERMINE_TRANSPORT_REQUEST
+    importing
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO
+      !IV_TRANSPORT_TYPE type ZIF_ABAPGIT_DEFINITIONS=>TY_TRANSPORT_TYPE
+    changing
+      !CV_TRANSPORT_REQUEST type TRKORR .
+  methods ENHANCE_REPO_TOOLBAR
+    importing
+      !IO_MENU type ref to ZCL_ABAPGIT_HTML_TOOLBAR
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_VALUE
+      !IV_ACT type STRING .
+  methods GET_CI_TESTS
+    importing
+      !IV_OBJECT type TADIR-OBJECT
+    changing
+      !CT_CI_REPOS type TY_CI_REPOS .
+  methods GET_SSL_ID
+    returning
+      value(RV_SSL_ID) type SSFAPPLSSL .
+  methods HTTP_CLIENT
+    importing
+      !IV_URL type STRING
+      !II_CLIENT type ref to IF_HTTP_CLIENT .
+  methods ON_EVENT
+    importing
+      !II_EVENT type ref to ZIF_ABAPGIT_GUI_EVENT
+    returning
+      value(RS_HANDLED) type ZIF_ABAPGIT_GUI_EVENT_HANDLER=>TY_HANDLING_RESULT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods PRE_CALCULATE_REPO_STATUS
+    importing
+      !IS_REPO_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
+    changing
+      !CT_LOCAL type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT
+      !CT_REMOTE type ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_FILES_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods SERIALIZE_POSTPROCESS
+    importing
+      !IV_PACKAGE type DEVCLASS
+      !II_LOG type ref to ZIF_ABAPGIT_LOG
+    changing
+      !CT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT .
+  methods VALIDATE_BEFORE_PUSH
+    importing
+      !IS_COMMENT type ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_COMMENT
+      !IO_STAGE type ref to ZCL_ABAPGIT_STAGE
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO_ONLINE
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods WALL_MESSAGE_LIST
+    importing
+      !II_HTML type ref to ZIF_ABAPGIT_HTML .
+  methods WALL_MESSAGE_REPO
+    importing
+      !IS_REPO_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
+      !II_HTML type ref to ZIF_ABAPGIT_HTML .
+endinterface.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -71,7 +71,7 @@ INTERFACE zif_abapgit_exit
     IMPORTING
       !iv_package TYPE devclass
       !ii_log TYPE REF TO zif_abapgit_log
-      !is_dot_data TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
+      !is_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
       !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
       !iv_only_local_objects TYPE abap_bool DEFAULT abap_false
     CHANGING

--- a/src/exits/zif_abapgit_exit.intf.xml
+++ b/src/exits/zif_abapgit_exit.intf.xml
@@ -10,6 +10,14 @@
     <STATE>1</STATE>
     <UNICODE>X</UNICODE>
    </VSEOINTERF>
+   <DESCRIPTIONS_SUB>
+    <SEOSUBCOTX>
+     <CMPNAME>CHANGE_TADIR</CMPNAME>
+     <SCONAME>IO_DOT</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>abapGit - .abapgit.xml</DESCRIPT>
+    </SEOSUBCOTX>
+   </DESCRIPTIONS_SUB>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/exits/zif_abapgit_exit.intf.xml
+++ b/src/exits/zif_abapgit_exit.intf.xml
@@ -10,14 +10,6 @@
     <STATE>1</STATE>
     <UNICODE>X</UNICODE>
    </VSEOINTERF>
-   <DESCRIPTIONS_SUB>
-    <SEOSUBCOTX>
-     <CMPNAME>CHANGE_TADIR</CMPNAME>
-     <SCONAME>IO_DOT</SCONAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>abapGit - .abapgit.xml</DESCRIPT>
-    </SEOSUBCOTX>
-   </DESCRIPTIONS_SUB>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/objects/core/zcl_abapgit_tadir.clas.abap
+++ b/src/objects/core/zcl_abapgit_tadir.clas.abap
@@ -77,7 +77,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_tadir IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
 
 
   METHOD add_local_packages.
@@ -403,10 +403,13 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
     li_exit = zcl_abapgit_exit=>get_instance( ).
     li_exit->change_tadir(
       EXPORTING
-        iv_package = iv_package
-        ii_log     = ii_log
+        iv_package            = iv_package
+        ii_log                = ii_log
+        io_dot                = io_dot
+        iv_ignore_subpackages = iv_ignore_subpackages
+        iv_only_local_objects = iv_only_local_objects
       CHANGING
-        ct_tadir   = rt_tadir ).
+        ct_tadir              = rt_tadir ).
 
     IF it_filter IS NOT INITIAL.
       "Apply filter manually instead of calling zcl_abapgit_repo_filter->apply,

--- a/src/objects/core/zcl_abapgit_tadir.clas.abap
+++ b/src/objects/core/zcl_abapgit_tadir.clas.abap
@@ -77,7 +77,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
+CLASS zcl_abapgit_tadir IMPLEMENTATION.
 
 
   METHOD add_local_packages.
@@ -405,7 +405,7 @@ CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
       EXPORTING
         iv_package            = iv_package
         ii_log                = ii_log
-        io_dot                = io_dot
+        is_dot_data           = io_dot->get_data( )
         iv_ignore_subpackages = iv_ignore_subpackages
         iv_only_local_objects = iv_only_local_objects
       CHANGING

--- a/src/objects/core/zcl_abapgit_tadir.clas.abap
+++ b/src/objects/core/zcl_abapgit_tadir.clas.abap
@@ -405,7 +405,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
       EXPORTING
         iv_package            = iv_package
         ii_log                = ii_log
-        is_dot_data           = io_dot->get_data( )
+        is_dot_abapgit        = io_dot->get_data( )
         iv_ignore_subpackages = iv_ignore_subpackages
         iv_only_local_objects = iv_only_local_objects
       CHANGING


### PR DESCRIPTION
Including in the method change_tadir of the user exits, the 3 parameters from local settings :

1. Ignore subpackages
2. Only Local Objects
3. Only Serialize Main Language

So that they are available for the implementation of the exit.

![image](https://github.com/abapGit/abapGit/assets/113029567/5c91a8aa-8786-4cd7-bd6d-6c8448b762e1)
