### PR TITLE
Improve error messages when checking branches/tags

### DIFF
--- a/src/git/zcl_abapgit_git_branch_list.clas.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.abap
@@ -45,6 +45,11 @@ CLASS zcl_abapgit_git_branch_list DEFINITION
         !iv_current_row_index TYPE sy-tabix OPTIONAL
       RETURNING
         VALUE(rv_type)        TYPE zif_abapgit_git_definitions=>ty_git_branch_type .
+    CLASS-METHODS get_description
+      IMPORTING
+        !iv_branch_name       TYPE clike
+      RETURNING
+        VALUE(rv_description) TYPE string.
     CLASS-METHODS complete_heads_branch_name
       IMPORTING
         !iv_branch_name TYPE clike
@@ -130,8 +135,7 @@ CLASS zcl_abapgit_git_branch_list IMPLEMENTATION.
         WITH TABLE KEY name_key
         COMPONENTS name = iv_branch_name.
       IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |Branch { get_display_name( iv_branch_name )
-          } not found. Use 'Branch' > 'Switch' to select a different branch| ).
+        zcx_abapgit_exception=>raise( |{ get_description( iv_branch_name ) } not found| ).
       ENDIF.
 
     ENDIF.
@@ -150,7 +154,7 @@ CLASS zcl_abapgit_git_branch_list IMPLEMENTATION.
         WITH TABLE KEY name_key
         COMPONENTS name = iv_branch_name.
       IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( 'Branch not found' ).
+        zcx_abapgit_exception=>raise( |{ get_description( iv_branch_name ) } not found| ).
       ENDIF.
 
     ENDIF.
@@ -173,6 +177,24 @@ CLASS zcl_abapgit_git_branch_list IMPLEMENTATION.
         APPEND <ls_branch> TO rt_branches.
       ENDIF.
     ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD get_description.
+
+    CASE get_type( iv_branch_name ).
+      WHEN zif_abapgit_git_definitions=>c_git_branch_type-branch.
+        rv_description = 'Branch'.
+      WHEN zif_abapgit_git_definitions=>c_git_branch_type-lightweight_tag.
+        rv_description = 'Tag'.
+      WHEN zif_abapgit_git_definitions=>c_git_branch_type-annotated_tag.
+        rv_description = 'Annotated Tag'.
+      WHEN OTHERS.
+        rv_description = 'Branch'.
+    ENDCASE.
+
+    rv_description = |{ rv_description } "{ get_display_name( iv_branch_name ) }"|.
+
   ENDMETHOD.
 
 

--- a/src/repo/zcl_abapgit_repo_online.clas.abap
+++ b/src/repo/zcl_abapgit_repo_online.clas.abap
@@ -174,6 +174,7 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     DATA:
       lo_branch_list TYPE REF TO zcl_abapgit_git_branch_list,
+      lx_error       TYPE REF TO zcx_abapgit_exception,
       lv_branch      TYPE string,
       lv_head        TYPE string,
       lv_msg         TYPE string.
@@ -185,16 +186,10 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
       TRY.
           lo_branch_list->find_by_name( lv_branch ).
-        CATCH zcx_abapgit_exception.
+        CATCH zcx_abapgit_exception INTO lx_error.
           " branch does not exist, fallback to head
           lv_head = lo_branch_list->get_head_symref( ).
-          IF lo_branch_list->get_type( lv_branch ) = zif_abapgit_git_definitions=>c_git_branch_type-branch.
-            lv_msg = 'Branch'.
-          ELSE.
-            lv_msg = 'Tag'.
-          ENDIF.
-          lv_msg = |{ lv_msg } { lo_branch_list->get_display_name( lv_branch ) } does not exist.|
-                && | Switched to { lo_branch_list->get_display_name( lv_head ) }|.
+          lv_msg = |{ lx_error->get_text( ) }. Switched to { lo_branch_list->get_display_name( lv_head ) }|.
           MESSAGE lv_msg TYPE 'S'.
           select_branch( lv_head ).
       ENDTRY.

--- a/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_sett_remo.clas.abap
@@ -890,7 +890,7 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
 
           " Cannot check for commit existence currently (needs API that doesn't rely on finding the first commit
           " in the branch), check format instead
-          IF lv_commit CN '0123456789abcdef'.
+          IF lv_commit CN '0123456789abcdef' AND ro_validation_log->get( c_id-commit ) IS INITIAL.
             ro_validation_log->set(
               iv_key = c_id-commit
               iv_val = 'Commit needs to be hexadecimal and in lowercase' ).
@@ -901,16 +901,19 @@ CLASS zcl_abapgit_gui_page_sett_remo IMPLEMENTATION.
             iv_val = 'Unknown head type' ).
       ENDCASE.
 
-      TRY.
-          IF lv_branch IS NOT INITIAL.
-            lo_branch_list = zcl_abapgit_git_factory=>get_git_transport( )->branches( lv_url ).
+      IF lv_branch IS NOT INITIAL.
+        " Problems with getting branches in general are raised to the page
+        lo_branch_list = zcl_abapgit_git_factory=>get_git_transport( )->branches( lv_url ).
+
+        TRY.
+            " Issues with finding a particular branch are shown next to corresponding field
             lo_branch_list->find_by_name( lv_branch ).
-          ENDIF.
-        CATCH zcx_abapgit_exception INTO lx_error.
-          ro_validation_log->set(
-            iv_key = lv_branch_check_error_id
-            iv_val = lx_error->get_text( ) ).
-      ENDTRY.
+          CATCH zcx_abapgit_exception INTO lx_error.
+            ro_validation_log->set(
+              iv_key = lv_branch_check_error_id
+              iv_val = lx_error->get_text( ) ).
+        ENDTRY.
+      ENDIF.
     ENDIF.
   ENDMETHOD.
 


### PR DESCRIPTION
- Avoid mixing up "branch" and "tag" in message texts

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/11b2820d-1194-4796-b995-4df1c189012e)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/eae927d6-5b45-4681-9984-0af5856fc977)

- Remove text from message that fits only certain situations

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/aa2211b9-e225-47dc-9631-d86329a67652)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/d180ffbc-6a2f-41ae-98fe-eeefcc64d0db)

On repo settings, show errors related to HTTP connection at bottom on page instead of next to "branch" field.

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/82f97525-fdbb-4dcb-a5d1-ff0b2d1c296f)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/41c5a88a-aab5-4fa6-8fd1-5957a5290856)
