### PR TITLE
SICF: Include alternate service name

### DIFF
--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -669,7 +669,10 @@ CLASS zcl_abapgit_object_sicf IMPLEMENTATION.
     CLEAR ls_icfservice-icf_user.
     CLEAR ls_icfservice-icf_cclnt.
     CLEAR ls_icfservice-icf_mclnt.
-    CLEAR ls_icfservice-icfaltnme_orig.
+    " If the original name is different (lower vs upper case), it needs to be serialized
+    IF ls_icfservice-icfaltnme = ls_icfservice-icfaltnme_orig.
+      CLEAR ls_icfservice-icfaltnme_orig.
+    ENDIF.
     CLEAR ls_icfservice-icfbitmap.
 
     io_xml->add( iv_name = 'URL'


### PR DESCRIPTION
Symptom: 

Deserializing an SICF service leads to a diff showing a new object with a different filename compared to the repository.

Cause:

The service has an alternative name in lower case (`icfservice-icfaltnme_orig`). When deserializing the service, it is created with an upper-case alternate name.

Fix:

Included the lower-case alternative name in the serialized file in order to create the same service definition when deserializing the object.

Closes #6847