### PR TITLE
Update the text "Submit Query" in the Command Palette.

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -560,7 +560,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_name      = |filter|
       iv_label     = |Filter: { render_filter_help_hint( ) }|
       iv_value     = ms_list_settings-filter ) ).
-    ri_html->add( |<input type="submit" class="hidden-submit">| ).
+    ri_html->add( |<input type="submit" class="hidden-submit" title="Filter">| ).
     ri_html->add( |</form>| ).
 
     IF ms_list_settings-only_favorites = abap_true.

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2383,7 +2383,7 @@ function enumerateUiActions() {
             submitSapeventForm({}, input.formAction, "post", input.form);
           }
         },
-        title: input.value + " " + input.title.replace(/\[.*\]/, "")
+        title: (input.value === "Submit Query" ? input.title : input.value + " " + input.title.replace(/\[.*\]/, ""))
       });
     });
 


### PR DESCRIPTION
***Update:
This new PR addresses the issue identified in #6807 by updating the text of the "Submit Query" action in the Command Palette on the "Repository List" page to "Filter".**

We've opted to implement a solution suggested by Marc, which involves directly updating the text of the action in the Command Palette (refer to https://github.com/abapGit/abapGit/issues/6807). This approach provides an immediate resolution to the inconsistency and ensures alignment with the corresponding command in the form interface.

@sbcgua, I appreciate your recommendation to mark unlistable commands in HTML for semantic correctness (#6808). While we've chosen a different solution for now, we'll keep your suggestion in mind for future enhancements to maintain flexibility and scalability in our codebase.