### PR TITLE
Fix Filter Application Bug

### DIFF
--- a/src/repo/zcl_abapgit_repo.clas.abap
+++ b/src/repo/zcl_abapgit_repo.clas.abap
@@ -797,6 +797,12 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     DATA lr_filter TYPE REF TO zcl_abapgit_repo_filter.
 
     rt_files = mt_remote.
+
+    "Filter Ignored Files prior to Applying a Filter
+    IF iv_ignore_files = abap_true.
+      remove_ignored_files( CHANGING ct_files = rt_files ).
+    ENDIF.
+
     IF ii_obj_filter IS NOT INITIAL.
       lt_filter = ii_obj_filter->get_filter( ).
 
@@ -809,10 +815,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
         CHANGING
           ct_files    = rt_files ).
 
-    ENDIF.
-
-    IF iv_ignore_files = abap_true.
-      remove_ignored_files( CHANGING ct_files = rt_files ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
Moved the filtering of ignored items before the application of the filter when getting remote files to avoid exceptions that might occur if a repo contains ignored files that have no corresponding representation in the SAP system
