### PR TITLE
"doesn't exists" (2).

### DIFF
--- a/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
@@ -974,7 +974,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
     ASSIGN COMPONENT 'ROWORCOLST' OF STRUCTURE ls_internal-dd09l TO <lg_roworcolst>.
     IF sy-subrc = 0 AND <lg_roworcolst> = 'C'.
-      CLEAR <lg_roworcolst>. "To avoid diff errors. This field doesn't exists in all releases
+      CLEAR <lg_roworcolst>. "To avoid diff errors. This field doesn't exist in all releases
     ENDIF.
 
 


### PR DESCRIPTION
The correct spelling is "doesn't exist".