### PR TITLE
apack: fix namespace problem

### DIFF
--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -107,7 +107,7 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
 
     IF lv_class_name(1) = '/'.
       CREATE OBJECT lo_nspc.
-      ls_namespace = lo_nspc->zif_abapgit_sap_namespace~split_by_name( iv_obj_with_namespace = lv_class_name ).
+      ls_namespace = lo_nspc->zif_abapgit_sap_namespace~split_by_name( lv_class_name ).
       IF ls_namespace-namespace IS NOT INITIAL.
         lv_descriptor_cust = |{ ls_namespace-namespace }{ lv_descriptor_sap }|.
       ENDIF.

--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -89,7 +89,11 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
           ls_my_dependency       TYPE zif_abapgit_apack_definitions=>ty_dependency,
           ls_descriptor          TYPE zif_abapgit_apack_definitions=>ty_descriptor,
           lv_descriptor_cust     TYPE string,
-          lv_descriptor_sap      TYPE string.
+          lv_descriptor_sap      TYPE string,
+          lv_class_name          TYPE abap_abstypename,
+          lv_empty               TYPE string,
+          lo_nspc                TYPE REF TO zcl_abapgit_sap_namespace,
+          ls_namespace           TYPE zif_abapgit_definitions=>ty_obj_namespace.
 
     FIELD-SYMBOLS: <lg_descriptor>   TYPE any,
                    <lt_dependencies> TYPE ANY TABLE,
@@ -97,6 +101,17 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
 
     lv_descriptor_cust = zif_abapgit_apack_definitions=>c_apack_interface_cust && '~DESCRIPTOR'.
     lv_descriptor_sap  = zif_abapgit_apack_definitions=>c_apack_interface_sap && '~DESCRIPTOR'.
+
+    lv_class_name = cl_abap_classdescr=>get_class_name( io_manifest_provider ).
+    SPLIT lv_class_name AT '\CLASS=' INTO lv_empty lv_class_name.
+
+    IF lv_class_name(1) = '/'.
+      CREATE OBJECT lo_nspc.
+      ls_namespace = lo_nspc->zif_abapgit_sap_namespace~split_by_name( iv_obj_with_namespace = lv_class_name ).
+      IF ls_namespace-namespace IS NOT INITIAL.
+        lv_descriptor_cust = |{ ls_namespace-namespace }{ lv_descriptor_sap }|.
+      ENDIF.
+    ENDIF.
 
     ASSIGN io_manifest_provider->(lv_descriptor_cust) TO <lg_descriptor>.
     IF <lg_descriptor> IS NOT ASSIGNED.

--- a/src/apack/zcl_abapgit_apack_reader.clas.abap
+++ b/src/apack/zcl_abapgit_apack_reader.clas.abap
@@ -92,7 +92,6 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
           lv_descriptor_sap      TYPE string,
           lv_class_name          TYPE abap_abstypename,
           lv_empty               TYPE string,
-          lo_nspc                TYPE REF TO zcl_abapgit_sap_namespace,
           ls_namespace           TYPE zif_abapgit_definitions=>ty_obj_namespace.
 
     FIELD-SYMBOLS: <lg_descriptor>   TYPE any,
@@ -104,13 +103,10 @@ CLASS zcl_abapgit_apack_reader IMPLEMENTATION.
 
     lv_class_name = cl_abap_classdescr=>get_class_name( io_manifest_provider ).
     SPLIT lv_class_name AT '\CLASS=' INTO lv_empty lv_class_name.
+    ls_namespace = zcl_abapgit_factory=>get_sap_namespace( )->split_by_name( lv_class_name ).
 
-    IF lv_class_name(1) = '/'.
-      CREATE OBJECT lo_nspc.
-      ls_namespace = lo_nspc->zif_abapgit_sap_namespace~split_by_name( lv_class_name ).
-      IF ls_namespace-namespace IS NOT INITIAL.
-        lv_descriptor_cust = |{ ls_namespace-namespace }{ lv_descriptor_sap }|.
-      ENDIF.
+    IF ls_namespace-namespace IS NOT INITIAL.
+      lv_descriptor_cust = |{ ls_namespace-namespace }{ lv_descriptor_sap }|.
     ENDIF.
 
     ASSIGN io_manifest_provider->(lv_descriptor_cust) TO <lg_descriptor>.


### PR DESCRIPTION
Add namespace handling to copy_manifest method. Extract package from manifest instance and use namespace if present.