### PR TITLE
Fix "dont".

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.testclasses.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.testclasses.abap
@@ -75,7 +75,7 @@ CLASS ltcl_test IMPLEMENTATION.
     DATA lv_where TYPE string.
 
     IF sy-sysid = 'ABC'.
-* dont run on open-abap
+* don't run on open-abap
       RETURN.
     ENDIF.
 


### PR DESCRIPTION
The correct spelling is "don't".