### PR TITLE
HTTP connection check and improved error messages

### DIFF
--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -323,14 +323,14 @@ CLASS zcl_abapgit_http IMPLEMENTATION.
         iv_act   = |{ zif_abapgit_definitions=>c_action-jump_transaction }?transaction=SMICM|
         iv_class = 'no-pad' )
       && |)|.
-  
+
     IF lv_proxy IS NOT INITIAL.
       rv_longtext = rv_longtext
         && |, and proxy configuration (|
         && zcl_abapgit_html=>create( )->a(
           iv_txt   = 'global settings'
           iv_act   = |{ zif_abapgit_definitions=>c_action-go_settings }|
-          iv_class = 'no-pad' ).
+          iv_class = 'no-pad' )
         && ')'.
     ENDIF.
 

--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -307,26 +307,41 @@ CLASS zcl_abapgit_http IMPLEMENTATION.
 
     rv_longtext = |abapGit is trying to connect to <b>{ iv_host }</b> |
       && |using SSL certificates under <b>{ iv_ssl_id }</b>{ lv_proxy }. |
-      && |Check system parameters |
+      && |Check system parameters (transaction |
       && zcl_abapgit_html=>create( )->a(
-        iv_txt   = '(transaction RZ10)'
+        iv_txt   = 'RZ10'
         iv_act   = |{ zif_abapgit_definitions=>c_action-jump_transaction }?transaction=RZ10|
         iv_class = 'no-pad' )
-      && |, SSL setup |
+      && |), SSL setup (transaction |
       && zcl_abapgit_html=>create( )->a(
-        iv_txt   = '(transaction STRUST)'
+        iv_txt   = 'STRUST'
         iv_act   = |{ zif_abapgit_definitions=>c_action-jump_transaction }?transaction=STRUST|
         iv_class = 'no-pad' )
-      && |, and proxy configuration |
+      && |), Internet connection monitor (transaction |
       && zcl_abapgit_html=>create( )->a(
-        iv_txt   = '(global settings)'
-        iv_act   = |{ zif_abapgit_definitions=>c_action-go_settings }|
-        iv_class = 'no-pad' ) && '.'
+        iv_txt   = 'SMICM'
+        iv_act   = |{ zif_abapgit_definitions=>c_action-jump_transaction }?transaction=SMICM|
+        iv_class = 'no-pad' )
+      && |)|.
+  
+    IF lv_proxy IS NOT INITIAL.
+      rv_longtext = rv_longtext
+        && |, and proxy configuration (|
+        && zcl_abapgit_html=>create( )->a(
+          iv_txt   = 'global settings'
+          iv_act   = |{ zif_abapgit_definitions=>c_action-go_settings }|
+          iv_class = 'no-pad' ).
+        && ')'.
+    ENDIF.
+
+    rv_longtext = rv_longtext
+      && |. It's recommended to get your SAP Basis and network teams involved. |
       && |For more information and troubleshooting, see the |
       && zcl_abapgit_html=>create( )->a(
         iv_txt   = 'abapGit documentation'
         iv_act   = |{ zif_abapgit_definitions=>c_action-url }?url={ lc_docs }|
-        iv_class = 'no-pad' ) && '.'.
+        iv_class = 'no-pad' ) 
+      && '.'.
 
   ENDMETHOD.
 

--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -297,11 +297,11 @@ CLASS zcl_abapgit_http IMPLEMENTATION.
       lv_proxy_service       TYPE string,
       lo_proxy_configuration TYPE REF TO zcl_abapgit_proxy_config.
 
+    CREATE OBJECT lo_proxy_configuration.
+
     ri_client = zcl_abapgit_exit=>get_instance( )->create_http_client( iv_url ).
 
     IF ri_client IS INITIAL.
-
-      CREATE OBJECT lo_proxy_configuration.
 
       lv_host          = zcl_abapgit_url=>host( iv_url ).
       lv_ssl_id        = zcl_abapgit_exit=>get_instance( )->get_ssl_id( ).

--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -340,7 +340,7 @@ CLASS zcl_abapgit_http IMPLEMENTATION.
       && zcl_abapgit_html=>create( )->a(
         iv_txt   = 'abapGit documentation'
         iv_act   = |{ zif_abapgit_definitions=>c_action-url }?url={ lc_docs }|
-        iv_class = 'no-pad' ) 
+        iv_class = 'no-pad' )
       && '.'.
 
   ENDMETHOD.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -467,6 +467,8 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
         lv_longtext = |{ lv_longtext }<p>{ <lv_longtext_paragraph> }</p>{ cl_abap_char_utilities=>newline }|.
       ENDLOOP.
+
+      lv_longtext = |{ lv_longtext }<br>|.
     ENDIF.
 
     ri_html->add( |<div id="message" class="message-panel">| ).
@@ -490,7 +492,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
         iv_msgno = ix_error->if_t100_message~t100key-msgno ).
 
       IF lv_title IS NOT INITIAL.
-        lv_text = |Message ({ ix_error->if_t100_message~t100key-msgid }/{ ix_error->if_t100_message~t100key-msgno })|.
+        lv_text = |Message E{ ix_error->if_t100_message~t100key-msgno }({ ix_error->if_t100_message~t100key-msgid })|.
 
         ri_html->add_a(
           iv_txt   = lv_text

--- a/src/ui/pages/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_addonline.clas.abap
@@ -229,6 +229,8 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
             iv_key = c_id-url
             iv_val = lx_err->get_text( ) ).
       ENDTRY.
+
+      zcl_abapgit_http=>check_connection( lv_url ).
     ENDIF.
 
     IF io_form_data->get( c_id-package ) IS NOT INITIAL.

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -43,6 +43,7 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
 
     DATA mo_repo TYPE REF TO zcl_abapgit_repo .
     DATA mo_repo_aggregated_state TYPE REF TO zcl_abapgit_repo_item_state.
+    DATA mv_connection_error TYPE abap_bool.
     DATA mv_cur_dir TYPE string .
     DATA mv_hide_files TYPE abap_bool .
     DATA mv_max_lines TYPE i .
@@ -189,6 +190,10 @@ CLASS zcl_abapgit_gui_page_repo_view DEFINITION
         VALUE(rv_crossout) LIKE zif_abapgit_html=>c_html_opt-crossout.
 
     METHODS check_branch
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS check_connection
       RAISING
         zcx_abapgit_exception.
 
@@ -572,6 +577,22 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
       lo_repo ?= mo_repo.
       lo_repo->check_for_valid_branch( ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD check_connection.
+
+    DATA lo_repo TYPE REF TO zif_abapgit_repo_online.
+
+    mv_connection_error = abap_true.
+
+    IF mo_repo->is_offline( ) = abap_false.
+      lo_repo ?= mo_repo.
+      zcl_abapgit_http=>check_connection( lo_repo->get_url( ) ).
+    ENDIF.
+
+    mv_connection_error = abap_false.
 
   ENDMETHOD.
 
@@ -1229,6 +1250,23 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
         " Reinit, for the case of type change
         mo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( mo_repo->get_key( ) ).
 
+        IF mv_connection_error = abap_true.
+          " If connection doesn't work, render a minimal header
+          ri_html->add( |<div class="repo" id="repo{ mv_key }">| ).
+          ri_html->add( zcl_abapgit_gui_chunk_lib=>render_repo_top(
+            io_repo               = mo_repo
+            iv_show_edit          = abap_true
+            iv_show_branch        = abap_false
+            iv_show_commit        = abap_false
+            iv_interactive_branch = abap_false ) ).
+          ri_html->add( '</div>' ).
+
+          CLEAR mv_connection_error.
+          RETURN.
+        ENDIF.
+
+        check_connection( ).
+
         check_branch( ).
 
         mv_are_changes_recorded_in_tr = zcl_abapgit_factory=>get_sap_package( mo_repo->get_package( )
@@ -1346,11 +1384,7 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
         " and allow troubleshooting of issue
         zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( || ).
 
-        ri_html->add( render_head_line( ) ).
-
-        ri_html->add( zcl_abapgit_gui_chunk_lib=>render_error(
-          iv_extra_style = 'repo_banner'
-          ix_error = lx_error ) ).
+        RAISE EXCEPTION lx_error.
     ENDTRY.
 
     register_deferred_script( render_scripts( ) ).

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -1261,6 +1261,9 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
             iv_interactive_branch = abap_false ) ).
           ri_html->add( '</div>' ).
 
+          ri_html->add( render_head_line( ) ).
+
+          " Reset error flag to try connecting again next time
           CLEAR mv_connection_error.
           RETURN.
         ENDIF.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -121,6 +121,7 @@ CLASS zcl_abapgit_gui_page_sett_remo DEFINITION
     METHODS validate_form
       IMPORTING
         io_form_data             TYPE REF TO zcl_abapgit_string_map
+        iv_connection_check      TYPE abap_bool DEFAULT abap_true
       RETURNING
         VALUE(ro_validation_log) TYPE REF TO zcl_abapgit_string_map
       RAISING
@@ -864,6 +865,10 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
             iv_key = c_id-url
             iv_val = lx_error->get_text( ) ).
       ENDTRY.
+
+      IF iv_connection_check = abap_true.
+        zcl_abapgit_http=>check_connection( lv_url ).
+      ENDIF.
     ENDIF.
 
     IF lv_offline = abap_false.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.testclasses.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.testclasses.abap
@@ -378,7 +378,9 @@ CLASS ltcl_validate_form IMPLEMENTATION.
 
   METHOD when_validate_form.
 
-    mo_act_validation_log = mo_cut->validate_form( mo_given_form_data ).
+    mo_act_validation_log = mo_cut->validate_form(
+      io_form_data        = mo_given_form_data
+      iv_connection_check = abap_false ).
 
   ENDMETHOD.
 

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -176,7 +176,7 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         system_failure        = 2 MESSAGE lv_msg
         OTHERS                = 3.
     IF sy-subrc <> 0.
-      lv_msg =  |Error starting transaction { iv_tcode }: { lv_msg }|.
+      lv_msg = |Error starting transaction { iv_tcode }: { lv_msg }|.
       MESSAGE lv_msg TYPE 'I'.
     ELSE.
       lv_msg = |Transaction { iv_tcode } opened in a new window|.

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -120,6 +120,11 @@ CLASS zcl_abapgit_gui_router DEFINITION
         !iv_url TYPE csequence
       RAISING
         zcx_abapgit_exception .
+    METHODS call_transaction
+      IMPORTING
+        !iv_tcode TYPE csequence
+      RAISING
+        zcx_abapgit_exception .
     METHODS get_state_settings
       IMPORTING
         !ii_event       TYPE REF TO zif_abapgit_gui_event
@@ -153,6 +158,30 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
   METHOD call_browser.
 
     zcl_abapgit_ui_factory=>get_frontend_services( )->execute( iv_document = |{ iv_url }| ).
+
+  ENDMETHOD.
+
+
+  METHOD call_transaction.
+
+    DATA lv_msg TYPE c LENGTH 200.
+
+    CALL FUNCTION 'ABAP4_CALL_TRANSACTION'
+      DESTINATION 'NONE'
+      STARTING NEW TASK 'ABAPGIT'
+      EXPORTING
+        tcode                 = iv_tcode
+      EXCEPTIONS
+        communication_failure = 1 MESSAGE lv_msg
+        system_failure        = 2 MESSAGE lv_msg
+        OTHERS                = 3.
+    IF sy-subrc <> 0.
+      lv_msg =  |Error starting transaction { iv_tcode }: { lv_msg }|.
+      MESSAGE lv_msg TYPE 'I'.
+    ELSE.
+      lv_msg = |Transaction { iv_tcode } opened in a new window|.
+      MESSAGE lv_msg TYPE 'S'.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -678,6 +707,10 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
           iv_line       = ii_event->query( )->get( 'LINE' )
           iv_new_window = ii_event->query( )->get( 'NEW_WINDOW' ) ).
 
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
+
+      WHEN zif_abapgit_definitions=>c_action-jump_transaction.
+        call_transaction( |{ ii_event->query( )->get( 'TRANSACTION' ) }| ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
 
       WHEN zif_abapgit_definitions=>c_action-jump_transport.

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -74,6 +74,7 @@ span.separator {
 .w40          { width: 40%; }
 .float-right  { float: right; }
 .pad-right    { padding-right: 6px; }
+.no-pad       { padding: 0px !important; }
 .inline       { display: inline; }
 .hidden       { visibility: hidden; }
 .nodisplay    { display: none }

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -341,6 +341,7 @@ INTERFACE zif_abapgit_definitions
       homepage                      TYPE string VALUE 'homepage',
       ie_devtools                   TYPE string VALUE 'ie_devtools',
       jump                          TYPE string VALUE 'jump',
+      jump_transaction              TYPE string VALUE 'jump_transaction',
       jump_transport                TYPE string VALUE 'jump_transport',
       jump_user                     TYPE string VALUE 'jump_user',
       performance_test              TYPE string VALUE 'performance_test',


### PR DESCRIPTION
One of the most common problems in abapGit is dealing with [connection issues](https://github.com/abapGit/abapGit/issues?q=is%3Aissue+ssl+is%3Aclosed).

This change introduces a connection check when working with online repositories. The connection is checked in the following situations:

- Creating a new online repo
- Changing the URL in remote settings of a repo
- Opening the repository view of a repo

Errors are now shown at the bottom of the current page. This allows viewing of the error longtext, which now provides details about the attempted HTTP connection (hostname, SSL ID, and proxy). It also includes links to the important transactions (rz10, strust), the global proxy settings, and the corresponding abapGit documentation (see last screenshot).

On the repo view, the header remains visible so that you can jump to the repo settings as well, for example, to correct the URL.

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/4b9fc8e9-1781-4512-88ff-9851a30518eb)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/bfde3982-ccdf-4772-9ed1-0a8291fa9733)

![image](https://github.com/abapGit/abapGit/assets/59966492/328c9cc4-332c-4689-a83e-1ed956ba72ff)

![image](https://github.com/abapGit/abapGit/assets/59966492/010f91f6-83bf-41e3-b851-3a32621dcceb)

Closes #6772