### PR TITLE
Ignore macOS "Desktop Services Store" files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ list.txt
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.DS_Store


### PR DESCRIPTION
In the Apple macOS operating system, .DS_Store is a file that stores custom attributes of its containing folder, such as folder view options, icon positions, and other visual information.
See: https://en.wikipedia.org/wiki/.DS_Store

We don't want to track them in our git repo.