### PR TITLE
unit test page: change colours for runtime

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_runit.clas.abap
@@ -175,9 +175,9 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
     IF rv_text IS INITIAL.
       rv_text = |<span class="boxed green-filled-set">PASSED</span>|.
       IF lv_runtime > 100.
-        rv_text = rv_text && | <span class="red">{ lv_msec }</span>|.
+        rv_text = rv_text && | <span class="warning">{ lv_msec }</span>|.
       ELSE.
-        rv_text = rv_text && | { lv_msec }|.
+        rv_text = rv_text && | <span class="success">{ lv_msec }</span>|.
       ENDIF.
     ELSE.
       rv_text = |<span class="boxed red-filled-set">{ rv_text }</span>|.


### PR DESCRIPTION
sometimes, eg. when the unit tests needs to compile, the runtime for a test is larger than 100ms, triggering the runtime to be shown in red,

![image](https://github.com/abapGit/abapGit/assets/5888506/95a23bf6-ba08-4620-b97f-883607ab2514)

Which immediately draws my attention, instead suggest changing it to yellow, and the good ones to green,

![image](https://github.com/abapGit/abapGit/assets/5888506/89b326e5-ef97-4652-ba0b-db1b13613278)
