### PR TITLE
Improve form validation of text fields

### DIFF
--- a/src/ui/lib/zcl_abapgit_html_form_utils.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form_utils.clas.abap
@@ -267,15 +267,21 @@ CLASS zcl_abapgit_html_form_utils IMPLEMENTATION.
       ENDIF.
       CASE <ls_field>-type.
         WHEN zif_abapgit_html_form=>c_field_type-text.
-          IF <ls_field>-min <> cl_abap_math=>min_int4 AND strlen( lv_value ) < <ls_field>-min.
+          IF <ls_field>-min = <ls_field>-max AND strlen( lv_value ) <> <ls_field>-min.
             ro_validation_log->set(
               iv_key = <ls_field>-name
-              iv_val = |{ <ls_field>-label } must not be shorter than { <ls_field>-min } characters| ).
-          ENDIF.
-          IF <ls_field>-max <> cl_abap_math=>max_int4 AND strlen( lv_value ) > <ls_field>-max.
-            ro_validation_log->set(
-              iv_key = <ls_field>-name
-              iv_val = |{ <ls_field>-label } must not be longer than { <ls_field>-max } characters| ).
+              iv_val = |{ <ls_field>-label } must be exactly { <ls_field>-min } characters long| ).
+          ELSE.
+            IF <ls_field>-min <> cl_abap_math=>min_int4 AND strlen( lv_value ) < <ls_field>-min.
+              ro_validation_log->set(
+                iv_key = <ls_field>-name
+                iv_val = |{ <ls_field>-label } must not be shorter than { <ls_field>-min } characters| ).
+            ENDIF.
+            IF <ls_field>-max <> cl_abap_math=>max_int4 AND strlen( lv_value ) > <ls_field>-max.
+              ro_validation_log->set(
+                iv_key = <ls_field>-name
+                iv_val = |{ <ls_field>-label } must not be longer than { <ls_field>-max } characters| ).
+            ENDIF.
           ENDIF.
         WHEN zif_abapgit_html_form=>c_field_type-number.
           TRY.

--- a/src/ui/lib/zcl_abapgit_html_form_utils.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_form_utils.clas.testclasses.abap
@@ -120,6 +120,7 @@ CLASS ltcl_test_form DEFINITION
     METHODS validate1 FOR TESTING RAISING zcx_abapgit_exception.
     METHODS validate2 FOR TESTING RAISING zcx_abapgit_exception.
     METHODS validate3 FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS validate4 FOR TESTING RAISING zcx_abapgit_exception.
     METHODS normalize FOR TESTING RAISING zcx_abapgit_exception.
     METHODS is_empty FOR TESTING RAISING zcx_abapgit_exception.
     METHODS exit_clean FOR TESTING RAISING zcx_abapgit_exception.
@@ -312,6 +313,50 @@ CLASS ltcl_test_form IMPLEMENTATION.
     lo_form_data->set(
       iv_key = 'field4'
       iv_val = '150' ).
+
+    lo_log = lo_cut->validate( lo_form_data ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 0 ).
+
+  ENDMETHOD.
+
+  METHOD validate4.
+
+    DATA lo_cut TYPE REF TO zcl_abapgit_html_form_utils.
+    DATA lo_form TYPE REF TO zcl_abapgit_html_form.
+    DATA lo_form_data TYPE REF TO zcl_abapgit_string_map.
+    DATA lo_log TYPE REF TO zcl_abapgit_string_map.
+
+    " New form
+    lo_form = zcl_abapgit_html_form=>create( ).
+    lo_form_data = zcl_abapgit_string_map=>create( ).
+
+    lo_form->text(
+      iv_name  = 'field5'
+      iv_min   = 5
+      iv_max   = 5
+      iv_label = 'Field name 5' ).
+
+    lo_cut = zcl_abapgit_html_form_utils=>create( lo_form ).
+
+    lo_form_data->set(
+      iv_key = 'field5'
+      iv_val = 'xy' ).
+
+    lo_log = lo_cut->validate( lo_form_data ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_log->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_log->get( 'field5' )
+      exp = '*must be exactly*' ).
+
+    lo_form_data->set(
+      iv_key = 'field5'
+      iv_val = 'abcde' ).
 
     lo_log = lo_cut->validate( lo_form_data ).
 


### PR DESCRIPTION
Better validation message for fields that have a fixed length (min = max len).

Example:

![image](https://github.com/abapGit/abapGit/assets/59966492/fd1b12d8-40eb-4999-89ef-e21b77da9080)
