### PR TITLE
Add "ignore sub-packages" option to package export

### DIFF
--- a/src/repo/utils/zcl_abapgit_zip.clas.abap
+++ b/src/repo/utils/zcl_abapgit_zip.clas.abap
@@ -34,6 +34,7 @@ CLASS zcl_abapgit_zip DEFINITION
         !iv_package        TYPE devclass
         !iv_folder_logic   TYPE string
         !iv_main_lang_only TYPE abap_bool
+        !iv_ign_subpkg     TYPE abap_bool OPTIONAL
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS load
@@ -196,6 +197,7 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
           lv_zip_xstring     TYPE xstring.
 
     ls_local_settings-main_language_only = iv_main_lang_only.
+    ls_local_settings-ignore_subpackages = iv_ign_subpkg.
 
     lo_dot_abapgit = zcl_abapgit_dot_abapgit=>build_default( ).
     lo_dot_abapgit->set_folder_logic( iv_folder_logic ).
@@ -207,18 +209,19 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
     lv_default = |{ lv_package_escaped }_{ sy-datlo }_{ sy-timlo }.zip|.
 
     lv_zip_xstring = export(
-     is_local_settings = ls_local_settings
-     iv_package        = iv_package
-     io_dot_abapgit    = lo_dot_abapgit ).
+      is_local_settings = ls_local_settings
+      iv_package        = iv_package
+      io_dot_abapgit    = lo_dot_abapgit ).
 
     lv_path = lo_frontend_serv->show_file_save_dialog(
-        iv_title            = 'Package Export'
-        iv_extension        = 'zip'
-        iv_default_filename = lv_default ).
+      iv_title            = 'Package Export'
+      iv_extension        = 'zip'
+      iv_default_filename = lv_default ).
 
     lo_frontend_serv->file_download(
-        iv_path = lv_path
-        iv_xstr = lv_zip_xstring ).
+      iv_path = lv_path
+      iv_xstr = lv_zip_xstring ).
+
   ENDMETHOD.
 
 

--- a/src/ui/pages/zcl_abapgit_gui_page_ex_pckage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_ex_pckage.clas.abap
@@ -21,9 +21,10 @@ CLASS zcl_abapgit_gui_page_ex_pckage DEFINITION
   PRIVATE SECTION.
     CONSTANTS:
       BEGIN OF c_id,
-        package        TYPE string VALUE 'package',
-        folder_logic   TYPE string VALUE 'folder_logic',
-        main_lang_only TYPE string VALUE 'main_lang_only',
+        package            TYPE string VALUE 'package',
+        folder_logic       TYPE string VALUE 'folder_logic',
+        ignore_subpackages TYPE string VALUE 'ignore_subpackages',
+        main_lang_only     TYPE string VALUE 'main_lang_only',
       END OF c_id.
 
     CONSTANTS:
@@ -74,16 +75,19 @@ CLASS zcl_abapgit_gui_page_ex_pckage IMPLEMENTATION.
   METHOD export_package.
     DATA lv_package TYPE devclass.
     DATA lv_folder_logic TYPE string.
+    DATA lv_ign_subpkg TYPE abap_bool.
     DATA lv_main_lang_only TYPE abap_bool.
 
     lv_package        = mo_form_data->get( c_id-package ).
     lv_folder_logic   = mo_form_data->get( c_id-folder_logic ).
+    lv_ign_subpkg     = mo_form_data->get( c_id-ignore_subpackages ).
     lv_main_lang_only = mo_form_data->get( c_id-main_lang_only ).
 
     zcl_abapgit_zip=>export_package(
-        iv_package        = lv_package
-        iv_folder_logic   = lv_folder_logic
-        iv_main_lang_only = lv_main_lang_only ).
+      iv_package        = lv_package
+      iv_folder_logic   = lv_folder_logic
+      iv_ign_subpkg     = lv_ign_subpkg
+      iv_main_lang_only = lv_main_lang_only ).
   ENDMETHOD.
 
 
@@ -111,9 +115,13 @@ CLASS zcl_abapgit_gui_page_ex_pckage IMPLEMENTATION.
       iv_label         = 'Mixed'
       iv_value         = zif_abapgit_dot_abapgit=>c_folder_logic-mixed
     )->checkbox(
+      iv_name          = c_id-ignore_subpackages
+      iv_label         = 'Ignore Subpackages'
+      iv_hint          = 'Export selected package only'
+    )->checkbox(
       iv_name          = c_id-main_lang_only
       iv_label         = 'Serialize Main Language Only'
-      iv_hint          = 'Ignore translations, serialize just main language'
+      iv_hint          = 'Ignore translations, export just main language'
     )->command(
       iv_label         = 'Export Package to ZIP'
       iv_action        = c_event-export_package


### PR DESCRIPTION
You can now select whether you want to export the package including all sub-packages (default) or just the selected package:

![image](https://github.com/abapGit/abapGit/assets/59966492/943d0895-9286-4437-9f68-6104506f9071)

Closes #6809