### PR TITLE
Where used page

### DIFF
--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -431,5 +431,12 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
       ir_package_scope = lt_package_scope
       it_tadir         = lt_tadir ).
 
+    SORT rt_objs.
+    DELETE ADJACENT DUPLICATES FROM rt_objs.
+    " Duplicates happen e.g. because where-used is found by method.
+    " However here this functionality aggregates them to the object
+    " These are not true duplicates, so if ever the method name (or any other duplicate cause)
+    " will be extracted, this sort can be removed
+
   ENDMETHOD.
 ENDCLASS.

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -1,0 +1,368 @@
+class ZCL_ABAPGIT_WHERE_USED_TOOLS definition
+  public
+  final
+  create public .
+
+  public section.
+
+    types ty_devc_range type range of tadir-devclass.
+    types:
+      begin of ty_dependency,
+        package type devclass,
+        obj_type type tadir-object,
+        obj_prog_type type trdir-subc,
+        obj_name type tadir-obj_name,
+        obj_cls  type rsfindlst-object_cls,
+        dep_package type devclass,
+        dep_obj_type type tadir-object,
+        dep_obj_name type tadir-obj_name,
+        dep_used_cls type rsfindlst-used_cls,
+        dep_used_obj type rsfindlst-used_obj,
+        cnt type i,
+      end of ty_dependency.
+    types:
+      tty_dependency type standard table of ty_dependency with default key.
+
+    " the initial version of this utility is also available as a standalone tool
+    " here: https://github.com/sbcgua/crossdeps
+    methods select_external_usages
+      importing
+        i_package        type tadir-devclass
+        ir_package_scope type ty_devc_range optional
+      returning
+        value(rt_objs) type tty_dependency
+      RAISING
+        zcx_abapgit_exception.
+
+  protected section.
+  private section.
+
+    types:
+      begin of ty_obj_signature,
+        package  type devclass,
+        obj_type type tadir-object,
+        obj_name type tadir-obj_name,
+      end of ty_obj_signature.
+
+    types tty_where_used type standard table of rsfindlst with default key.
+    types ty_seu_obj type standard table of seu_obj with default key.
+    types:
+      begin of ty_dev_object,
+        type type seu_stype,
+        tadir type trobjtype,
+      end of ty_dev_object.
+
+    data mt_object_packages type hashed table of ty_obj_signature with unique key obj_type obj_name.
+    data mt_dev_obj_cache type hashed table of ty_dev_object with unique key type.
+
+    methods get_where_used
+      importing
+        iv_obj_type      type euobj-id
+        iv_obj_name      type tadir-obj_name
+        it_scope         type ty_seu_obj optional
+        ir_package_scope type ty_devc_range optional
+      returning
+        value(rt_findings) type tty_where_used
+      RAISING
+        zcx_abapgit_exception.
+
+    methods get_obj_package
+      importing
+        iv_obj_type      type tadir-object
+        iv_obj_name      type tadir-obj_name
+      returning
+        value(rv_package) type tadir-devclass.
+
+    methods get_func_package
+      importing
+        iv_func_name      type tadir-obj_name
+      returning
+        value(rv_package) type tadir-devclass.
+
+    methods build_package_scope
+      importing
+        it_tadir type standard table
+        ir_package_scope type ty_devc_range
+      returning
+        value(rt_package_scope) type ty_devc_range.
+
+    methods collect_where_used
+      importing
+        it_tadir type standard table
+        ir_package_scope type ty_devc_range
+      returning
+        value(rt_objs) type tty_dependency
+      RAISING
+        zcx_abapgit_exception.
+
+    methods convert_list
+      importing
+        iv_package  type ty_dependency-dep_package
+        iv_obj_type type ty_dependency-dep_obj_type
+        iv_obj_name type ty_dependency-dep_obj_name
+        it_where_used type tty_where_used
+      returning
+        value(rt_objs) type tty_dependency.
+
+    methods decode_obj_type
+      importing
+        iv_type type rsfindlst-object_cls
+      returning
+        value(rv_type) type ty_dev_object-tadir.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
+
+
+  method build_package_scope.
+
+    field-symbols <tadir> type zif_abapgit_definitions=>ty_tadir.
+    field-symbols <pkg> like line of rt_package_scope.
+
+    rt_package_scope = ir_package_scope.
+    loop at it_tadir assigning <tadir>.
+      check <tadir>-object = 'DEVC'.
+      append initial line to rt_package_scope assigning <pkg>.
+      <pkg>-sign   = 'E'.
+      <pkg>-option = 'EQ'.
+      <pkg>-low    = <tadir>-obj_name.
+    endloop.
+
+  endmethod.
+
+
+  method collect_where_used.
+
+    data li_progress type ref to zif_abapgit_progress.
+    data lt_where_used type tty_where_used.
+    data lt_objs_portion like rt_objs.
+
+    field-symbols <tadir> type zif_abapgit_definitions=>ty_tadir.
+
+    li_progress = zcl_abapgit_progress=>get_instance( lines( it_tadir ) ).
+
+    loop at it_tadir assigning <tadir>.
+      check <tadir>-object <> 'DEVC'.
+
+      li_progress->show(
+        iv_current = sy-tabix
+        iv_text    = |{ <tadir>-object } { <tadir>-obj_name }| ).
+
+      lt_where_used = get_where_used(
+        iv_obj_type = |{ <tadir>-object }|
+        iv_obj_name = <tadir>-obj_name
+        ir_package_scope = ir_package_scope ).
+
+      lt_objs_portion = convert_list(
+        iv_package    = <tadir>-devclass
+        iv_obj_type   = <tadir>-object
+        iv_obj_name   = <tadir>-obj_name
+        it_where_used = lt_where_used ).
+
+      append lines of lt_objs_portion to rt_objs.
+
+    endloop.
+
+    li_progress->off( ).
+
+  endmethod.
+
+
+  method convert_list.
+
+    " See also CL_FINB_GN_BBI=>GET_CROSSREF
+
+    field-symbols <dep> like line of rt_objs.
+    field-symbols <use> like line of it_where_used.
+
+    loop at it_where_used assigning <use>.
+
+      append initial line to rt_objs assigning <dep>.
+      <dep>-cnt = 1.
+      <dep>-dep_package  = iv_package.
+      <dep>-dep_obj_type = iv_obj_type.
+      <dep>-dep_obj_name = iv_obj_name.
+
+      <dep>-dep_used_obj = <use>-used_obj.
+      <dep>-dep_used_cls = <use>-used_cls.
+
+      <dep>-obj_cls  = <use>-object_cls.
+      <dep>-obj_name = <use>-encl_objec.
+      if <dep>-obj_name is initial.
+        <dep>-obj_name = <use>-object.
+      endif.
+
+      if <use>-object_cls = 'FF'. " Function module
+        <dep>-obj_type = 'FUNC'.
+        <dep>-package = get_func_package( <dep>-obj_name ).
+
+      else.
+        <dep>-obj_type = decode_obj_type( <use>-object_cls ).
+
+        <dep>-package = get_obj_package(
+          iv_obj_type = <dep>-obj_type
+          iv_obj_name = <dep>-obj_name ).
+
+        if <dep>-package is initial and <dep>-obj_type = 'CLAS'.
+          <dep>-package = get_obj_package(
+            iv_obj_type = 'INTF'
+            iv_obj_name = <dep>-obj_name ).
+          if <dep>-package is not initial.
+            <dep>-obj_type = 'INTF'.
+          endif.
+        endif.
+      endif.
+
+      if <dep>-package is initial.
+        <dep>-package = '????'.
+
+        if <dep>-obj_type = 'PROG'. " Maybe it is an include
+          select single subc into <dep>-obj_prog_type from trdir where name = <dep>-obj_name.
+          if <dep>-obj_prog_type is not initial and <dep>-obj_prog_type <> '1'. " Exec. prog
+            <dep>-obj_type = 'INCL'.
+          endif.
+        endif.
+
+      endif.
+
+    endloop.
+
+    " some includes are FUGR and some are ENHO ...
+    " include detection TRDIR, D010INC ???
+    " How to find FUGR by main program name ???
+    " how to find connection with ENHO ?
+
+  endmethod.
+
+
+  method decode_obj_type.
+
+    field-symbols <devobj> like line of mt_dev_obj_cache.
+
+    if mt_dev_obj_cache is initial.
+      select type tadir into table mt_dev_obj_cache
+        from euobjedit.
+    endif.
+
+    read table mt_dev_obj_cache assigning <devobj> with key type = iv_type.
+    if sy-subrc = 0.
+      rv_type = <devobj>-tadir.
+    endif.
+
+  endmethod.
+
+
+  method get_func_package.
+
+    " See also: FUNCTION_INCLUDE_INFO, TFDIR, find main program -> get its pkg
+
+    data ls_obj_sig like line of mt_object_packages.
+
+    read table mt_object_packages into ls_obj_sig with key obj_type = 'FUNC' obj_name = iv_func_name.
+
+    if sy-subrc <> 0.
+      select single devclass into ls_obj_sig-package
+        from info_func
+        where funcname = iv_func_name.
+      if ls_obj_sig-package is not initial.
+        ls_obj_sig-obj_type = 'FUNC'.
+        ls_obj_sig-obj_name = iv_func_name.
+        insert ls_obj_sig into table mt_object_packages.
+      endif.
+    endif.
+
+    rv_package = ls_obj_sig-package.
+
+  endmethod.
+
+
+  method get_obj_package.
+
+    " see also zcl_abapgit_tadir->get_object_package for checks
+
+    data ls_obj_sig like line of mt_object_packages.
+
+    read table mt_object_packages into ls_obj_sig with key obj_type = iv_obj_type obj_name = iv_obj_name.
+
+    if sy-subrc <> 0.
+      ls_obj_sig-package = zcl_abapgit_factory=>get_tadir( )->read_single(
+        iv_object   = iv_obj_type
+        iv_obj_name = iv_obj_name )-devclass.
+      if ls_obj_sig-package is not initial.
+        ls_obj_sig-obj_type = iv_obj_type.
+        ls_obj_sig-obj_name = iv_obj_name.
+        insert ls_obj_sig into table mt_object_packages.
+      endif.
+    endif.
+
+    rv_package = ls_obj_sig-package.
+
+  endmethod.
+
+
+  method get_where_used.
+
+    data lt_findstrings type string_table.
+    data lt_scope       like it_scope.
+    data lv_findstring  like line of lt_findstrings.
+
+    if iv_obj_name is initial.
+      return.
+    endif.
+
+    lt_scope = it_scope.
+
+    lv_findstring = iv_obj_name.
+    insert lv_findstring into table lt_findstrings.
+
+    call function 'RS_EU_CROSSREF'
+      exporting
+        i_find_obj_cls           = iv_obj_type
+        no_dialog                = abap_true
+        without_text             = abap_true
+      tables
+        i_findstrings            = lt_findstrings
+        o_founds                 = rt_findings
+        i_scope_object_cls       = lt_scope
+        i_scope_devclass         = ir_package_scope
+      exceptions
+        not_executed             = 1
+        not_found                = 2
+        illegal_object           = 3
+        no_cross_for_this_object = 4
+        batch                    = 5
+        batchjob_error           = 6
+        wrong_type               = 7
+        object_not_exist         = 8
+        others                   = 9.
+
+    if sy-subrc = 1 or sy-subrc = 2 or lines( rt_findings ) = 0.
+      return.
+    elseif sy-subrc > 2.
+      zcx_abapgit_exception=>raise( |RS_EU_CROSSREF({ sy-subrc }) for { iv_obj_type } { iv_obj_name }| ).
+    endif.
+
+  endmethod.
+
+
+  method select_external_usages.
+
+    data lt_tadir type zif_abapgit_definitions=>ty_tadir_tt.
+    data lt_where_used type tty_where_used.
+    data lt_package_scope like ir_package_scope.
+
+    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( i_package ).
+
+    lt_package_scope = build_package_scope(
+      ir_package_scope = ir_package_scope
+      it_tadir         = lt_tadir ).
+
+    rt_objs = collect_where_used(
+      ir_package_scope = lt_package_scope
+      it_tadir         = lt_tadir ).
+
+  endmethod.
+ENDCLASS.

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -128,16 +128,16 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
 
   METHOD build_package_scope.
 
-    FIELD-SYMBOLS <tadir> TYPE zif_abapgit_definitions=>ty_tadir.
-    FIELD-SYMBOLS <pkg> LIKE LINE OF rt_package_scope.
+    FIELD-SYMBOLS <ls_tadir> TYPE zif_abapgit_definitions=>ty_tadir.
+    FIELD-SYMBOLS <ls_pkg> LIKE LINE OF rt_package_scope.
 
     rt_package_scope = ir_package_scope.
-    LOOP AT it_tadir ASSIGNING <tadir>.
-      CHECK <tadir>-object = 'DEVC'.
-      APPEND INITIAL LINE TO rt_package_scope ASSIGNING <pkg>.
-      <pkg>-sign   = 'E'.
-      <pkg>-option = 'EQ'.
-      <pkg>-low    = <tadir>-obj_name.
+    LOOP AT it_tadir ASSIGNING <ls_tadir>.
+      CHECK <ls_tadir>-object = 'DEVC'.
+      APPEND INITIAL LINE TO rt_package_scope ASSIGNING <ls_pkg>.
+      <ls_pkg>-sign   = 'E'.
+      <ls_pkg>-option = 'EQ'.
+      <ls_pkg>-low    = <ls_tadir>-obj_name.
     ENDLOOP.
 
   ENDMETHOD.
@@ -149,26 +149,26 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
     DATA lt_where_used TYPE ty_where_used_tt.
     DATA lt_objs_portion LIKE rt_objs.
 
-    FIELD-SYMBOLS <tadir> TYPE zif_abapgit_definitions=>ty_tadir.
+    FIELD-SYMBOLS <ls_tadir> TYPE zif_abapgit_definitions=>ty_tadir.
 
     li_progress = zcl_abapgit_progress=>get_instance( lines( it_tadir ) ).
 
-    LOOP AT it_tadir ASSIGNING <tadir>.
-      CHECK <tadir>-object <> 'DEVC'.
+    LOOP AT it_tadir ASSIGNING <ls_tadir>.
+      CHECK <ls_tadir>-object <> 'DEVC'.
 
       li_progress->show(
         iv_current = sy-tabix
-        iv_text    = |{ <tadir>-object } { <tadir>-obj_name }| ).
+        iv_text    = |{ <ls_tadir>-object } { <ls_tadir>-obj_name }| ).
 
       lt_where_used = get_where_used(
-        iv_obj_type = |{ <tadir>-object }|
-        iv_obj_name = <tadir>-obj_name
+        iv_obj_type = |{ <ls_tadir>-object }|
+        iv_obj_name = <ls_tadir>-obj_name
         ir_package_scope = ir_package_scope ).
 
       lt_objs_portion = convert_list(
-        iv_package    = <tadir>-devclass
-        iv_obj_type   = <tadir>-object
-        iv_obj_name   = <tadir>-obj_name
+        iv_package    = <ls_tadir>-devclass
+        iv_obj_type   = <ls_tadir>-object
+        iv_obj_name   = <ls_tadir>-obj_name
         it_where_used = lt_where_used ).
 
       APPEND LINES OF lt_objs_portion TO rt_objs.
@@ -184,61 +184,61 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
 
     " See also CL_FINB_GN_BBI=>GET_CROSSREF
 
-    FIELD-SYMBOLS <dep> LIKE LINE OF rt_objs.
-    FIELD-SYMBOLS <use> LIKE LINE OF it_where_used.
+    FIELD-SYMBOLS <ls_dep> LIKE LINE OF rt_objs.
+    FIELD-SYMBOLS <ls_use> LIKE LINE OF it_where_used.
 
-    LOOP AT it_where_used ASSIGNING <use>.
+    LOOP AT it_where_used ASSIGNING <ls_use>.
 
-      APPEND INITIAL LINE TO rt_objs ASSIGNING <dep>.
-      <dep>-dep_package  = iv_package.
-      <dep>-dep_obj_type = iv_obj_type.
-      <dep>-dep_obj_name = iv_obj_name.
+      APPEND INITIAL LINE TO rt_objs ASSIGNING <ls_dep>.
+      <ls_dep>-dep_package  = iv_package.
+      <ls_dep>-dep_obj_type = iv_obj_type.
+      <ls_dep>-dep_obj_name = iv_obj_name.
 
-      <dep>-dep_used_obj = <use>-used_obj.
-      <dep>-dep_used_cls = <use>-used_cls.
+      <ls_dep>-dep_used_obj = <ls_use>-used_obj.
+      <ls_dep>-dep_used_cls = <ls_use>-used_cls.
 
-      <dep>-obj_cls  = <use>-object_cls.
-      <dep>-obj_name = <use>-encl_objec.
-      IF <dep>-obj_name IS INITIAL.
-        <dep>-obj_name = <use>-object.
+      <ls_dep>-obj_cls  = <ls_use>-object_cls.
+      <ls_dep>-obj_name = <ls_use>-encl_objec.
+      IF <ls_dep>-obj_name IS INITIAL.
+        <ls_dep>-obj_name = <ls_use>-object.
       ENDIF.
 
-      IF <use>-object_cls = 'FF'. " Function module
-        <dep>-obj_type = 'FUNC'.
-        <dep>-package = get_func_package( <dep>-obj_name ).
+      IF <ls_use>-object_cls = 'FF'. " Function module
+        <ls_dep>-obj_type = 'FUNC'.
+        <ls_dep>-package = get_func_package( <ls_dep>-obj_name ).
 
       ELSE.
-        <dep>-obj_type = decode_obj_type( <use>-object_cls ).
+        <ls_dep>-obj_type = decode_obj_type( <ls_use>-object_cls ).
 
-        <dep>-package = get_obj_package(
-          iv_obj_type = <dep>-obj_type
-          iv_obj_name = <dep>-obj_name ).
+        <ls_dep>-package = get_obj_package(
+          iv_obj_type = <ls_dep>-obj_type
+          iv_obj_name = <ls_dep>-obj_name ).
 
-        IF <dep>-package IS INITIAL AND <dep>-obj_type = 'CLAS'.
-          <dep>-package = get_obj_package(
+        IF <ls_dep>-package IS INITIAL AND <ls_dep>-obj_type = 'CLAS'.
+          <ls_dep>-package = get_obj_package(
             iv_obj_type = 'INTF'
-            iv_obj_name = <dep>-obj_name ).
-          IF <dep>-package IS NOT INITIAL.
-            <dep>-obj_type = 'INTF'.
+            iv_obj_name = <ls_dep>-obj_name ).
+          IF <ls_dep>-package IS NOT INITIAL.
+            <ls_dep>-obj_type = 'INTF'.
           ENDIF.
         ENDIF.
       ENDIF.
 
-      IF <dep>-package IS INITIAL.
-        IF <dep>-obj_type = 'PROG'. " Maybe it is an include
+      IF <ls_dep>-package IS INITIAL.
+        IF <ls_dep>-obj_type = 'PROG'. " Maybe it is an include
 
-          <dep>-package = get_incl_package( <dep>-obj_name ).
-          IF <dep>-package IS INITIAL.
-            SELECT SINGLE subc INTO <dep>-obj_prog_type FROM trdir WHERE name = <dep>-obj_name.
-            IF <dep>-obj_prog_type IS NOT INITIAL AND <dep>-obj_prog_type <> '1'. " Exec. prog
-              <dep>-obj_type = 'INCL'.
+          <ls_dep>-package = get_incl_package( <ls_dep>-obj_name ).
+          IF <ls_dep>-package IS INITIAL.
+            SELECT SINGLE subc INTO <ls_dep>-obj_prog_type FROM trdir WHERE name = <ls_dep>-obj_name.
+            IF <ls_dep>-obj_prog_type IS NOT INITIAL AND <ls_dep>-obj_prog_type <> '1'. " Exec. prog
+              <ls_dep>-obj_type = 'INCL'.
             ENDIF.
           ENDIF.
 
         ENDIF.
 
-        IF <dep>-package IS INITIAL.
-          <dep>-package = '????'.
+        IF <ls_dep>-package IS INITIAL.
+          <ls_dep>-package = '????'.
         ENDIF.
       ENDIF.
 
@@ -256,16 +256,16 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
 
   METHOD decode_obj_type.
 
-    FIELD-SYMBOLS <devobj> LIKE LINE OF mt_dev_obj_cache.
+    FIELD-SYMBOLS <ls_devobj> LIKE LINE OF mt_dev_obj_cache.
 
     IF mt_dev_obj_cache IS INITIAL.
       SELECT type tadir INTO TABLE mt_dev_obj_cache
         FROM euobjedit.
     ENDIF.
 
-    READ TABLE mt_dev_obj_cache ASSIGNING <devobj> WITH KEY type = iv_type.
+    READ TABLE mt_dev_obj_cache ASSIGNING <ls_devobj> WITH KEY type = iv_type.
     IF sy-subrc = 0.
-      rv_type = <devobj>-tadir.
+      rv_type = <ls_devobj>-tadir.
     ENDIF.
 
   ENDMETHOD.

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -20,7 +20,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         dep_used_obj  TYPE rsfindlst-used_obj,
       END OF ty_dependency.
     TYPES:
-      tty_dependency TYPE STANDARD TABLE OF ty_dependency WITH DEFAULT KEY.
+      ty_dependency_tt TYPE STANDARD TABLE OF ty_dependency WITH DEFAULT KEY.
 
     CLASS-METHODS new
       RETURNING
@@ -33,7 +33,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         i_package        TYPE tadir-devclass
         ir_package_scope TYPE ty_devc_range OPTIONAL
       RETURNING
-        VALUE(rt_objs)   TYPE tty_dependency
+        VALUE(rt_objs)   TYPE ty_dependency_tt
       RAISING
         zcx_abapgit_exception.
 
@@ -94,7 +94,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         it_tadir         TYPE STANDARD TABLE
         ir_package_scope TYPE ty_devc_range
       RETURNING
-        VALUE(rt_objs)   TYPE tty_dependency
+        VALUE(rt_objs)   TYPE ty_dependency_tt
       RAISING
         zcx_abapgit_exception.
 
@@ -105,7 +105,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         iv_obj_name    TYPE ty_dependency-dep_obj_name
         it_where_used  TYPE tty_where_used
       RETURNING
-        VALUE(rt_objs) TYPE tty_dependency.
+        VALUE(rt_objs) TYPE ty_dependency_tt.
 
     METHODS decode_obj_type
       IMPORTING

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -30,7 +30,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
     " here: https://github.com/sbcgua/crossdeps
     METHODS select_external_usages
       IMPORTING
-        i_package        TYPE tadir-devclass
+        iv_package       TYPE tadir-devclass
         ir_package_scope TYPE ty_devc_range OPTIONAL
       RETURNING
         VALUE(rt_objs)   TYPE ty_dependency_tt
@@ -358,10 +358,9 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
   METHOD select_external_usages.
 
     DATA lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
-    DATA lt_where_used TYPE ty_where_used_tt.
     DATA lt_package_scope LIKE ir_package_scope.
 
-    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( i_package ).
+    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( iv_package ).
 
     lt_package_scope = build_package_scope(
       ir_package_scope = ir_package_scope

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -18,7 +18,6 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         dep_obj_name  TYPE tadir-obj_name,
         dep_used_cls  TYPE rsfindlst-used_cls,
         dep_used_obj  TYPE rsfindlst-used_obj,
-        cnt           TYPE i,
       END OF ty_dependency.
     TYPES:
       tty_dependency TYPE STANDARD TABLE OF ty_dependency WITH DEFAULT KEY.
@@ -185,7 +184,6 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
     LOOP AT it_where_used ASSIGNING <use>.
 
       APPEND INITIAL LINE TO rt_objs ASSIGNING <dep>.
-      <dep>-cnt = 1.
       <dep>-dep_package  = iv_package.
       <dep>-dep_obj_type = iv_obj_type.
       <dep>-dep_obj_name = iv_obj_name.

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -47,7 +47,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         obj_name TYPE tadir-obj_name,
       END OF ty_obj_signature.
 
-    TYPES tty_where_used TYPE STANDARD TABLE OF rsfindlst WITH DEFAULT KEY.
+    TYPES ty_where_used_tt TYPE STANDARD TABLE OF rsfindlst WITH DEFAULT KEY.
     TYPES ty_seu_obj TYPE STANDARD TABLE OF seu_obj WITH DEFAULT KEY.
     TYPES:
       BEGIN OF ty_dev_object,
@@ -65,7 +65,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         it_scope           TYPE ty_seu_obj OPTIONAL
         ir_package_scope   TYPE ty_devc_range OPTIONAL
       RETURNING
-        VALUE(rt_findings) TYPE tty_where_used
+        VALUE(rt_findings) TYPE ty_where_used_tt
       RAISING
         zcx_abapgit_exception.
 
@@ -103,7 +103,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
         iv_package     TYPE ty_dependency-dep_package
         iv_obj_type    TYPE ty_dependency-dep_obj_type
         iv_obj_name    TYPE ty_dependency-dep_obj_name
-        it_where_used  TYPE tty_where_used
+        it_where_used  TYPE ty_where_used_tt
       RETURNING
         VALUE(rt_objs) TYPE ty_dependency_tt.
 
@@ -140,7 +140,7 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
   METHOD collect_where_used.
 
     DATA li_progress TYPE REF TO zif_abapgit_progress.
-    DATA lt_where_used TYPE tty_where_used.
+    DATA lt_where_used TYPE ty_where_used_tt.
     DATA lt_objs_portion LIKE rt_objs.
 
     FIELD-SYMBOLS <tadir> TYPE zif_abapgit_definitions=>ty_tadir.
@@ -358,7 +358,7 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
   METHOD select_external_usages.
 
     DATA lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
-    DATA lt_where_used TYPE tty_where_used.
+    DATA lt_where_used TYPE ty_where_used_tt.
     DATA lt_package_scope LIKE ir_package_scope.
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( i_package ).

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -31,6 +31,7 @@ CLASS zcl_abapgit_where_used_tools DEFINITION
     METHODS select_external_usages
       IMPORTING
         iv_package       TYPE tadir-devclass
+        iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
         ir_package_scope TYPE ty_devc_range OPTIONAL
       RETURNING
         VALUE(rt_objs)   TYPE ty_dependency_tt
@@ -418,7 +419,9 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
     DATA lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
     DATA lt_package_scope LIKE ir_package_scope.
 
-    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( iv_package ).
+    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read(
+     iv_package            = iv_package
+     iv_ignore_subpackages = iv_ignore_subpackages ).
 
     lt_package_scope = build_package_scope(
       ir_package_scope = ir_package_scope

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.abap
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.abap
@@ -1,114 +1,118 @@
-class ZCL_ABAPGIT_WHERE_USED_TOOLS definition
-  public
-  final
-  create public .
+CLASS zcl_abapgit_where_used_tools DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-  public section.
+  PUBLIC SECTION.
 
-    types ty_devc_range type range of tadir-devclass.
-    types:
-      begin of ty_dependency,
-        package type devclass,
-        obj_type type tadir-object,
-        obj_prog_type type trdir-subc,
-        obj_name type tadir-obj_name,
-        obj_cls  type rsfindlst-object_cls,
-        dep_package type devclass,
-        dep_obj_type type tadir-object,
-        dep_obj_name type tadir-obj_name,
-        dep_used_cls type rsfindlst-used_cls,
-        dep_used_obj type rsfindlst-used_obj,
-        cnt type i,
-      end of ty_dependency.
-    types:
-      tty_dependency type standard table of ty_dependency with default key.
+    TYPES ty_devc_range TYPE RANGE OF tadir-devclass.
+    TYPES:
+      BEGIN OF ty_dependency,
+        package       TYPE devclass,
+        obj_type      TYPE tadir-object,
+        obj_prog_type TYPE trdir-subc,
+        obj_name      TYPE tadir-obj_name,
+        obj_cls       TYPE rsfindlst-object_cls,
+        dep_package   TYPE devclass,
+        dep_obj_type  TYPE tadir-object,
+        dep_obj_name  TYPE tadir-obj_name,
+        dep_used_cls  TYPE rsfindlst-used_cls,
+        dep_used_obj  TYPE rsfindlst-used_obj,
+        cnt           TYPE i,
+      END OF ty_dependency.
+    TYPES:
+      tty_dependency TYPE STANDARD TABLE OF ty_dependency WITH DEFAULT KEY.
+
+    CLASS-METHODS new
+      RETURNING
+        VALUE(ro_instance) TYPE REF TO zcl_abapgit_where_used_tools.
 
     " the initial version of this utility is also available as a standalone tool
     " here: https://github.com/sbcgua/crossdeps
-    methods select_external_usages
-      importing
-        i_package        type tadir-devclass
-        ir_package_scope type ty_devc_range optional
-      returning
-        value(rt_objs) type tty_dependency
+    METHODS select_external_usages
+      IMPORTING
+        i_package        TYPE tadir-devclass
+        ir_package_scope TYPE ty_devc_range OPTIONAL
+      RETURNING
+        VALUE(rt_objs)   TYPE tty_dependency
       RAISING
         zcx_abapgit_exception.
 
-  protected section.
-  private section.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 
-    types:
-      begin of ty_obj_signature,
-        package  type devclass,
-        obj_type type tadir-object,
-        obj_name type tadir-obj_name,
-      end of ty_obj_signature.
+    TYPES:
+      BEGIN OF ty_obj_signature,
+        package  TYPE devclass,
+        obj_type TYPE tadir-object,
+        obj_name TYPE tadir-obj_name,
+      END OF ty_obj_signature.
 
-    types tty_where_used type standard table of rsfindlst with default key.
-    types ty_seu_obj type standard table of seu_obj with default key.
-    types:
-      begin of ty_dev_object,
-        type type seu_stype,
-        tadir type trobjtype,
-      end of ty_dev_object.
+    TYPES tty_where_used TYPE STANDARD TABLE OF rsfindlst WITH DEFAULT KEY.
+    TYPES ty_seu_obj TYPE STANDARD TABLE OF seu_obj WITH DEFAULT KEY.
+    TYPES:
+      BEGIN OF ty_dev_object,
+        type  TYPE seu_stype,
+        tadir TYPE trobjtype,
+      END OF ty_dev_object.
 
-    data mt_object_packages type hashed table of ty_obj_signature with unique key obj_type obj_name.
-    data mt_dev_obj_cache type hashed table of ty_dev_object with unique key type.
+    DATA mt_object_packages TYPE HASHED TABLE OF ty_obj_signature WITH UNIQUE KEY obj_type obj_name.
+    DATA mt_dev_obj_cache TYPE HASHED TABLE OF ty_dev_object WITH UNIQUE KEY type.
 
-    methods get_where_used
-      importing
-        iv_obj_type      type euobj-id
-        iv_obj_name      type tadir-obj_name
-        it_scope         type ty_seu_obj optional
-        ir_package_scope type ty_devc_range optional
-      returning
-        value(rt_findings) type tty_where_used
+    METHODS get_where_used
+      IMPORTING
+        iv_obj_type        TYPE euobj-id
+        iv_obj_name        TYPE tadir-obj_name
+        it_scope           TYPE ty_seu_obj OPTIONAL
+        ir_package_scope   TYPE ty_devc_range OPTIONAL
+      RETURNING
+        VALUE(rt_findings) TYPE tty_where_used
       RAISING
         zcx_abapgit_exception.
 
-    methods get_obj_package
-      importing
-        iv_obj_type      type tadir-object
-        iv_obj_name      type tadir-obj_name
-      returning
-        value(rv_package) type tadir-devclass.
+    METHODS get_obj_package
+      IMPORTING
+        iv_obj_type       TYPE tadir-object
+        iv_obj_name       TYPE tadir-obj_name
+      RETURNING
+        VALUE(rv_package) TYPE tadir-devclass.
 
-    methods get_func_package
-      importing
-        iv_func_name      type tadir-obj_name
-      returning
-        value(rv_package) type tadir-devclass.
+    METHODS get_func_package
+      IMPORTING
+        iv_func_name      TYPE tadir-obj_name
+      RETURNING
+        VALUE(rv_package) TYPE tadir-devclass.
 
-    methods build_package_scope
-      importing
-        it_tadir type standard table
-        ir_package_scope type ty_devc_range
-      returning
-        value(rt_package_scope) type ty_devc_range.
+    METHODS build_package_scope
+      IMPORTING
+        it_tadir                TYPE STANDARD TABLE
+        ir_package_scope        TYPE ty_devc_range
+      RETURNING
+        VALUE(rt_package_scope) TYPE ty_devc_range.
 
-    methods collect_where_used
-      importing
-        it_tadir type standard table
-        ir_package_scope type ty_devc_range
-      returning
-        value(rt_objs) type tty_dependency
+    METHODS collect_where_used
+      IMPORTING
+        it_tadir         TYPE STANDARD TABLE
+        ir_package_scope TYPE ty_devc_range
+      RETURNING
+        VALUE(rt_objs)   TYPE tty_dependency
       RAISING
         zcx_abapgit_exception.
 
-    methods convert_list
-      importing
-        iv_package  type ty_dependency-dep_package
-        iv_obj_type type ty_dependency-dep_obj_type
-        iv_obj_name type ty_dependency-dep_obj_name
-        it_where_used type tty_where_used
-      returning
-        value(rt_objs) type tty_dependency.
+    METHODS convert_list
+      IMPORTING
+        iv_package     TYPE ty_dependency-dep_package
+        iv_obj_type    TYPE ty_dependency-dep_obj_type
+        iv_obj_name    TYPE ty_dependency-dep_obj_name
+        it_where_used  TYPE tty_where_used
+      RETURNING
+        VALUE(rt_objs) TYPE tty_dependency.
 
-    methods decode_obj_type
-      importing
-        iv_type type rsfindlst-object_cls
-      returning
-        value(rv_type) type ty_dev_object-tadir.
+    METHODS decode_obj_type
+      IMPORTING
+        iv_type        TYPE rsfindlst-object_cls
+      RETURNING
+        VALUE(rv_type) TYPE ty_dev_object-tadir.
 
 ENDCLASS.
 
@@ -117,35 +121,35 @@ ENDCLASS.
 CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
 
 
-  method build_package_scope.
+  METHOD build_package_scope.
 
-    field-symbols <tadir> type zif_abapgit_definitions=>ty_tadir.
-    field-symbols <pkg> like line of rt_package_scope.
+    FIELD-SYMBOLS <tadir> TYPE zif_abapgit_definitions=>ty_tadir.
+    FIELD-SYMBOLS <pkg> LIKE LINE OF rt_package_scope.
 
     rt_package_scope = ir_package_scope.
-    loop at it_tadir assigning <tadir>.
-      check <tadir>-object = 'DEVC'.
-      append initial line to rt_package_scope assigning <pkg>.
+    LOOP AT it_tadir ASSIGNING <tadir>.
+      CHECK <tadir>-object = 'DEVC'.
+      APPEND INITIAL LINE TO rt_package_scope ASSIGNING <pkg>.
       <pkg>-sign   = 'E'.
       <pkg>-option = 'EQ'.
       <pkg>-low    = <tadir>-obj_name.
-    endloop.
+    ENDLOOP.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method collect_where_used.
+  METHOD collect_where_used.
 
-    data li_progress type ref to zif_abapgit_progress.
-    data lt_where_used type tty_where_used.
-    data lt_objs_portion like rt_objs.
+    DATA li_progress TYPE REF TO zif_abapgit_progress.
+    DATA lt_where_used TYPE tty_where_used.
+    DATA lt_objs_portion LIKE rt_objs.
 
-    field-symbols <tadir> type zif_abapgit_definitions=>ty_tadir.
+    FIELD-SYMBOLS <tadir> TYPE zif_abapgit_definitions=>ty_tadir.
 
     li_progress = zcl_abapgit_progress=>get_instance( lines( it_tadir ) ).
 
-    loop at it_tadir assigning <tadir>.
-      check <tadir>-object <> 'DEVC'.
+    LOOP AT it_tadir ASSIGNING <tadir>.
+      CHECK <tadir>-object <> 'DEVC'.
 
       li_progress->show(
         iv_current = sy-tabix
@@ -162,25 +166,25 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
         iv_obj_name   = <tadir>-obj_name
         it_where_used = lt_where_used ).
 
-      append lines of lt_objs_portion to rt_objs.
+      APPEND LINES OF lt_objs_portion TO rt_objs.
 
-    endloop.
+    ENDLOOP.
 
     li_progress->off( ).
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method convert_list.
+  METHOD convert_list.
 
     " See also CL_FINB_GN_BBI=>GET_CROSSREF
 
-    field-symbols <dep> like line of rt_objs.
-    field-symbols <use> like line of it_where_used.
+    FIELD-SYMBOLS <dep> LIKE LINE OF rt_objs.
+    FIELD-SYMBOLS <use> LIKE LINE OF it_where_used.
 
-    loop at it_where_used assigning <use>.
+    LOOP AT it_where_used ASSIGNING <use>.
 
-      append initial line to rt_objs assigning <dep>.
+      APPEND INITIAL LINE TO rt_objs ASSIGNING <dep>.
       <dep>-cnt = 1.
       <dep>-dep_package  = iv_package.
       <dep>-dep_obj_type = iv_obj_type.
@@ -191,144 +195,144 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
 
       <dep>-obj_cls  = <use>-object_cls.
       <dep>-obj_name = <use>-encl_objec.
-      if <dep>-obj_name is initial.
+      IF <dep>-obj_name IS INITIAL.
         <dep>-obj_name = <use>-object.
-      endif.
+      ENDIF.
 
-      if <use>-object_cls = 'FF'. " Function module
+      IF <use>-object_cls = 'FF'. " Function module
         <dep>-obj_type = 'FUNC'.
         <dep>-package = get_func_package( <dep>-obj_name ).
 
-      else.
+      ELSE.
         <dep>-obj_type = decode_obj_type( <use>-object_cls ).
 
         <dep>-package = get_obj_package(
           iv_obj_type = <dep>-obj_type
           iv_obj_name = <dep>-obj_name ).
 
-        if <dep>-package is initial and <dep>-obj_type = 'CLAS'.
+        IF <dep>-package IS INITIAL AND <dep>-obj_type = 'CLAS'.
           <dep>-package = get_obj_package(
             iv_obj_type = 'INTF'
             iv_obj_name = <dep>-obj_name ).
-          if <dep>-package is not initial.
+          IF <dep>-package IS NOT INITIAL.
             <dep>-obj_type = 'INTF'.
-          endif.
-        endif.
-      endif.
+          ENDIF.
+        ENDIF.
+      ENDIF.
 
-      if <dep>-package is initial.
+      IF <dep>-package IS INITIAL.
         <dep>-package = '????'.
 
-        if <dep>-obj_type = 'PROG'. " Maybe it is an include
-          select single subc into <dep>-obj_prog_type from trdir where name = <dep>-obj_name.
-          if <dep>-obj_prog_type is not initial and <dep>-obj_prog_type <> '1'. " Exec. prog
+        IF <dep>-obj_type = 'PROG'. " Maybe it is an include
+          SELECT SINGLE subc INTO <dep>-obj_prog_type FROM trdir WHERE name = <dep>-obj_name.
+          IF <dep>-obj_prog_type IS NOT INITIAL AND <dep>-obj_prog_type <> '1'. " Exec. prog
             <dep>-obj_type = 'INCL'.
-          endif.
-        endif.
+          ENDIF.
+        ENDIF.
 
-      endif.
+      ENDIF.
 
-    endloop.
+    ENDLOOP.
 
     " some includes are FUGR and some are ENHO ...
     " include detection TRDIR, D010INC ???
     " How to find FUGR by main program name ???
     " how to find connection with ENHO ?
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method decode_obj_type.
+  METHOD decode_obj_type.
 
-    field-symbols <devobj> like line of mt_dev_obj_cache.
+    FIELD-SYMBOLS <devobj> LIKE LINE OF mt_dev_obj_cache.
 
-    if mt_dev_obj_cache is initial.
-      select type tadir into table mt_dev_obj_cache
-        from euobjedit.
-    endif.
+    IF mt_dev_obj_cache IS INITIAL.
+      SELECT type tadir INTO TABLE mt_dev_obj_cache
+        FROM euobjedit.
+    ENDIF.
 
-    read table mt_dev_obj_cache assigning <devobj> with key type = iv_type.
-    if sy-subrc = 0.
+    READ TABLE mt_dev_obj_cache ASSIGNING <devobj> WITH KEY type = iv_type.
+    IF sy-subrc = 0.
       rv_type = <devobj>-tadir.
-    endif.
+    ENDIF.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method get_func_package.
+  METHOD get_func_package.
 
     " See also: FUNCTION_INCLUDE_INFO, TFDIR, find main program -> get its pkg
 
-    data ls_obj_sig like line of mt_object_packages.
+    DATA ls_obj_sig LIKE LINE OF mt_object_packages.
 
-    read table mt_object_packages into ls_obj_sig with key obj_type = 'FUNC' obj_name = iv_func_name.
+    READ TABLE mt_object_packages INTO ls_obj_sig WITH KEY obj_type = 'FUNC' obj_name = iv_func_name.
 
-    if sy-subrc <> 0.
-      select single devclass into ls_obj_sig-package
-        from info_func
-        where funcname = iv_func_name.
-      if ls_obj_sig-package is not initial.
+    IF sy-subrc <> 0.
+      SELECT SINGLE devclass INTO ls_obj_sig-package
+        FROM info_func
+        WHERE funcname = iv_func_name.
+      IF ls_obj_sig-package IS NOT INITIAL.
         ls_obj_sig-obj_type = 'FUNC'.
         ls_obj_sig-obj_name = iv_func_name.
-        insert ls_obj_sig into table mt_object_packages.
-      endif.
-    endif.
+        INSERT ls_obj_sig INTO TABLE mt_object_packages.
+      ENDIF.
+    ENDIF.
 
     rv_package = ls_obj_sig-package.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method get_obj_package.
+  METHOD get_obj_package.
 
     " see also zcl_abapgit_tadir->get_object_package for checks
 
-    data ls_obj_sig like line of mt_object_packages.
+    DATA ls_obj_sig LIKE LINE OF mt_object_packages.
 
-    read table mt_object_packages into ls_obj_sig with key obj_type = iv_obj_type obj_name = iv_obj_name.
+    READ TABLE mt_object_packages INTO ls_obj_sig WITH KEY obj_type = iv_obj_type obj_name = iv_obj_name.
 
-    if sy-subrc <> 0.
+    IF sy-subrc <> 0.
       ls_obj_sig-package = zcl_abapgit_factory=>get_tadir( )->read_single(
         iv_object   = iv_obj_type
         iv_obj_name = iv_obj_name )-devclass.
-      if ls_obj_sig-package is not initial.
+      IF ls_obj_sig-package IS NOT INITIAL.
         ls_obj_sig-obj_type = iv_obj_type.
         ls_obj_sig-obj_name = iv_obj_name.
-        insert ls_obj_sig into table mt_object_packages.
-      endif.
-    endif.
+        INSERT ls_obj_sig INTO TABLE mt_object_packages.
+      ENDIF.
+    ENDIF.
 
     rv_package = ls_obj_sig-package.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method get_where_used.
+  METHOD get_where_used.
 
-    data lt_findstrings type string_table.
-    data lt_scope       like it_scope.
-    data lv_findstring  like line of lt_findstrings.
+    DATA lt_findstrings TYPE string_table.
+    DATA lt_scope       LIKE it_scope.
+    DATA lv_findstring  LIKE LINE OF lt_findstrings.
 
-    if iv_obj_name is initial.
-      return.
-    endif.
+    IF iv_obj_name IS INITIAL.
+      RETURN.
+    ENDIF.
 
     lt_scope = it_scope.
 
     lv_findstring = iv_obj_name.
-    insert lv_findstring into table lt_findstrings.
+    INSERT lv_findstring INTO TABLE lt_findstrings.
 
-    call function 'RS_EU_CROSSREF'
-      exporting
+    CALL FUNCTION 'RS_EU_CROSSREF'
+      EXPORTING
         i_find_obj_cls           = iv_obj_type
         no_dialog                = abap_true
         without_text             = abap_true
-      tables
+      TABLES
         i_findstrings            = lt_findstrings
         o_founds                 = rt_findings
         i_scope_object_cls       = lt_scope
         i_scope_devclass         = ir_package_scope
-      exceptions
+      EXCEPTIONS
         not_executed             = 1
         not_found                = 2
         illegal_object           = 3
@@ -337,22 +341,27 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
         batchjob_error           = 6
         wrong_type               = 7
         object_not_exist         = 8
-        others                   = 9.
+        OTHERS                   = 9.
 
-    if sy-subrc = 1 or sy-subrc = 2 or lines( rt_findings ) = 0.
-      return.
-    elseif sy-subrc > 2.
+    IF sy-subrc = 1 OR sy-subrc = 2 OR lines( rt_findings ) = 0.
+      RETURN.
+    ELSEIF sy-subrc > 2.
       zcx_abapgit_exception=>raise( |RS_EU_CROSSREF({ sy-subrc }) for { iv_obj_type } { iv_obj_name }| ).
-    endif.
+    ENDIF.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method select_external_usages.
+  METHOD new.
+    CREATE OBJECT ro_instance.
+  ENDMETHOD.
 
-    data lt_tadir type zif_abapgit_definitions=>ty_tadir_tt.
-    data lt_where_used type tty_where_used.
-    data lt_package_scope like ir_package_scope.
+
+  METHOD select_external_usages.
+
+    DATA lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt.
+    DATA lt_where_used TYPE tty_where_used.
+    DATA lt_package_scope LIKE ir_package_scope.
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( i_package ).
 
@@ -364,5 +373,5 @@ CLASS ZCL_ABAPGIT_WHERE_USED_TOOLS IMPLEMENTATION.
       ir_package_scope = lt_package_scope
       it_tadir         = lt_tadir ).
 
-  endmethod.
+  ENDMETHOD.
 ENDCLASS.

--- a/src/inspect/zcl_abapgit_where_used_tools.clas.xml
+++ b/src/inspect/zcl_abapgit_where_used_tools.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_WHERE_USED_TOOLS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit where used utilities</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -115,7 +115,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
 
 
   METHOD back.
@@ -412,7 +412,7 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
     ENDIF.
 
     li_html = mi_cur_page->render( ).
-    lv_html = li_html->render( abap_true ).
+    lv_html = li_html->render( iv_no_indent_jscss = abap_true ).
 
     IF mi_html_processor IS BOUND.
       lv_html = mi_html_processor->process(

--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -482,6 +482,8 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       iv_tag   = 'div'
       iv_content = iv_content
       ii_content = ii_content
+      is_data_attr  = is_data_attr
+      it_data_attrs = it_data_attrs
       iv_id    = iv_id
       iv_class = iv_class ).
     ri_self = me.
@@ -512,14 +514,18 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
     FIELD-SYMBOLS: <lv_line>   LIKE LINE OF lt_temp,
                    <lv_line_c> LIKE LINE OF lt_temp.
 
-    ls_context-no_indent_jscss = iv_no_indent_jscss.
+    IF iv_no_line_breaks = abap_true.
+      CONCATENATE LINES OF mt_buffer INTO rv_html.
+    ELSE.
+      ls_context-no_indent_jscss = iv_no_indent_jscss.
 
-    LOOP AT mt_buffer ASSIGNING <lv_line>.
-      APPEND <lv_line> TO lt_temp ASSIGNING <lv_line_c>.
-      indent_line( CHANGING cs_context = ls_context cv_line = <lv_line_c> ).
-    ENDLOOP.
+      LOOP AT mt_buffer ASSIGNING <lv_line>.
+        APPEND <lv_line> TO lt_temp ASSIGNING <lv_line_c>.
+        indent_line( CHANGING cs_context = ls_context cv_line = <lv_line_c> ).
+      ENDLOOP.
 
-    CONCATENATE LINES OF lt_temp INTO rv_html SEPARATED BY cl_abap_char_utilities=>newline.
+      CONCATENATE LINES OF lt_temp INTO rv_html SEPARATED BY cl_abap_char_utilities=>newline.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -538,7 +544,8 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       ii_content = ii_content
       iv_id    = iv_id
       iv_class = iv_class
-      is_data_attr = is_data_attr
+      is_data_attr  = is_data_attr
+      it_data_attrs = it_data_attrs
       iv_hint  = iv_hint ).
     ri_self = me.
   ENDMETHOD.
@@ -552,7 +559,8 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       ii_content = ii_content
       iv_id    = iv_id
       iv_class = iv_class
-      is_data_attr = is_data_attr
+      is_data_attr  = is_data_attr
+      it_data_attrs = it_data_attrs
       iv_hint  = iv_hint ).
     ri_self = me.
   ENDMETHOD.
@@ -562,6 +570,7 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
 
     DATA lv_open_tag TYPE string.
     DATA lv_close_tag TYPE string.
+    DATA ls_data_attr LIKE LINE OF it_data_attrs.
 
     DATA: lv_class TYPE string,
           lv_id    TYPE string,
@@ -583,6 +592,10 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
     IF is_data_attr IS NOT INITIAL.
       lv_data_attr = | data-{ is_data_attr-name }="{ is_data_attr-value }"|.
     ENDIF.
+
+    LOOP AT it_data_attrs INTO ls_data_attr.
+      lv_data_attr = lv_data_attr && | data-{ ls_data_attr-name }="{ ls_data_attr-value }"|.
+    ENDLOOP.
 
     lv_open_tag = |<{ iv_tag }{ lv_id }{ lv_class }{ lv_data_attr }{ lv_title }>|.
     lv_close_tag = |</{ iv_tag }>|.

--- a/src/ui/core/zif_abapgit_gui_hotkeys.intf.abap
+++ b/src/ui/core/zif_abapgit_gui_hotkeys.intf.abap
@@ -15,6 +15,8 @@ INTERFACE zif_abapgit_gui_hotkeys
 
   METHODS get_hotkey_actions
     RETURNING
-      VALUE(rt_hotkey_actions) TYPE ty_hotkeys_with_descr .
+      VALUE(rt_hotkey_actions) TYPE ty_hotkeys_with_descr
+    RAISING
+      zcx_abapgit_exception.
 
 ENDINTERFACE.

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -4,7 +4,8 @@ INTERFACE zif_abapgit_html PUBLIC.
     BEGIN OF ty_data_attr,
       name TYPE string,
       value TYPE string,
-    END OF ty_data_attr.
+    END OF ty_data_attr,
+    ty_data_attrs TYPE STANDARD TABLE OF ty_data_attr WITH KEY name.
 
   CONSTANTS:
     BEGIN OF c_action_type,
@@ -40,7 +41,8 @@ INTERFACE zif_abapgit_html PUBLIC.
 
   METHODS render
     IMPORTING
-      !iv_no_indent_jscss TYPE abap_bool OPTIONAL
+      !iv_no_indent_jscss TYPE abap_bool DEFAULT abap_false
+      !iv_no_line_breaks TYPE abap_bool DEFAULT abap_false
     RETURNING
       VALUE(rv_html)      TYPE string .
 
@@ -111,6 +113,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_hint    TYPE string OPTIONAL
       !iv_format_single_line TYPE abap_bool DEFAULT abap_false
       !is_data_attr TYPE ty_data_attr OPTIONAL
+      !it_data_attrs TYPE ty_data_attrs OPTIONAL
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
 
@@ -123,6 +126,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_hint    TYPE string OPTIONAL
       !iv_format_single_line TYPE abap_bool DEFAULT abap_true
       !is_data_attr TYPE ty_data_attr OPTIONAL
+      !it_data_attrs TYPE ty_data_attrs OPTIONAL
       PREFERRED PARAMETER iv_content
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
@@ -136,6 +140,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_hint    TYPE string OPTIONAL
       !iv_format_single_line TYPE abap_bool DEFAULT abap_true
       !is_data_attr TYPE ty_data_attr OPTIONAL
+      !it_data_attrs TYPE ty_data_attrs OPTIONAL
       PREFERRED PARAMETER iv_content
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.
@@ -147,6 +152,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_id      TYPE string OPTIONAL
       !iv_class   TYPE string OPTIONAL
       !is_data_attr TYPE ty_data_attr OPTIONAL
+      !it_data_attrs TYPE ty_data_attrs OPTIONAL
       PREFERRED PARAMETER iv_content
     RETURNING
       VALUE(ri_self) TYPE REF TO zif_abapgit_html.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -195,7 +195,10 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
 
     CLASS-METHODS get_item_link
       IMPORTING
-        !is_item       TYPE zif_abapgit_definitions=>ty_repo_item
+        !is_item       TYPE zif_abapgit_definitions=>ty_repo_item OPTIONAL
+        !iv_obj_type   TYPE zif_abapgit_definitions=>ty_repo_item-obj_type OPTIONAL
+        !iv_obj_name   TYPE zif_abapgit_definitions=>ty_repo_item-obj_name OPTIONAL
+        PREFERRED PARAMETER is_item
       RETURNING
         VALUE(rv_html) TYPE string.
 
@@ -234,7 +237,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
 
   METHOD class_constructor.
@@ -288,15 +291,23 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
     DATA lv_encode TYPE string.
     DATA li_html TYPE REF TO zif_abapgit_html.
+    DATA ls_item LIKE is_item.
+
+    IF is_item IS INITIAL.
+      ls_item-obj_type = iv_obj_type.
+      ls_item-obj_name = iv_obj_name.
+    ELSE.
+      ls_item = is_item.
+    ENDIF.
 
     CREATE OBJECT li_html TYPE zcl_abapgit_html.
 
     lv_encode = zcl_abapgit_html_action_utils=>jump_encode(
-      iv_obj_type = is_item-obj_type
-      iv_obj_name = is_item-obj_name ).
+      iv_obj_type = ls_item-obj_type
+      iv_obj_name = ls_item-obj_name ).
 
     rv_html = li_html->a(
-      iv_txt = |{ is_item-obj_name }|
+      iv_txt = |{ ls_item-obj_name }|
       iv_act = |{ zif_abapgit_definitions=>c_action-jump }?{ lv_encode }| ).
 
   ENDMETHOD.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -19,6 +19,11 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         !iv_extra_style TYPE string OPTIONAL
       RETURNING
         VALUE(ri_html)  TYPE REF TO zif_abapgit_html .
+    CLASS-METHODS render_success
+      IMPORTING
+        iv_message TYPE string
+      RETURNING
+        VALUE(ri_html)  TYPE REF TO zif_abapgit_html .
     CLASS-METHODS render_repo_top
       IMPORTING
         !io_repo               TYPE REF TO zcl_abapgit_repo
@@ -1121,6 +1126,17 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
       WHEN OTHERS. " Including NO_RUN
         RETURN.
     ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD render_success.
+
+    ri_html = zcl_abapgit_html=>create( ).
+    ri_html->add( '<div class="dummydiv success">' ).
+    ri_html->add_icon( 'check' ).
+    ri_html->add( iv_message ).
+    ri_html->add( '</div>' ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -184,6 +184,7 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
     CLASS-METHODS render_help_hint
       IMPORTING
         iv_text_to_wrap TYPE string
+        iv_add_class TYPE string OPTIONAL
       RETURNING
         VALUE(rv_html)  TYPE string.
 
@@ -553,22 +554,25 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
   METHOD render_help_hint.
 
-    " TODO potentially move to or integrate with zcl_abapgit_html_form
-
-    DATA lt_fragments TYPE string_table.
     DATA li_html TYPE REF TO zif_abapgit_html.
+    DATA lv_add_class TYPE string.
+
     li_html = zcl_abapgit_html=>create( ).
 
-    APPEND `<div class="form-field-help-tooltip">` TO lt_fragments.
-    APPEND li_html->icon(
-      iv_name = 'question-circle-solid'
-      iv_class = 'blue' ) TO lt_fragments.
-    APPEND `<div class="form-field-help-tooltip-text">` TO lt_fragments.
-    APPEND iv_text_to_wrap TO lt_fragments.
-    APPEND `</div>` TO lt_fragments.
-    APPEND `</div>` TO lt_fragments.
+    IF iv_add_class IS NOT INITIAL.
+      lv_add_class = ` ` && iv_add_class.
+    ENDIF.
 
-    rv_html = concat_lines_of( lt_fragments ).
+    li_html->add( |<div class="form-field-help-tooltip{ lv_add_class }">| ).
+    li_html->add_icon(
+      iv_name = 'question-circle-solid'
+      iv_class = 'blue' ).
+    li_html->add( `<div class="form-field-help-tooltip-text">` ).
+    li_html->add( iv_text_to_wrap ).
+    li_html->add( `</div>` ).
+    li_html->add( `</div>` ).
+
+    rv_html = li_html->render( iv_no_line_breaks = abap_true ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -99,7 +99,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<th>Col 2</th>' )->add(
       '<th></th>' )->add(
       '</tr>' )->add(
-      '</thead>' )->add(
+      '</thead>' ).
+    li_html_exp->add(
       '<tbody>' )->add(
       '<tr class="r1">' )->add(
       '<td class="cell">Hello</td>' )->add(
@@ -150,7 +151,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<th data-cid="col1">Col 1</th>' )->add(
       '<th data-cid="col2">Col 2</th>' )->add(
       '</tr>' )->add(
-      '</thead>' )->add(
+      '</thead>' ).
+    li_html_exp->add(
       '<tbody>' )->add(
       '<tr data-attr="1">' )->add(
       '<td data-cid="col1">Hello</td>' )->add(
@@ -201,12 +203,13 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<table id="with-sort">' )->add(
       '<thead>' )->add(
       '<tr>' )->add(
-      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a><span class="sort-arrow sort-active">&#x25BE;</span></th>'
-      )->add(
+      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a>' &&
+        '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
       '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
-      '</thead>' )->add(
+      '</thead>' ).
+    li_html_exp->add(
       '<tbody>' )->add(
       '<tr>' )->add(
       '<td>Hello</td>' )->add(
@@ -241,6 +244,7 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
         iv_column_title = 'Col 1'
       )->define_column_group(
         iv_group_title = 'Group'
+        iv_group_id = ''
       )->define_column(
         iv_column_id    = 'col2'
         iv_column_title = 'Col 2'
@@ -264,16 +268,16 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<tr>' )->add(
       '<th></th>' )->add(
       '<th colspan="2">Group</th>' )->add(
-      '</tr>' )->add(
-
+      '</tr>' ).
+    li_html_exp->add(
       '<tr>' )->add(
-      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a><span class="sort-arrow sort-active">&#x25BE;</span></th>'
-      )->add(
+      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a>' &&
+        '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
       '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
-      '</thead>' )->add(
-
+      '</thead>' ).
+    li_html_exp->add(
       '<tbody>' )->add(
       '<tr>' )->add(
       '<td>Hello</td>' )->add(

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -17,6 +17,7 @@ CLASS ltcl_test_simple_table DEFINITION FINAL
     METHODS simple_render FOR TESTING RAISING zcx_abapgit_exception.
     METHODS with_cids FOR TESTING RAISING zcx_abapgit_exception.
     METHODS with_sort FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS with_groups FOR TESTING RAISING zcx_abapgit_exception.
 
     METHODS test_data_set
       RETURNING
@@ -206,6 +207,73 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
       '</thead>' )->add(
+      '<tbody>' )->add(
+      '<tr>' )->add(
+      '<td>Hello</td>' )->add(
+      '<td>1</td>' )->add(
+      '<td>10</td>' )->add(
+      '</tr>' )->add(
+      '<tr>' )->add(
+      '<td>World</td>' )->add(
+      '<td>2</td>' )->add(
+      '<td>20</td>' )->add(
+      '</tr>' )->add(
+      '</tbody>' )->add(
+      '</table>' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_html_act
+      exp = li_html_exp->render( ) ).
+
+  ENDMETHOD.
+
+  METHOD with_groups.
+
+    DATA lo_tab TYPE REF TO zcl_abapgit_html_table.
+    DATA lv_html_act TYPE string.
+    DATA li_html_exp TYPE REF TO zif_abapgit_html.
+    DATA ls_sort TYPE zif_abapgit_html_table=>ty_sorting_state.
+
+    lo_tab = zcl_abapgit_html_table=>create( me
+      )->define_column_group(
+      )->define_column(
+        iv_column_id    = 'col1'
+        iv_column_title = 'Col 1'
+      )->define_column_group(
+        iv_group_title = 'Group'
+      )->define_column(
+        iv_column_id    = 'col2'
+        iv_column_title = 'Col 2'
+      )->define_column(
+        iv_column_id    = 'col3'
+        iv_column_title = 'Col 3'
+        iv_sortable     = abap_false ).
+
+    ls_sort-column_id = 'col1'.
+
+    lv_html_act = lo_tab->render(
+      is_sorting_state = ls_sort
+      iv_id        = 'with-sort'
+      it_data      = test_data_set( ) )->render( ).
+
+    CREATE OBJECT li_html_exp TYPE zcl_abapgit_html.
+
+    li_html_exp->add(
+      '<table id="with-sort">' )->add(
+      '<thead>' )->add(
+      '<tr>' )->add(
+      '<th></th>' )->add(
+      '<th colspan="2">Group</th>' )->add(
+      '</tr>' )->add(
+
+      '<tr>' )->add(
+      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a><span class="sort-arrow sort-active">&#x25BE;</span></th>'
+      )->add(
+      '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
+      '<th>Col 3</th>' )->add(
+      '</tr>' )->add(
+      '</thead>' )->add(
+
       '<tbody>' )->add(
       '<tr>' )->add(
       '<td>Hello</td>' )->add(

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -83,7 +83,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
     CASE ii_event->mv_action.
       WHEN c_action-refresh.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
-      WHEN others.
+      WHEN OTHERS.
         RETURN.
     ENDCASE.
 
@@ -135,8 +135,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
     " TODO auto sorting ?
 
-    li_table = zcl_abapgit_html_table=>create(
-      )->define_column_group( 'Repo object'
+    li_table = zcl_abapgit_html_table=>create( ).
+    li_table->define_column_group(
+        iv_group_title = 'Repo object'
+        iv_group_id    = '' " No need
       )->define_column(
         iv_column_id    = 'dep_package'
         iv_column_title = 'Pkg'
@@ -148,11 +150,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
         iv_column_title = 'Obj name'
       )->define_column(
         iv_column_id    = 'dep_used_obj'
-        iv_column_title = 'Used obj'
-
-      )->define_column_group(
-        iv_group_id    = 'where'
+        iv_column_title = 'Used obj' ).
+    li_table->define_column_group(
         iv_group_title = 'Used in'
+        iv_group_id    = 'where' " Needed for CSS
       )->define_column(
         iv_column_id    = 'package'
         iv_column_title = 'Pkg'

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -113,34 +113,17 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->div(
-*      iv_class   = 'wu-header'
+      iv_class   = 'wu-header'
       iv_content = |Where used for package <b>{ mv_package }</b> and it's subpackages| ).
 
     DATA li_table TYPE REF TO zcl_abapgit_html_table.
-    DATA lt_where_used TYPE zcl_abapgit_where_used_tools=>tty_dependency.
+    DATA lt_where_used TYPE zcl_abapgit_where_used_tools=>ty_dependency_tt.
 
-    " TODO join w obj_type+cls
-    " TODO groups
-    " TODO drill downs
     " TODO some css?
     " TODO auto sorting ?
 
     li_table = zcl_abapgit_html_table=>create(
-      )->define_column(
-        iv_column_id    = 'package'
-        iv_column_title = 'Pkg'
-      )->define_column(
-        iv_column_id    = 'obj_type'
-        iv_column_title = 'Type'
-      )->define_column(
-        iv_column_id    = 'obj_prog_type'
-        iv_column_title = 'Prog type'
-      )->define_column(
-        iv_column_id    = 'obj_name'
-        iv_column_title = 'Obj name'
-      )->define_column(
-        iv_column_id    = 'obj_cls'
-        iv_column_title = 'Obj cls'
+      )->define_column_group( 'Repo object'
       )->define_column(
         iv_column_id    = 'dep_package'
         iv_column_title = 'Pkg'
@@ -151,11 +134,19 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
         iv_column_id    = 'dep_obj_name'
         iv_column_title = 'Obj name'
       )->define_column(
-        iv_column_id    = 'dep_used_cls'
-        iv_column_title = 'Obj cls'
-      )->define_column(
         iv_column_id    = 'dep_used_obj'
-        iv_column_title = 'Used obj' ).
+        iv_column_title = 'Used obj'
+
+      )->define_column_group( 'Used in'
+      )->define_column(
+        iv_column_id    = 'package'
+        iv_column_title = 'Pkg'
+      )->define_column(
+        iv_column_id    = 'obj_type'
+        iv_column_title = 'Type'
+      )->define_column(
+        iv_column_id    = 'obj_name'
+        iv_column_title = 'Obj name' ).
 
     lt_where_used = zcl_abapgit_where_used_tools=>new( )->select_external_usages( mv_package ).
 
@@ -172,20 +163,37 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 *        is_sorting_state = ms_sorting_state
         iv_wrap_in_div   = 'default-table-container'
         iv_css_class     = 'default-table'
-*        iv_with_cids     = abap_true
+        iv_with_cids     = abap_true
         it_data          = lt_where_used ) ).
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_html_table~get_row_attrs.
-
-
   ENDMETHOD.
 
 
   METHOD zif_abapgit_html_table~render_cell.
-    rs_render-content = iv_value.
-    " TODO add title for object cls ?
+
+    FIELD-SYMBOLS <ls_i> TYPE zcl_abapgit_where_used_tools=>ty_dependency.
+
+    ASSIGN is_row TO <ls_i>.
+
+    CASE iv_column_id.
+      WHEN 'obj_type'.
+        if <ls_i>-obj_prog_type IS INITIAL.
+          rs_render-content = <ls_i>-obj_type.
+        else.
+          rs_render-content = <ls_i>-obj_type && ':' && <ls_i>-obj_prog_type.
+        endif.
+      WHEN 'obj_name'.
+        rs_render-content = zcl_abapgit_gui_chunk_lib=>get_item_link(
+          iv_obj_type = <ls_i>-obj_type
+          iv_obj_name = <ls_i>-obj_name ).
+      WHEN OTHERS.
+        rs_render-content = iv_value.
+    ENDCASE.
+    " TODO maybe add title for object cls ?
+
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -83,6 +83,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
     CASE ii_event->mv_action.
       WHEN c_action-refresh.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+      WHEN others.
+        RETURN.
     ENDCASE.
 
   ENDMETHOD.
@@ -118,6 +120,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_renderable~render.
 
+    DATA li_table TYPE REF TO zcl_abapgit_html_table.
+    DATA lt_where_used TYPE zcl_abapgit_where_used_tools=>ty_dependency_tt.
+
     register_handlers( ).
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
@@ -127,9 +132,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
       iv_content = |Where used for package {
         zcl_abapgit_gui_chunk_lib=>render_package_name( mv_package )->render( iv_no_line_breaks = abap_true )
         } and it's subpackages| ).
-
-    DATA li_table TYPE REF TO zcl_abapgit_html_table.
-    DATA lt_where_used TYPE zcl_abapgit_where_used_tools=>ty_dependency_tt.
 
     " TODO auto sorting ?
 
@@ -194,11 +196,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
     CASE iv_column_id.
       WHEN 'obj_type'.
-        if <ls_i>-obj_prog_type IS INITIAL.
+        IF <ls_i>-obj_prog_type IS INITIAL.
           rs_render-content = <ls_i>-obj_type.
-        else.
+        ELSE.
           rs_render-content = <ls_i>-obj_type && ':' && <ls_i>-obj_prog_type.
-        endif.
+        ENDIF.
       WHEN 'obj_name'.
         rs_render-content = zcl_abapgit_gui_chunk_lib=>get_item_link(
           iv_obj_type = <ls_i>-obj_type

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -40,7 +40,6 @@ CLASS zcl_abapgit_gui_page_whereused DEFINITION
     CONSTANTS c_title TYPE string VALUE 'Where Used'.
     DATA mv_package TYPE devclass.
     DATA mv_ignore_subpackages TYPE abap_bool.
-    DATA mi_repo TYPE REF TO zif_abapgit_repo.
     DATA mi_table TYPE REF TO zcl_abapgit_html_table.
 
     METHODS init_table_component
@@ -153,8 +152,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
       )->add( `and external to it (e.g. when deploying updates `
       )->add( `to a library-like repo).</p>` ).
 
-    rv_html = zcl_abapgit_gui_chunk_lib=>render_help_hint(
-      li_html->render( iv_no_line_breaks = abap_true ) ).
+    rv_html = zcl_abapgit_gui_chunk_lib=>render_help_hint( li_html->render( iv_no_line_breaks = abap_true ) ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -226,10 +226,18 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
+    DATA lv_show_used_txt TYPE string.
+
+    IF mv_show_used_obj = abap_true.
+      lv_show_used_txt = 'Hide used type'.
+    ELSE.
+      lv_show_used_txt = 'Show used type'.
+    ENDIF.
+
     ro_toolbar = zcl_abapgit_html_toolbar=>create(
       )->add(
-        iv_txt   = 'Show used type'
-        iv_title = 'Show used type or object (when available)'
+        iv_txt   = lv_show_used_txt
+        iv_title = 'Show/Hide used type or object (when available)'
         iv_act   = c_action-show_used_obj
       )->add(
         iv_txt = 'Refresh'

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -42,6 +42,10 @@ CLASS zcl_abapgit_gui_page_whereused DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+    METHODS render_filter_help_hint
+      RETURNING
+        VALUE(rv_html) TYPE string.
+
 ENDCLASS.
 
 
@@ -119,6 +123,26 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_filter_help_hint.
+
+    DATA li_html TYPE REF TO zif_abapgit_html.
+
+    li_html = zcl_abapgit_html=>create(
+      )->add( `<p>This tool cycles through all objects in the repo `
+      )->add( `and runs the standard where-used function against it. `
+      )->add( `The result is displayed here less the usages `
+      )->add( `inside the repo itself.</p>`
+      )->add( `<p>The tool can be used to detect `
+      )->add( `potential regressions in the code which uses the repo `
+      )->add( `and external to it (e.g. when deploying updates `
+      )->add( `to a library-like repo).</p>` ).
+
+    rv_html = zcl_abapgit_gui_chunk_lib=>render_help_hint(
+      li_html->render( iv_no_line_breaks = abap_true ) ).
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_gui_event_handler~on_event.
 
     IF mi_table->process_sorting_request( ii_event->mv_action ) = abap_true.
@@ -177,7 +201,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
       iv_class   = 'wu-header'
       iv_content = |Where used for package {
         zcl_abapgit_gui_chunk_lib=>render_package_name( mv_package )->render( iv_no_line_breaks = abap_true )
-        } and it's subpackages| ).
+        } and it's subpackages. { render_filter_help_hint( ) }| ).
 
     lt_where_used = zcl_abapgit_where_used_tools=>new( )->select_external_usages( mv_package ).
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -206,21 +206,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
 
   METHOD zif_abapgit_gui_hotkeys~get_hotkey_actions.
-
-    DATA ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
-
-    ls_hotkey_action-ui_component = c_title.
-
-    ls_hotkey_action-description = |Refresh|.
-    ls_hotkey_action-action = c_action-refresh.
-    ls_hotkey_action-hotkey = |r|.
-    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
-
-    ls_hotkey_action-description = |Show used type|.
-    ls_hotkey_action-action = c_action-show_used_obj.
-    ls_hotkey_action-hotkey = |u|.
-    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
-
+    rt_hotkey_actions = zif_abapgit_gui_menu_provider~get_menu( )->get_hotkeys( c_title ).
   ENDMETHOD.
 
 
@@ -236,12 +222,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
     ro_toolbar = zcl_abapgit_html_toolbar=>create(
       )->add(
-        iv_txt   = lv_show_used_txt
-        iv_title = 'Show/Hide used type or object (when available)'
-        iv_act   = c_action-show_used_obj
+        iv_txt    = lv_show_used_txt
+        iv_title  = 'Show/Hide used type or object (when available)'
+        iv_act    = c_action-show_used_obj
+        iv_hotkey = 'u'
       )->add(
-        iv_txt = 'Refresh'
-        iv_act = c_action-refresh ).
+        iv_txt    = 'Refresh'
+        iv_act    = c_action-refresh
+        iv_hotkey = 'r' ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -113,8 +113,67 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
 
     ri_html->div(
-      iv_class   = 'repo'
-      iv_content = |Hello { mv_package }| ).
+*      iv_class   = 'wu-header'
+      iv_content = |Where used for package <b>{ mv_package }</b> and it's subpackages| ).
+
+    DATA li_table TYPE REF TO zcl_abapgit_html_table.
+    DATA lt_where_used TYPE zcl_abapgit_where_used_tools=>tty_dependency.
+
+    " TODO join w obj_type+cls
+    " TODO groups
+    " TODO drill downs
+    " TODO some css?
+    " TODO auto sorting ?
+
+    li_table = zcl_abapgit_html_table=>create(
+      )->define_column(
+        iv_column_id    = 'package'
+        iv_column_title = 'Pkg'
+      )->define_column(
+        iv_column_id    = 'obj_type'
+        iv_column_title = 'Type'
+      )->define_column(
+        iv_column_id    = 'obj_prog_type'
+        iv_column_title = 'Prog type'
+      )->define_column(
+        iv_column_id    = 'obj_name'
+        iv_column_title = 'Obj name'
+      )->define_column(
+        iv_column_id    = 'obj_cls'
+        iv_column_title = 'Obj cls'
+      )->define_column(
+        iv_column_id    = 'dep_package'
+        iv_column_title = 'Pkg'
+      )->define_column(
+        iv_column_id    = 'dep_obj_type'
+        iv_column_title = 'Type'
+      )->define_column(
+        iv_column_id    = 'dep_obj_name'
+        iv_column_title = 'Obj name'
+      )->define_column(
+        iv_column_id    = 'dep_used_cls'
+        iv_column_title = 'Obj cls'
+      )->define_column(
+        iv_column_id    = 'dep_used_obj'
+        iv_column_title = 'Used obj' ).
+
+    lt_where_used = zcl_abapgit_where_used_tools=>new( )->select_external_usages( mv_package ).
+
+*    IF ms_sorting_state-column_id IS INITIAL.
+*      ms_sorting_state-column_id = 'package'.
+*    ENDIF.
+
+*    apply_sorting( CHANGING ct_view = lt_where_used ).
+
+    ri_html->div(
+      iv_class   = 'wu'
+      ii_content = li_table->render(
+        ii_renderer      = me
+*        is_sorting_state = ms_sorting_state
+        iv_wrap_in_div   = 'default-table-container'
+        iv_css_class     = 'default-table'
+*        iv_with_cids     = abap_true
+        it_data          = lt_where_used ) ).
 
   ENDMETHOD.
 
@@ -126,6 +185,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
 
   METHOD zif_abapgit_html_table~render_cell.
-
+    rs_render-content = iv_value.
+    " TODO add title for object cls ?
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -281,7 +281,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
       WHEN 'dep_obj_name'.
         rs_render-content = <ls_i>-dep_obj_name.
         IF mv_show_used_obj = abap_true.
-           rs_render-content = rs_render-content && |<span class='used-obj'>{ <ls_i>-dep_used_obj }</span>|.
+          rs_render-content = rs_render-content && |<span class='used-obj'>{ <ls_i>-dep_used_obj }</span>|.
         ENDIF.
       WHEN 'obj_type'.
         IF <ls_i>-obj_prog_type IS INITIAL.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -36,6 +36,7 @@ CLASS zcl_abapgit_gui_page_whereused DEFINITION
 
     CONSTANTS c_title TYPE string VALUE 'Where Used'.
     DATA mv_package TYPE devclass.
+    DATA ms_sorting_state TYPE zif_abapgit_html_table=>ty_sorting_state.
 
 ENDCLASS.
 
@@ -69,6 +70,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
 
   METHOD zif_abapgit_gui_event_handler~on_event.
+
+    DATA ls_sorting_req TYPE zif_abapgit_html_table=>ty_sorting_state.
+
+    ls_sorting_req = zcl_abapgit_html_table=>detect_sorting_request( ii_event->mv_action ).
+    IF ls_sorting_req IS NOT INITIAL.
+      ms_sorting_state = ls_sorting_req.
+      rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+      RETURN.
+    ENDIF.
 
     CASE ii_event->mv_action.
       WHEN c_action-refresh.
@@ -153,9 +163,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
     lt_where_used = zcl_abapgit_where_used_tools=>new( )->select_external_usages( mv_package ).
 
-*    IF ms_sorting_state-column_id IS INITIAL.
-*      ms_sorting_state-column_id = 'package'.
-*    ENDIF.
+    IF ms_sorting_state-column_id IS INITIAL.
+      ms_sorting_state-column_id = 'package'.
+    ENDIF.
 
 *    apply_sorting( CHANGING ct_view = lt_where_used ).
 
@@ -163,7 +173,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
       iv_class   = 'wu'
       ii_content = li_table->render(
         ii_renderer      = me
-*        is_sorting_state = ms_sorting_state
+        is_sorting_state = ms_sorting_state
         iv_wrap_in_div   = 'default-table-container'
         iv_css_class     = 'default-table'
         iv_with_cids     = abap_true

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -93,13 +93,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
         iv_group_id    = '' " No need
       )->define_column(
         iv_column_id    = 'dep_package'
-        iv_column_title = 'Pkg'
+        iv_column_title = 'Package'
       )->define_column(
         iv_column_id    = 'dep_obj_type'
         iv_column_title = 'Type'
       )->define_column(
         iv_column_id    = 'dep_obj_name'
-        iv_column_title = 'Obj name'
+        iv_column_title = 'Name'
       )->define_column(
         iv_column_id    = 'dep_used_obj'
         iv_column_title = 'Used obj' ).
@@ -108,13 +108,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
         iv_group_id    = 'where' " Needed for CSS
       )->define_column(
         iv_column_id    = 'package'
-        iv_column_title = 'Pkg'
+        iv_column_title = 'Package'
       )->define_column(
         iv_column_id    = 'obj_type'
         iv_column_title = 'Type'
       )->define_column(
         iv_column_id    = 'obj_name'
-        iv_column_title = 'Obj name' ).
+        iv_column_title = 'Name' ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -1,0 +1,131 @@
+CLASS zcl_abapgit_gui_page_whereused DEFINITION
+  PUBLIC
+  FINAL
+  INHERITING FROM zcl_abapgit_gui_component
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    INTERFACES:
+      zif_abapgit_gui_page_title,
+      zif_abapgit_gui_event_handler,
+      zif_abapgit_gui_hotkeys,
+      zif_abapgit_gui_menu_provider,
+      zif_abapgit_gui_renderable,
+      zif_abapgit_html_table.
+
+    CLASS-METHODS create
+      IMPORTING
+        iv_package     TYPE devclass
+      RETURNING
+        VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS constructor
+      IMPORTING
+        iv_package TYPE devclass
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CONSTANTS:
+      BEGIN OF c_action,
+        refresh TYPE string VALUE 'refresh',
+      END OF c_action.
+
+    CONSTANTS c_title TYPE string VALUE 'Where Used'.
+    DATA mv_package TYPE devclass.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
+
+
+  METHOD constructor.
+    super->constructor( ).
+    mv_package = iv_package.
+
+    IF zcl_abapgit_factory=>get_sap_package( iv_package )->exists( ) = abap_false.
+      zcx_abapgit_exception=>raise( |Package { iv_package } does not exist| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD create.
+
+    DATA lo_component TYPE REF TO zcl_abapgit_gui_page_whereused.
+
+    CREATE OBJECT lo_component
+      EXPORTING
+        iv_package = iv_package.
+
+    ri_page = zcl_abapgit_gui_page_hoc=>create( lo_component ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_event_handler~on_event.
+
+    CASE ii_event->mv_action.
+      WHEN c_action-refresh.
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+    ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_hotkeys~get_hotkey_actions.
+
+    DATA ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
+
+    ls_hotkey_action-ui_component = c_title.
+
+    ls_hotkey_action-description = |Refresh|.
+    ls_hotkey_action-action = c_action-refresh.
+    ls_hotkey_action-hotkey = |r|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_menu_provider~get_menu.
+
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( )->add(
+      iv_txt = 'Refresh'
+      iv_act = c_action-refresh ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_title~get_page_title.
+    rv_title = c_title.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_renderable~render.
+
+    register_handlers( ).
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    ri_html->div(
+      iv_class   = 'repo'
+      iv_content = |Hello { mv_package }| ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_html_table~get_row_attrs.
+
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_html_table~render_cell.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -114,12 +114,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
 
     ri_html->div(
       iv_class   = 'wu-header'
-      iv_content = |Where used for package <b>{ mv_package }</b> and it's subpackages| ).
+      iv_content = |Where used for package {
+        zcl_abapgit_gui_chunk_lib=>render_package_name( mv_package )->render( iv_no_line_breaks = abap_true )
+        } and it's subpackages| ).
 
     DATA li_table TYPE REF TO zcl_abapgit_html_table.
     DATA lt_where_used TYPE zcl_abapgit_where_used_tools=>ty_dependency_tt.
 
-    " TODO some css?
     " TODO auto sorting ?
 
     li_table = zcl_abapgit_html_table=>create(
@@ -137,7 +138,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
         iv_column_id    = 'dep_used_obj'
         iv_column_title = 'Used obj'
 
-      )->define_column_group( 'Used in'
+      )->define_column_group(
+        iv_group_id    = 'where'
+        iv_group_title = 'Used in'
       )->define_column(
         iv_column_id    = 'package'
         iv_column_title = 'Pkg'

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -215,9 +215,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
     DATA lv_show_used_txt TYPE string.
 
     IF mv_show_used_obj = abap_true.
-      lv_show_used_txt = 'Hide used type'.
+      lv_show_used_txt = 'Hide Used Type'.
     ELSE.
-      lv_show_used_txt = 'Show used type'.
+      lv_show_used_txt = 'Show Used Type'.
     ENDIF.
 
     ro_toolbar = zcl_abapgit_html_toolbar=>create(

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.xml
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_WHEREUSED</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit where-used page</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -312,8 +312,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
                                iv_act = |{ c_actions-go_unit }| ).
     ro_advanced_dropdown->add( iv_txt = 'Run Code Inspector'
                                iv_act = |{ zif_abapgit_definitions=>c_action-repo_code_inspector }?key={ mv_key }| ).
-    ro_advanced_dropdown->add( iv_txt = 'Where Used'
-                               iv_act = |{ zif_abapgit_definitions=>c_action-where_used }?pkg={ mo_repo->get_package( ) }| ).
+    ro_advanced_dropdown->add(
+      iv_txt = 'Where Used'
+      iv_act = |{ zif_abapgit_definitions=>c_action-where_used }?pkg={ mo_repo->get_package( ) }| ).
 
     ro_advanced_dropdown->add( iv_txt = 'Very Advanced'
                                iv_typ = zif_abapgit_html=>c_action_type-separator ).

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -312,9 +312,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
                                iv_act = |{ c_actions-go_unit }| ).
     ro_advanced_dropdown->add( iv_txt = 'Run Code Inspector'
                                iv_act = |{ zif_abapgit_definitions=>c_action-repo_code_inspector }?key={ mv_key }| ).
-    ro_advanced_dropdown->add(
-      iv_txt = 'Where Used'
-      iv_act = |{ zif_abapgit_definitions=>c_action-where_used }?pkg={ mo_repo->get_package( ) }| ).
+    ro_advanced_dropdown->add( iv_txt = 'Where Used'
+                               iv_act = |{ zif_abapgit_definitions=>c_action-where_used }?key={ mv_key }| ).
 
     ro_advanced_dropdown->add( iv_txt = 'Very Advanced'
                                iv_typ = zif_abapgit_html=>c_action_type-separator ).

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -201,7 +201,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -312,6 +312,8 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                                iv_act = |{ c_actions-go_unit }| ).
     ro_advanced_dropdown->add( iv_txt = 'Run Code Inspector'
                                iv_act = |{ zif_abapgit_definitions=>c_action-repo_code_inspector }?key={ mv_key }| ).
+    ro_advanced_dropdown->add( iv_txt = 'Where Used'
+                               iv_act = |{ zif_abapgit_definitions=>c_action-where_used }?pkg={ mo_repo->get_package( ) }| ).
 
     ro_advanced_dropdown->add( iv_txt = 'Very Advanced'
                                iv_typ = zif_abapgit_html=>c_action_type-separator ).

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -866,7 +866,8 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         rs_handled-page  = zcl_abapgit_gui_page_ex_object=>create( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
       WHEN zif_abapgit_definitions=>c_action-where_used.
-        rs_handled-page  = zcl_abapgit_gui_page_whereused=>create( |{ ii_event->query( )->get( 'PKG' ) }| ).
+        lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
+        rs_handled-page  = zcl_abapgit_gui_page_whereused=>create( ii_repo = lo_repo ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
     ENDCASE.
 

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -865,6 +865,9 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>c_action-zip_object.                      " Export object as ZIP
         rs_handled-page  = zcl_abapgit_gui_page_ex_object=>create( ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
+      WHEN zif_abapgit_definitions=>c_action-where_used.
+        rs_handled-page  = zcl_abapgit_gui_page_whereused=>create( |{ ii_event->query( )->get( 'PKG' ) }| ).
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
     ENDCASE.
 
   ENDMETHOD.

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1168,6 +1168,7 @@ table ul.repo-labels li {
   z-index: 1;
   border: 1px solid;
   padding: 0.4em 0.6em;
+  text-align: justify;
 }
 .form-field-help-tooltip .form-field-help-tooltip-text p {
   margin: 0px;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -238,6 +238,10 @@ span.transport-box {
   display: inline-block;
 }
 
+span.package-box i.icon {
+  margin-right: 0.15em;
+}
+
 /* MISC AND REFACTOR */
 
 .hidden-submit {
@@ -1196,7 +1200,7 @@ table.default-table {
   width: 100%;
 }
 
-table.default-table thead tr {
+table.default-table thead tr:last-child {
   border-bottom: #efefef solid 1px;
 }
 /*table.default-table tbody tr {
@@ -1628,4 +1632,31 @@ table.unit_tests {
 }
 .modal .radio-container label:hover {
   background-color: rgba(0, 0, 0, 0.1);
+}
+
+/* WHERE USED PAGE */
+
+div.wu-header {
+  padding: 8px 0.5em;
+  margin: 0px 0.5em;
+}
+div.wu {
+  padding: 8px 0.5em;
+}
+div.wu table thead tr:first-child {
+  /* TODO: maybe move this to default table style */
+  color: hsl(0, 0%, 80%);
+  text-transform: uppercase;
+  font-size: 90%;
+}
+div.wu table tbody {
+  font-size: 90%;
+}
+div.wu table td[data-cid="dep_used_obj"] {
+  color: hsl(0, 0%, 70%);
+  font-style: italic;
+}
+div.wu table td[data-gid="where"],
+div.wu table th[data-gid="where"] {
+  background-color: hsl(0, 0%, 97%);
 }

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1194,6 +1194,7 @@ div.default-table-container {
   padding: 6px 0.5em;
   background-color: white;
   border-radius: 6px;
+  overflow-x: hidden;
 }
 
 table.default-table {
@@ -1204,17 +1205,15 @@ table.default-table {
 table.default-table thead tr:last-child {
   border-bottom: #efefef solid 1px;
 }
-/*table.default-table tbody tr {
-  border-bottom: #efefef solid 1px;
-}
-table.default-table tbody tr:last-child {
-  border-bottom: none;
-}*/
 
 table.default-table td,
 table.default-table th {
   padding: 6px 8px;
   text-align: left;
+}
+
+table.default-table th {
+  white-space: nowrap;
 }
 
 table.default-table th span.sort-arrow {
@@ -1652,10 +1651,13 @@ div.wu table thead tr:first-child {
 }
 div.wu table tbody {
   font-size: 90%;
+  vertical-align: baseline; /* for second lines, used type */
 }
-div.wu table td[data-cid="dep_used_obj"] {
+div.wu table td[data-cid="dep_obj_name"] span.used-obj {
+  display: block;
   color: hsl(0, 0%, 70%);
-  font-style: italic;
+  font-size: smaller;
+  text-transform: lowercase;
 }
 div.wu table td[data-gid="where"],
 div.wu table th[data-gid="where"] {

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -539,3 +539,6 @@ table.settings_tab input:focus {
   background-color: #f4f4f4;
   color: var(--theme-greyscale-dark);
 }
+
+/* WHERE USED PAGE */
+

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -539,6 +539,3 @@ table.settings_tab input:focus {
   background-color: #f4f4f4;
   color: var(--theme-greyscale-dark);
 }
-
-/* WHERE USED PAGE */
-

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -371,6 +371,7 @@ INTERFACE zif_abapgit_definitions
       sponsor                       TYPE string VALUE 'sponsor',
       toggle_favorites              TYPE string VALUE 'toggle_favorites',
       url                           TYPE string VALUE 'url',
+      where_used                    TYPE string VALUE 'where_used',
       yank_to_clipboard             TYPE string VALUE 'yank_to_clipboard',
       zip_export                    TYPE string VALUE 'zip_export',
       zip_export_transport          TYPE string VALUE 'zip_export_transport',


### PR DESCRIPTION
ref: #6868

## Main feature

where used command in Advanced options of the repo - find all external (to the repo package) usages of objects in this package (and it's sub-packages). It's useful for checking potential dumps in the code which uses package code after update deployments.

![image](https://github.com/abapGit/abapGit/assets/15635498/d9d3726c-9e67-402f-b0e7-a5d272d49a10)

![image](https://github.com/abapGit/abapGit/assets/15635498/e76eae0f-9307-42de-a95c-cde7e8d757c2)

logic is implemented in `zcl_abapgit_where_used_tools` which is more or less copy of https://github.com/sbcgua/crossdeps/blob/master/src/zcl_dependency_model_wu.clas.abap

## Secondary improvements

- `html->render( iv_no_line_breaks )` - which does not apply indentation (can be useful sometimes, though generally a workaround)
- `html` allows specifying multiple `data-attrs`
- `chunk_lib->get_item_link` allows passing object directly (rather than repo item)
- `html_table` supports 2-level headers (the upper is called groups). Though without default styling - it's tricky. Consequently support `data-gid` in all relevant cells for styling. "Used in" shade demostrates the feature
- `html_table` supports `inline` sorting. It is ugly (imho) but convenient for simple tables (which are probably the majority) because does not need handling sorting in the higher component (which is also ugly). In general, I'm not super happy with the architecture but it's definitely far more convenient than building tables "manually" each time :) I think now it is OK to implement tables in other places (@mbtools), I'm personally thinking of the pool dialog and maybe repo-view (because it needs redesign) but no promises

Docs for new table features: https://github.com/abapGit/docs.abapgit.org/pull/225