### PR TITLE
fix unit tests after gui classes moved

### DIFF
--- a/test/abap_transpile.json
+++ b/test/abap_transpile.json
@@ -72,6 +72,9 @@
   "libs": [
     {
       "url": "https://github.com/open-abap/open-abap-core"
+    },
+    {
+      "url": "https://github.com/open-abap/open-abap-gui"
     }
   ],
   "write_unit_tests": true,


### PR DESCRIPTION
it broke due to https://github.com/open-abap/open-abap-core/pull/869