### PR TITLE
Code inspector pages improvements

### DIFF
--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -29,6 +29,11 @@ CLASS zcl_abapgit_html DEFINITION
         iv_checked     TYPE abap_bool OPTIONAL
       RETURNING
         VALUE(rv_html) TYPE string .
+    CLASS-METHODS data_attr
+      IMPORTING
+        iv_str         TYPE string OPTIONAL
+      RETURNING
+        VALUE(rs_data_attr) TYPE zif_abapgit_html=>ty_data_attr .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -122,6 +127,16 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
     IF iv_initial_chunk IS NOT INITIAL.
       ri_instance->add( iv_initial_chunk ).
     ENDIF.
+  ENDMETHOD.
+
+
+  METHOD data_attr.
+
+    SPLIT iv_str AT '=' INTO rs_data_attr-name rs_data_attr-value.
+    IF rs_data_attr-name IS INITIAL.
+      CLEAR rs_data_attr.
+    ENDIF.
+
   ENDMETHOD.
 
 
@@ -523,6 +538,7 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       ii_content = ii_content
       iv_id    = iv_id
       iv_class = iv_class
+      is_data_attr = is_data_attr
       iv_hint  = iv_hint ).
     ri_self = me.
   ENDMETHOD.
@@ -536,6 +552,7 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       ii_content = ii_content
       iv_id    = iv_id
       iv_class = iv_class
+      is_data_attr = is_data_attr
       iv_hint  = iv_hint ).
     ri_self = me.
   ENDMETHOD.
@@ -548,6 +565,7 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
 
     DATA: lv_class TYPE string,
           lv_id    TYPE string,
+          lv_data_attr TYPE string,
           lv_title TYPE string.
 
     IF iv_id IS NOT INITIAL.
@@ -562,7 +580,11 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       lv_title = | title="{ iv_hint }"|.
     ENDIF.
 
-    lv_open_tag = |<{ iv_tag }{ lv_id }{ lv_class }{ lv_title }>|.
+    IF is_data_attr IS NOT INITIAL.
+      lv_data_attr = | data-{ is_data_attr-name }="{ is_data_attr-value }"|.
+    ENDIF.
+
+    lv_open_tag = |<{ iv_tag }{ lv_id }{ lv_class }{ lv_data_attr }{ lv_title }>|.
     lv_close_tag = |</{ iv_tag }>|.
 
     IF ii_content IS NOT BOUND AND iv_content IS INITIAL.

--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -29,7 +29,7 @@ CLASS zcl_abapgit_html DEFINITION
         iv_checked     TYPE abap_bool OPTIONAL
       RETURNING
         VALUE(rv_html) TYPE string .
-    CLASS-METHODS data_attr
+    CLASS-METHODS parse_data_attr
       IMPORTING
         iv_str         TYPE string OPTIONAL
       RETURNING
@@ -127,16 +127,6 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
     IF iv_initial_chunk IS NOT INITIAL.
       ri_instance->add( iv_initial_chunk ).
     ENDIF.
-  ENDMETHOD.
-
-
-  METHOD data_attr.
-
-    SPLIT iv_str AT '=' INTO rs_data_attr-name rs_data_attr-value.
-    IF rs_data_attr-name IS INITIAL.
-      CLEAR rs_data_attr.
-    ENDIF.
-
   ENDMETHOD.
 
 
@@ -242,6 +232,16 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       ELSE.
         cv_line = gv_spaces && cv_line.
       ENDIF.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD parse_data_attr.
+
+    SPLIT iv_str AT '=' INTO rs_data_attr-name rs_data_attr-value.
+    IF rs_data_attr-name IS INITIAL.
+      CLEAR rs_data_attr.
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -77,7 +77,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_html IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
 
 
   METHOD checkbox.
@@ -459,6 +459,17 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
 
     ri_self = me.
 
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_html~div.
+    zif_abapgit_html~wrap(
+      iv_tag   = 'div'
+      iv_content = iv_content
+      ii_content = ii_content
+      iv_id    = iv_id
+      iv_class = iv_class ).
+    ri_self = me.
   ENDMETHOD.
 
 

--- a/src/ui/core/zcl_abapgit_html.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.testclasses.abap
@@ -217,18 +217,24 @@ CLASS ltcl_html IMPLEMENTATION.
       iv_tag     = 'td'
       iv_content = 'Hello'
       iv_format_single_line = abap_true ).
+    mo_html->wrap(
+      iv_tag     = 'td'
+      iv_content = 'Hello'
+      is_data_attr = zcl_abapgit_html=>data_attr( 'id=123' )
+      iv_format_single_line = abap_true ).
 
     cl_abap_unit_assert=>assert_equals(
       act = mo_html->render( )
       exp =
-        '<td></td>' && cl_abap_char_utilities=>newline &&
-        '<td>' && cl_abap_char_utilities=>newline &&
-        '  Hello' && cl_abap_char_utilities=>newline &&
-        '</td>' && cl_abap_char_utilities=>newline &&
-        '<td id="id" class="class" title="hint">' && cl_abap_char_utilities=>newline &&
-        '  Hello' && cl_abap_char_utilities=>newline &&
-        '</td>' && cl_abap_char_utilities=>newline &&
-        '<td>Hello</td>' ).
+        |<td></td>\n| &&
+        |<td>\n| &&
+        |  Hello\n| &&
+        |</td>\n| &&
+        |<td id="id" class="class" title="hint">\n| &&
+        |  Hello\n| &&
+        |</td>\n| &&
+        |<td>Hello</td>\n| &&
+        |<td data-id="123">Hello</td>| ).
 
   ENDMETHOD.
 

--- a/src/ui/core/zcl_abapgit_html.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.testclasses.abap
@@ -220,7 +220,7 @@ CLASS ltcl_html IMPLEMENTATION.
     mo_html->wrap(
       iv_tag     = 'td'
       iv_content = 'Hello'
-      is_data_attr = zcl_abapgit_html=>data_attr( 'id=123' )
+      is_data_attr = zcl_abapgit_html=>parse_data_attr( 'id=123' )
       iv_format_single_line = abap_true ).
 
     cl_abap_unit_assert=>assert_equals(

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -131,4 +131,14 @@ INTERFACE zif_abapgit_html PUBLIC.
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
 
+  METHODS div
+    IMPORTING
+      !iv_content TYPE string OPTIONAL
+      !ii_content TYPE REF TO zif_abapgit_html OPTIONAL
+      !iv_id      TYPE string OPTIONAL
+      !iv_class   TYPE string OPTIONAL
+      PREFERRED PARAMETER iv_content
+    RETURNING
+      VALUE(ri_self) TYPE REF TO zif_abapgit_html.
+
 ENDINTERFACE.

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -1,5 +1,12 @@
 INTERFACE zif_abapgit_html PUBLIC.
 
+  TYPES:
+    BEGIN OF ty_data_attr,
+      name TYPE string,
+      value TYPE string,
+    END OF ty_data_attr,
+    ty_data_attr_tab TYPE STANDARD TABLE OF ty_data_attr WITH KEY name.
+
   CONSTANTS:
     BEGIN OF c_action_type,
       sapevent  TYPE c VALUE 'E',
@@ -104,6 +111,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_class   TYPE string OPTIONAL
       !iv_hint    TYPE string OPTIONAL
       !iv_format_single_line TYPE abap_bool DEFAULT abap_false
+      !is_data_attr TYPE ty_data_attr OPTIONAL
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
 
@@ -115,6 +123,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_class   TYPE string OPTIONAL
       !iv_hint    TYPE string OPTIONAL
       !iv_format_single_line TYPE abap_bool DEFAULT abap_true
+      !is_data_attr TYPE ty_data_attr OPTIONAL
       PREFERRED PARAMETER iv_content
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
@@ -127,6 +136,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_class   TYPE string OPTIONAL
       !iv_hint    TYPE string OPTIONAL
       !iv_format_single_line TYPE abap_bool DEFAULT abap_true
+      !is_data_attr TYPE ty_data_attr OPTIONAL
       PREFERRED PARAMETER iv_content
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
@@ -137,6 +147,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !ii_content TYPE REF TO zif_abapgit_html OPTIONAL
       !iv_id      TYPE string OPTIONAL
       !iv_class   TYPE string OPTIONAL
+      !is_data_attr TYPE ty_data_attr OPTIONAL
       PREFERRED PARAMETER iv_content
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -4,8 +4,7 @@ INTERFACE zif_abapgit_html PUBLIC.
     BEGIN OF ty_data_attr,
       name TYPE string,
       value TYPE string,
-    END OF ty_data_attr,
-    ty_data_attr_tab TYPE STANDARD TABLE OF ty_data_attr WITH KEY name.
+    END OF ty_data_attr.
 
   CONSTANTS:
     BEGIN OF c_action_type,

--- a/src/ui/flow/zcl_abapgit_gui_page_flow.clas.abap
+++ b/src/ui/flow/zcl_abapgit_gui_page_flow.clas.abap
@@ -226,6 +226,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_FLOW IMPLEMENTATION.
           iv_key    = lv_key ).
 
         rs_handled-page = zcl_abapgit_gui_page_stage=>create(
+          ii_force_refresh = abap_false
           io_repo       = lo_online
           ii_obj_filter = lo_filter ).
 

--- a/src/ui/lib/zcl_abapgit_gui_page_hoc.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page_hoc.clas.abap
@@ -54,7 +54,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_hoc IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_HOC IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -92,6 +92,20 @@ CLASS zcl_abapgit_gui_page_hoc IMPLEMENTATION.
     ls_control-extra_css_url       = iv_extra_css_url.
     ls_control-extra_js_url        = iv_extra_js_url.
     ls_control-show_as_modal       = iv_show_as_modal.
+
+    IF ls_control-page_menu_provider IS NOT BOUND. " try component itself
+      TRY.
+          ls_control-page_menu_provider ?= ii_child_component.
+        CATCH cx_sy_move_cast_error.
+      ENDTRY.
+    ENDIF.
+
+    IF ls_control-page_title_provider IS NOT BOUND. " try component itself
+      TRY.
+          ls_control-page_title_provider ?= ii_child_component.
+        CATCH cx_sy_move_cast_error.
+      ENDTRY.
+    ENDIF.
 
     CREATE OBJECT lo_page
       EXPORTING

--- a/src/ui/lib/zcl_abapgit_html_table.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.abap
@@ -142,9 +142,14 @@ CLASS ZCL_ABAPGIT_HTML_TABLE IMPLEMENTATION.
 
     DATA lv_req TYPE string.
 
-    IF find( val = iv_event regex = c_sort_by_event_regex ) = 0.
+    IF find(
+        val = iv_event
+        regex = c_sort_by_event_regex ) = 0.
 
-      lv_req = replace( val = iv_event sub = c_sort_by_event_prefix with = '' ).
+      lv_req = replace(
+        val  = iv_event
+        sub  = c_sort_by_event_prefix
+        with = '' ).
       SPLIT lv_req AT ':' INTO rs_sorting_request-column_id lv_req.
       rs_sorting_request-descending = boolc( lv_req = 'dsc' ).
 

--- a/src/ui/lib/zcl_abapgit_html_table.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.abap
@@ -8,7 +8,7 @@ CLASS zcl_abapgit_html_table DEFINITION
 
     CLASS-METHODS create
       IMPORTING
-        !ii_renderer    TYPE REF TO zif_abapgit_html_table
+        !ii_renderer    TYPE REF TO zif_abapgit_html_table OPTIONAL
       RETURNING
         VALUE(ro_instance) TYPE REF TO zcl_abapgit_html_table .
     " probably th css_class
@@ -25,6 +25,7 @@ CLASS zcl_abapgit_html_table DEFINITION
     " Record Limit
     METHODS render
       IMPORTING
+        !ii_renderer   TYPE REF TO zif_abapgit_html_table OPTIONAL
         !it_data       TYPE ANY TABLE
         !iv_id         TYPE csequence OPTIONAL
         !iv_css_class  TYPE csequence OPTIONAL
@@ -116,7 +117,6 @@ CLASS ZCL_ABAPGIT_HTML_TABLE IMPLEMENTATION.
 
 
   METHOD create.
-    ASSERT ii_renderer IS BOUND.
     CREATE OBJECT ro_instance.
     ro_instance->mi_renderer = ii_renderer.
   ENDMETHOD.
@@ -161,6 +161,12 @@ CLASS ZCL_ABAPGIT_HTML_TABLE IMPLEMENTATION.
   METHOD render.
 
     DATA lv_attrs TYPE string.
+
+    IF ii_renderer IS BOUND.
+      mi_renderer = ii_renderer.
+    ENDIF.
+
+    ASSERT mi_renderer IS BOUND.
 
     mv_with_cids     = iv_with_cids.
     mv_table_id      = iv_id.

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -16,6 +16,7 @@ CLASS ltcl_test_simple_table DEFINITION FINAL
 
     METHODS simple_render FOR TESTING RAISING zcx_abapgit_exception.
     METHODS with_cids FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS with_sort FOR TESTING RAISING zcx_abapgit_exception.
 
     METHODS test_data_set
       RETURNING
@@ -44,6 +45,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
         rs_render-content = |{ iv_value }|.
       ENDIF.
     ELSEIF iv_table_id = 'with-cids'.
+      rs_render-content = iv_value.
+    ELSEIF iv_table_id = 'with-sort'.
       rs_render-content = iv_value.
     ENDIF.
 
@@ -156,6 +159,64 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<tr data-attr="2">' )->add(
       '<td data-cid="col1">World</td>' )->add(
       '<td data-cid="col2">2</td>' )->add(
+      '</tr>' )->add(
+      '</tbody>' )->add(
+      '</table>' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_html_act
+      exp = li_html_exp->render( ) ).
+
+  ENDMETHOD.
+
+  METHOD with_sort.
+
+    DATA lo_tab TYPE REF TO zcl_abapgit_html_table.
+    DATA lv_html_act TYPE string.
+    DATA li_html_exp TYPE REF TO zif_abapgit_html.
+    DATA ls_sort TYPE zif_abapgit_html_table=>ty_sorting_state.
+
+    lo_tab = zcl_abapgit_html_table=>create( me
+      )->define_column(
+        iv_column_id    = 'col1'
+        iv_column_title = 'Col 1'
+      )->define_column(
+        iv_column_id    = 'col2'
+        iv_column_title = 'Col 2'
+      )->define_column(
+        iv_column_id    = 'col3'
+        iv_column_title = 'Col 3'
+        iv_sortable     = abap_false
+      ).
+
+    ls_sort-column_id = 'col1'.
+
+    lv_html_act = lo_tab->render(
+      is_sorting_state = ls_sort
+      iv_id        = 'with-sort'
+      it_data      = test_data_set( ) )->render( ).
+
+    CREATE OBJECT li_html_exp TYPE zcl_abapgit_html.
+
+    li_html_exp->add(
+      '<table id="with-sort">' )->add(
+      '<thead>' )->add(
+      '<tr>' )->add(
+      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a> &#x25B4;</th>' )->add(
+      '<th><a href="sapevent:sort_by:col2:asc">Col 2</a></th>' )->add(
+      '<th>Col 3</th>' )->add(
+      '</tr>' )->add(
+      '</thead>' )->add(
+      '<tbody>' )->add(
+      '<tr>' )->add(
+      '<td>Hello</td>' )->add(
+      '<td>1</td>' )->add(
+      '<td>10</td>' )->add(
+      '</tr>' )->add(
+      '<tr>' )->add(
+      '<td>World</td>' )->add(
+      '<td>2</td>' )->add(
+      '<td>20</td>' )->add(
       '</tr>' )->add(
       '</tbody>' )->add(
       '</table>' ).

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -133,8 +133,7 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
         iv_column_title = 'Col 1'
       )->define_column(
         iv_column_id    = 'col2'
-        iv_column_title = 'Col 2'
-      ).
+        iv_column_title = 'Col 2' ).
 
     lv_html_act = lo_tab->render(
       iv_id        = 'with-cids'
@@ -186,8 +185,7 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       )->define_column(
         iv_column_id    = 'col3'
         iv_column_title = 'Col 3'
-        iv_sortable     = abap_false
-      ).
+        iv_sortable     = abap_false ).
 
     ls_sort-column_id = 'col1'.
 
@@ -202,8 +200,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<table id="with-sort">' )->add(
       '<thead>' )->add(
       '<tr>' )->add(
-      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a> &#x25B4;</th>' )->add(
-      '<th><a href="sapevent:sort_by:col2:asc">Col 2</a></th>' )->add(
+      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a><span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
+      '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
       '</thead>' )->add(

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -28,7 +28,7 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
     IF iv_table_id = 'simple'.
       rs_attrs-css_class = |r{ iv_row_index }|.
     ELSEIF iv_table_id = 'with-cids'.
-      rs_attrs-data = zcl_abapgit_html=>data_attr( |attr={ iv_row_index }| ).
+      rs_attrs-data = zcl_abapgit_html=>parse_data_attr( |attr={ iv_row_index }| ).
     ENDIF.
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -11,36 +11,64 @@ CLASS ltcl_test_simple_table DEFINITION FINAL
         col2 TYPE i,
         col3 TYPE i,
         col4 TYPE REF TO data,
-      END OF ty_simple_data.
+      END OF ty_simple_data,
+      ty_simple_data_tab TYPE STANDARD TABLE OF ty_simple_data WITH DEFAULT KEY.
 
     METHODS simple_render FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS with_cids FOR TESTING RAISING zcx_abapgit_exception.
+
+    METHODS test_data_set
+      RETURNING
+        VALUE(rt_data_set) TYPE ty_simple_data_tab.
 ENDCLASS.
 
 CLASS ltcl_test_simple_table IMPLEMENTATION.
   METHOD zif_abapgit_html_table~get_row_attrs.
-    rs_attrs-css_class = |r{ iv_row_index }|.
+    IF iv_table_id = 'simple'.
+      rs_attrs-css_class = |r{ iv_row_index }|.
+    ELSEIF iv_table_id = 'with-cids'.
+      rs_attrs-data = zcl_abapgit_html=>data_attr( |attr={ iv_row_index }| ).
+    ENDIF.
   ENDMETHOD.
 
   METHOD zif_abapgit_html_table~render_cell.
-    rs_render-css_class = 'cell'.
-    IF iv_column_id = 'colX'.
-      IF iv_row_index = 2.
-        rs_render-html = zcl_abapgit_html=>create( )->add( 'XHTML' ).
+    IF iv_table_id = 'simple'.
+      rs_render-css_class = 'cell'.
+      IF iv_column_id = 'colX'.
+        IF iv_row_index = 2.
+          rs_render-html = zcl_abapgit_html=>create( )->add( 'XHTML' ).
+        ELSE.
+          rs_render-content = 'X'.
+        ENDIF.
       ELSE.
-        rs_render-content = 'X'.
+        rs_render-content = |{ iv_value }|.
       ENDIF.
-    ELSE.
-      rs_render-content = |{ iv_value }|.
+    ELSEIF iv_table_id = 'with-cids'.
+      rs_render-content = iv_value.
     ENDIF.
+
+  ENDMETHOD.
+
+  METHOD test_data_set.
+
+    FIELD-SYMBOLS <ls_i> LIKE LINE OF rt_data_set.
+
+    APPEND INITIAL LINE TO rt_data_set ASSIGNING <ls_i>.
+    <ls_i>-col1 = 'Hello'.
+    <ls_i>-col2 = 1.
+    <ls_i>-col3 = 10.
+    APPEND INITIAL LINE TO rt_data_set ASSIGNING <ls_i>.
+    <ls_i>-col1 = 'World'.
+    <ls_i>-col2 = 2.
+    <ls_i>-col3 = 20.
+
   ENDMETHOD.
 
   METHOD simple_render.
 
     DATA lo_tab TYPE REF TO zcl_abapgit_html_table.
-    DATA lt_dummy_data TYPE TABLE OF ty_simple_data.
     DATA lv_html_act TYPE string.
     DATA li_html_exp TYPE REF TO zif_abapgit_html.
-    FIELD-SYMBOLS <ls_i> LIKE LINE OF lt_dummy_data.
 
     lo_tab = zcl_abapgit_html_table=>create( me
       )->define_column(
@@ -52,24 +80,15 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
         iv_from_field = 'col3'
       )->define_column( 'colX' ).
 
-    APPEND INITIAL LINE TO lt_dummy_data ASSIGNING <ls_i>.
-    <ls_i>-col1 = 'Hello'.
-    <ls_i>-col2 = 1.
-    <ls_i>-col3 = 10.
-    APPEND INITIAL LINE TO lt_dummy_data ASSIGNING <ls_i>.
-    <ls_i>-col1 = 'World'.
-    <ls_i>-col2 = 2.
-    <ls_i>-col3 = 20.
-
     lv_html_act = lo_tab->render(
-      iv_id        = 'tabid'
+      iv_id        = 'simple'
       iv_css_class = 'tabclass'
-      it_data      = lt_dummy_data )->render( ).
+      it_data      = test_data_set( ) )->render( ).
 
     CREATE OBJECT li_html_exp TYPE zcl_abapgit_html.
 
     li_html_exp->add(
-      '<table id="tabid" class="tabclass">' )->add(
+      '<table id="simple" class="tabclass">' )->add(
       '<thead>' )->add(
       '<tr>' )->add(
       '<th>Col 1</th>' )->add(
@@ -89,6 +108,54 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<td class="cell">' )->add(
       'XHTML' )->add(
       '</td>' )->add(
+      '</tr>' )->add(
+      '</tbody>' )->add(
+      '</table>' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_html_act
+      exp = li_html_exp->render( ) ).
+
+  ENDMETHOD.
+
+  METHOD with_cids.
+
+    DATA lo_tab TYPE REF TO zcl_abapgit_html_table.
+    DATA lv_html_act TYPE string.
+    DATA li_html_exp TYPE REF TO zif_abapgit_html.
+
+    lo_tab = zcl_abapgit_html_table=>create( me
+      )->define_column(
+        iv_column_id    = 'col1'
+        iv_column_title = 'Col 1'
+      )->define_column(
+        iv_column_id    = 'col2'
+        iv_column_title = 'Col 2'
+      ).
+
+    lv_html_act = lo_tab->render(
+      iv_id        = 'with-cids'
+      iv_with_cids = abap_true
+      it_data      = test_data_set( ) )->render( ).
+
+    CREATE OBJECT li_html_exp TYPE zcl_abapgit_html.
+
+    li_html_exp->add(
+      '<table id="with-cids">' )->add(
+      '<thead>' )->add(
+      '<tr>' )->add(
+      '<th data-cid="col1">Col 1</th>' )->add(
+      '<th data-cid="col2">Col 2</th>' )->add(
+      '</tr>' )->add(
+      '</thead>' )->add(
+      '<tbody>' )->add(
+      '<tr data-attr="1">' )->add(
+      '<td data-cid="col1">Hello</td>' )->add(
+      '<td data-cid="col2">1</td>' )->add(
+      '</tr>' )->add(
+      '<tr data-attr="2">' )->add(
+      '<td data-cid="col1">World</td>' )->add(
+      '<td data-cid="col2">2</td>' )->add(
       '</tr>' )->add(
       '</tbody>' )->add(
       '</table>' ).

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -200,7 +200,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<table id="with-sort">' )->add(
       '<thead>' )->add(
       '<tr>' )->add(
-      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a><span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
+      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a><span class="sort-arrow sort-active">&#x25BE;</span></th>'
+      )->add(
       '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(

--- a/src/ui/lib/zif_abapgit_html_table.intf.abap
+++ b/src/ui/lib/zif_abapgit_html_table.intf.abap
@@ -4,6 +4,7 @@ INTERFACE zif_abapgit_html_table
   TYPES:
     BEGIN OF ty_row_attrs,
       css_class TYPE string,
+      data TYPE zif_abapgit_html=>ty_data_attr,
     END OF ty_row_attrs.
 
   TYPES:
@@ -15,6 +16,7 @@ INTERFACE zif_abapgit_html_table
 
   METHODS get_row_attrs
     IMPORTING
+      iv_table_id TYPE string
       iv_row_index TYPE i
       is_row TYPE any
     RETURNING
@@ -24,6 +26,7 @@ INTERFACE zif_abapgit_html_table
 
   METHODS render_cell
     IMPORTING
+      iv_table_id TYPE string
       iv_row_index TYPE i
       is_row TYPE any
       iv_column_id TYPE string

--- a/src/ui/lib/zif_abapgit_html_table.intf.abap
+++ b/src/ui/lib/zif_abapgit_html_table.intf.abap
@@ -14,6 +14,12 @@ INTERFACE zif_abapgit_html_table
       html TYPE REF TO zif_abapgit_html,
     END OF ty_cell_render.
 
+  TYPES:
+    BEGIN OF ty_sorting_state,
+      column_id TYPE string,
+      descending TYPE abap_bool,
+    END OF ty_sorting_state.
+
   METHODS get_row_attrs
     IMPORTING
       iv_table_id TYPE string

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -315,23 +315,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    render_variant(
+    render_ci_report(
       ii_html    = ri_html
       iv_variant = mv_check_variant
-      iv_summary = mv_summary ).
-
-    IF lines( mt_result ) = 0.
-      render_success(
-        ii_html    = ri_html
-        iv_message = 'No code inspector findings' ).
-    ELSE.
-      render_stats(
-        ii_html   = ri_html
-        it_result = mt_result ).
-      render_result(
-        ii_html   = ri_html
-        it_result = mt_result ).
-    ENDIF.
+      iv_success_msg = 'No code inspector findings' ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -24,15 +24,14 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-    METHODS:
-      constructor
-        IMPORTING
-          io_repo                  TYPE REF TO zcl_abapgit_repo
-          io_stage                 TYPE REF TO zcl_abapgit_stage OPTIONAL
-          iv_check_variant         TYPE sci_chkv OPTIONAL
-          iv_raise_when_no_results TYPE abap_bool DEFAULT abap_false
-        RAISING
-          zcx_abapgit_exception.
+    METHODS constructor
+      IMPORTING
+        io_repo                  TYPE REF TO zcl_abapgit_repo
+        io_stage                 TYPE REF TO zcl_abapgit_stage OPTIONAL
+        iv_check_variant         TYPE sci_chkv OPTIONAL
+        iv_raise_when_no_results TYPE abap_bool DEFAULT abap_false
+      RAISING
+        zcx_abapgit_exception.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -66,10 +65,6 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION
     METHODS status
       RETURNING
         VALUE(rv_status) TYPE zif_abapgit_definitions=>ty_sci_result.
-
-    METHODS render_success
-      IMPORTING
-        ii_html TYPE REF TO zif_abapgit_html.
 
 ENDCLASS.
 
@@ -138,8 +133,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
 
   METHOD has_inspection_errors.
 
-    READ TABLE mt_result TRANSPORTING NO FIELDS
-      WITH KEY kind = 'E'.
+    READ TABLE mt_result TRANSPORTING NO FIELDS WITH KEY kind = 'E'.
     rv_has_inspection_errors = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
@@ -149,16 +143,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
 
     rv_is_stage_allowed = boolc( NOT (
       mo_repo->get_local_settings( )-block_commit = abap_true AND has_inspection_errors( ) = abap_true ) ).
-
-  ENDMETHOD.
-
-
-  METHOD render_success.
-
-    ii_html->add( '<div class="dummydiv success">' ).
-    ii_html->add( ii_html->icon( 'check' ) ).
-    ii_html->add( 'No code inspector findings' ).
-    ii_html->add( '</div>' ).
 
   ENDMETHOD.
 
@@ -331,13 +315,19 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    ri_html->add( render_variant(
+    render_variant(
+      ii_html    = ri_html
       iv_variant = mv_check_variant
-      iv_summary = mv_summary ) ).
+      iv_summary = mv_summary ).
 
     IF lines( mt_result ) = 0.
-      render_success( ri_html ).
+      render_success(
+        ii_html    = ri_html
+        iv_message = 'No code inspector findings' ).
     ELSE.
+      render_stats(
+        ii_html   = ri_html
+        it_result = mt_result ).
       render_result(
         ii_html   = ri_html
         it_result = mt_result ).

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -456,7 +456,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODI_BASE IMPLEMENTATION.
       iv_class   = 'ci-detail'
       ii_content = li_table->render(
         is_sorting_state = ms_sorting_state
-        iv_wrap_in_div   = 'ci-detail-table-container'
+        iv_wrap_in_div   = 'default-table-container'
+        iv_css_class     = 'default-table'
         iv_with_cids     = abap_true
         it_data          = lt_view ) ).
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -424,7 +424,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODI_BASE IMPLEMENTATION.
     DATA li_table TYPE REF TO zcl_abapgit_html_table.
     DATA lt_view TYPE ty_view_tab.
 
-    li_table = zcl_abapgit_html_table=>create( me
+    li_table = zcl_abapgit_html_table=>create(
       )->define_column(
         iv_column_id    = 'kind'
         iv_column_title = zcl_abapgit_html=>icon( 'exclamation-circle' )
@@ -450,6 +450,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODI_BASE IMPLEMENTATION.
     ii_html->div(
       iv_class   = 'ci-detail'
       ii_content = li_table->render(
+        ii_renderer      = me
         is_sorting_state = ms_sorting_state
         iv_wrap_in_div   = 'default-table-container'
         iv_css_class     = 'default-table'

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -33,17 +33,13 @@ CLASS zcl_abapgit_gui_page_codi_base DEFINITION
         !ii_html        TYPE REF TO zif_abapgit_html
         !iv_variant     TYPE sci_chkv
         !iv_success_msg TYPE string
-      RETURNING
-        VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception.
     METHODS render_head
       IMPORTING
         !ii_html       TYPE REF TO zif_abapgit_html
         !iv_variant    TYPE sci_chkv
-        !iv_summary    TYPE string
-      RETURNING
-        VALUE(ri_html) TYPE REF TO zif_abapgit_html.
+        !iv_summary    TYPE string.
     METHODS render_detail
       IMPORTING
         !ii_html   TYPE REF TO zif_abapgit_html
@@ -440,8 +436,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODI_BASE IMPLEMENTATION.
         iv_column_title = 'Obj. name / location'
       )->define_column(
         iv_column_id    = 'text'
-        iv_column_title = 'Text'
-      ).
+        iv_column_title = 'Text' ).
 
     lt_view = convert_result_to_view( it_result ).
 
@@ -575,7 +570,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODI_BASE IMPLEMENTATION.
   METHOD zif_abapgit_html_table~get_row_attrs.
 
     FIELD-SYMBOLS <ls_item> TYPE ty_result_view.
-    DATA lv_render_kind TYPE string.
 
     ASSIGN is_row TO <ls_item>.
     rs_attrs-data-name = 'kind'.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_syntax.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_syntax.clas.abap
@@ -139,23 +139,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
         io_repo        = mo_repo
         iv_show_commit = abap_false ) ).
 
-    render_variant(
+    render_ci_report(
       ii_html    = ri_html
       iv_variant = c_variant
-      iv_summary = mv_summary ).
-
-    IF lines( mt_result ) = 0.
-      render_success(
-        ii_html    = ri_html
-        iv_message = 'No syntax errors' ).
-    ELSE.
-      render_stats(
-        ii_html   = ri_html
-        it_result = mt_result ).
-      render_result(
-        ii_html   = ri_html
-        it_result = mt_result ).
-    ENDIF.
+      iv_success_msg = 'No syntax errors' ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_syntax.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_syntax.clas.abap
@@ -21,12 +21,11 @@ CLASS zcl_abapgit_gui_page_syntax DEFINITION
       RAISING
         zcx_abapgit_exception.
 
-    METHODS:
-      constructor
-        IMPORTING
-          io_repo TYPE REF TO zcl_abapgit_repo
-        RAISING
-          zcx_abapgit_exception.
+    METHODS constructor
+      IMPORTING
+        io_repo TYPE REF TO zcl_abapgit_repo
+      RAISING
+        zcx_abapgit_exception.
 
   PROTECTED SECTION.
 
@@ -37,9 +36,6 @@ CLASS zcl_abapgit_gui_page_syntax DEFINITION
     METHODS run_syntax_check
       RAISING
         zcx_abapgit_exception.
-    METHODS render_success
-      IMPORTING
-        ii_html TYPE REF TO zif_abapgit_html.
 
 ENDCLASS.
 
@@ -65,14 +61,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create( lo_component ).
 
-  ENDMETHOD.
-
-
-  METHOD render_success.
-    ii_html->add( '<div class="dummydiv success">' ).
-    ii_html->add( ii_html->icon( 'check' ) ).
-    ii_html->add( 'No syntax errors' ).
-    ii_html->add( '</div>' ).
   ENDMETHOD.
 
 
@@ -146,18 +134,24 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->div(
-      iv_class = 'repo'
+      iv_class   = 'repo'
       ii_content = zcl_abapgit_gui_chunk_lib=>render_repo_top(
         io_repo        = mo_repo
         iv_show_commit = abap_false ) ).
 
-    ri_html->add( render_variant(
+    render_variant(
+      ii_html    = ri_html
       iv_variant = c_variant
-      iv_summary = mv_summary ) ).
+      iv_summary = mv_summary ).
 
     IF lines( mt_result ) = 0.
-      render_success( ri_html ).
+      render_success(
+        ii_html    = ri_html
+        iv_message = 'No syntax errors' ).
     ELSE.
+      render_stats(
+        ii_html   = ri_html
+        it_result = mt_result ).
       render_result(
         ii_html   = ri_html
         it_result = mt_result ).

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -135,7 +135,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
 
   METHOD check_selected.
@@ -183,6 +183,9 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     DATA lv_ts TYPE timestamp.
 
     super->constructor( ).
+
+    " force refresh on stage, to make sure the latest local and remote files are used
+    io_repo->refresh( ).
 
     mo_repo               = io_repo.
     mv_seed               = iv_seed.

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -25,6 +25,7 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
         iv_seed        TYPE string OPTIONAL
         iv_sci_result  TYPE zif_abapgit_definitions=>ty_sci_result DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
         ii_obj_filter  TYPE REF TO zif_abapgit_object_filter OPTIONAL
+        ii_force_refresh TYPE abap_bool DEFAULT abap_true
       RETURNING
         VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
       RAISING
@@ -36,6 +37,7 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
         iv_seed       TYPE string OPTIONAL
         iv_sci_result TYPE zif_abapgit_definitions=>ty_sci_result DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
         ii_obj_filter TYPE REF TO zif_abapgit_object_filter OPTIONAL
+        ii_force_refresh TYPE abap_bool DEFAULT abap_true
       RAISING
         zcx_abapgit_exception.
 
@@ -185,7 +187,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     super->constructor( ).
 
     " force refresh on stage, to make sure the latest local and remote files are used
-    io_repo->refresh( ).
+    IF ii_force_refresh = abap_true.
+      io_repo->refresh( ).
+    ENDIF.
 
     mo_repo               = io_repo.
     mv_seed               = iv_seed.
@@ -234,6 +238,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
         io_repo       = io_repo
         iv_seed       = iv_seed
         iv_sci_result = iv_sci_result
+        ii_force_refresh = ii_force_refresh
         ii_obj_filter = ii_obj_filter.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -142,7 +142,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_router IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -402,9 +402,6 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
     ENDIF.
 
     IF ri_page IS INITIAL.
-      " force refresh on stage, to make sure the latest local and remote files are used
-      lo_repo->refresh( ).
-
       ri_page = zcl_abapgit_gui_page_stage=>create(
         io_repo       = lo_repo
         iv_seed       = lv_seed

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1185,21 +1185,92 @@ table ul.repo-labels li {
 
 /* CODE INSPECTOR */
 
-.ci-head { padding: 0.5em 1em; }
-.ci-head .package-name span { margin-left: 0.3em; }
-.ci-variant { font-weight: bold; }
-.ci-result {
-  padding: 6px;
-  margin-top: 4px;
+div.ci {
+  margin-top: 1px;
+  margin-bottom: 1px;
 }
-.ci-result li {
-  list-style-type: none;
-  padding: 0.3em 0.8em;
-  margin-top: 6px;
-  border-left: 4px solid;
+
+div.ci-msg {
+  padding: 0.7em 1em 0.5em;
 }
-.ci-result li:first-child { margin-top: 0px; }
-.ci-result li > span { display: block; }
+div.ci-msg span.ci-variant {
+  font-weight: bold;
+}
+
+div.ci-stats {
+  padding: 0.5em 1em;
+}
+div.ci-stats span.count {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+
+div.ci-detail {
+  padding: 6px 0.5em;
+}
+
+div.ci-detail div.ci-detail-table-container {
+  padding: 6px 0.5em;
+  background-color: white;
+  border-radius: 6px;
+}
+
+div.ci-detail table {
+  line-height: 1.5;
+  width: 100%;
+}
+
+div.ci-detail table thead tr {
+  border-bottom: #efefef solid 1px;
+}
+/*div.ci-detail table tbody tr {
+  border-bottom: #efefef solid 1px;
+}
+div.ci-detail table tbody tr:last-child {
+  border-bottom: none;
+}*/
+
+div.ci-detail table td,
+div.ci-detail table th {
+  padding: 6px 8px;
+  text-align: left;
+  vertical-align: text-top;
+}
+
+div.ci-detail table th span.sort-arrow {
+  display: inline-block;
+  color: hsla(0, 0%, 0%, 0.15);
+  width: 1em; /*for constant width*/
+  text-align: right;
+}
+
+div.ci-detail table th span.sort-active {
+  color: #4078c0;
+}
+
+div.ci-detail table th {
+  padding-bottom: 10px;
+}
+
+div.ci-detail table th[data-cid="kind"],
+div.ci-detail table th[data-cid="obj_type"] {
+  white-space: nowrap
+}
+
+div.ci-detail table td[data-cid="kind"] span {
+  display: inline-block;
+  border-radius: 3px;
+  width: 1em;
+  height: 1em;
+  vertical-align: inherit;
+  color: transparent;
+}
+
+div.ci-detail table td[data-cid="text"] {
+  font-size: smaller;
+}
 
 /* FLOATING BUTTONS */
 

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1183,6 +1183,50 @@ table ul.repo-labels li {
   word-wrap: break-word;
 }
 
+/* TABLE COMPONENT DEFAULT STYLE */
+
+div.default-table-container {
+  padding: 6px 0.5em;
+  background-color: white;
+  border-radius: 6px;
+}
+
+table.default-table {
+  line-height: 1.5;
+  width: 100%;
+}
+
+table.default-table thead tr {
+  border-bottom: #efefef solid 1px;
+}
+/*table.default-table tbody tr {
+  border-bottom: #efefef solid 1px;
+}
+table.default-table tbody tr:last-child {
+  border-bottom: none;
+}*/
+
+table.default-table td,
+table.default-table th {
+  padding: 6px 8px;
+  text-align: left;
+}
+
+table.default-table th span.sort-arrow {
+  display: inline-block;
+  color: hsla(0, 0%, 0%, 0.15);
+  width: 1em; /*for constant width*/
+  text-align: right;
+}
+
+table.default-table th span.sort-active {
+  color: #4078c0;
+}
+
+table.default-table th {
+  padding-bottom: 10px;
+}
+
 /* CODE INSPECTOR */
 
 div.ci {
@@ -1211,47 +1255,9 @@ div.ci-detail {
   padding: 6px 0.5em;
 }
 
-div.ci-detail div.ci-detail-table-container {
-  padding: 6px 0.5em;
-  background-color: white;
-  border-radius: 6px;
-}
-
-div.ci-detail table {
-  line-height: 1.5;
-  width: 100%;
-}
-
-div.ci-detail table thead tr {
-  border-bottom: #efefef solid 1px;
-}
-/*div.ci-detail table tbody tr {
-  border-bottom: #efefef solid 1px;
-}
-div.ci-detail table tbody tr:last-child {
-  border-bottom: none;
-}*/
-
 div.ci-detail table td,
 div.ci-detail table th {
-  padding: 6px 8px;
-  text-align: left;
   vertical-align: text-top;
-}
-
-div.ci-detail table th span.sort-arrow {
-  display: inline-block;
-  color: hsla(0, 0%, 0%, 0.15);
-  width: 1em; /*for constant width*/
-  text-align: right;
-}
-
-div.ci-detail table th span.sort-active {
-  color: #4078c0;
-}
-
-div.ci-detail table th {
-  padding-bottom: 10px;
 }
 
 div.ci-detail table th[data-cid="kind"],

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -405,14 +405,39 @@ div.corner-hint {
 
 /* CODE INSPECTOR */
 
-.ci-head { background-color: var(--theme-container-background-color); }
-.ci-head .package-name span { color: grey; }
-.ci-variant   { color: #444; }
-.ci-result    { background-color: #f6f6f6; }
-.ci-result li { color: #444; }
-.ci-result li.ci-error   { border-left-color: #cd5353; }
-.ci-result li.ci-warning { border-left-color: #ecd227; }
-.ci-result li.ci-info    { border-left-color: #acacac; }
+div.ci { background-color: var(--theme-container-background-color); }
+
+div.ci-msg span.ci-variant { color: var(--theme-primary-font-color); }
+
+div.ci-stats span.error-count {
+  border-color: hsl(350, 100%, 80%);
+  background-color: hsl(350, 100%, 90%);
+}
+div.ci-stats span.warn-count {
+  border-color: hsl(60, 100%, 42%);
+  background-color: hsl(60, 100%, 90%);
+}
+div.ci-stats span.info-count {
+  border-color: hsl(120, 80%, 80%);
+  background-color: hsl(120, 80%, 94%);
+}
+div.ci-stats span.all-count {
+  border-color: hsl(235, 100%, 89%);
+  background-color: hsl(235, 100%, 93%);
+}
+div.ci-detail table td[data-cid="text"] {
+  color: hsl(0, 0%, 40%);
+}
+
+div.ci-detail table tr[data-kind="error"] td[data-cid="kind"] span {
+  background-color: hsl(0, 100%, 68%);
+}
+div.ci-detail table tr[data-kind="warning"] td[data-cid="kind"] span {
+  background-color:hsl(52, 100%, 49%);
+}
+div.ci-detail table tr[data-kind="info"] td[data-cid="kind"] span {
+  background-color: hsl(118, 67%, 47%);
+}
 
 /* COMMAND PALETTE */
 


### PR DESCRIPTION
User-wise - visual and UX improvement of codi pages (code inspector and syntax check):
- better look in general
- table formatting
- sorting
- filtering
- err/warn counters
- the visualization code is plus-minus rewritten completely

<img width="972" alt="image" src="https://github.com/abapGit/abapGit/assets/15635498/ce6f2088-7f9d-448d-80bc-f5d2628f95df">

Invisible internals:
- significant progress on html_table component:
  - sorting support and event helper
  - default css style
  - support for rendering data attributes - which helps with CSS in particular, but can be useful elsewhere as well (e.g. JS logic)
  - relevant unit tests
- html: `div` wrapper, `data_attr` helper added
- HOC: menu and title providers are takes from the components unless passed explicitely

Offtopic: minor fix of stage refresh placing. For good. Was interfering the changes in codi page.

TODO: will write some docs about table component (in doc repo)

P.S. I wanted also to add JS search like in stage. But I'm lazy. Next time. Maybe. Or maybe elsewhere.