### PR TITLE
Make HTTP/1.1 new default in abapGit

### DIFF
--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -204,6 +204,8 @@ CLASS zcl_abapgit_http IMPLEMENTATION.
       li_client->propertytype_logon_popup = li_client->co_disabled.
     ENDIF.
 
+    li_client->request->set_version( if_http_request=>co_protocol_version_1_1 ).
+
     zcl_abapgit_exit=>get_instance( )->http_client(
       iv_url    = iv_url
       ii_client = li_client ).


### PR DESCRIPTION
Previously the implicit default of NW release was used. Which could be 1.0 or 1.1 depending on the release and causing issues with git servers which require 1.1.

#6900 