### PR TITLE
Fix bug in Command Palette

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2416,7 +2416,7 @@ function enumerateUiActions() {
           if (anchor.href.includes("label")) {
             result = "Label: " + result;
           }
-          return result;
+          return result.trim();
         })()
       });
     });


### PR DESCRIPTION
Fix issue in Command Palette ("Only Favorites" and "Detail") following @mbtools' recommendation of trimming the text in JavaScript.
Details of this issue can be found in #6798.