### PR TITLE
Refactor: Translations for AFF

### DIFF
--- a/src/objects/aff/zcl_abapgit_json_handler.clas.abap
+++ b/src/objects/aff/zcl_abapgit_json_handler.clas.abap
@@ -51,7 +51,7 @@ CLASS zcl_abapgit_json_handler DEFINITION
     "! @parameter ev_data | data of the xstring
     METHODS deserialize
       IMPORTING
-        !iv_content       TYPE xstring
+        !iv_content       TYPE string
         !iv_defaults      TYPE ty_skip_paths OPTIONAL
         !iv_enum_mappings TYPE ty_enum_mappings OPTIONAL
       EXPORTING
@@ -99,14 +99,11 @@ CLASS zcl_abapgit_json_handler IMPLEMENTATION.
 
 
   METHOD deserialize.
-    DATA lv_json    TYPE string.
-    DATA lo_ajson   TYPE REF TO zif_abapgit_ajson.
+    DATA lo_ajson TYPE REF TO zif_abapgit_ajson.
 
     CLEAR ev_data.
 
-    lv_json = zcl_abapgit_convert=>xstring_to_string_utf8( iv_content ).
-
-    lo_ajson = zcl_abapgit_ajson=>parse( lv_json
+    lo_ajson = zcl_abapgit_ajson=>parse( iv_content
       )->map( zcl_abapgit_ajson_mapping=>create_to_snake_case( ) ).
 
     map2abap_original_language( CHANGING co_ajson = lo_ajson ).

--- a/src/objects/aff/zcl_abapgit_json_path.clas.abap
+++ b/src/objects/aff/zcl_abapgit_json_path.clas.abap
@@ -6,13 +6,23 @@ CLASS zcl_abapgit_json_path DEFINITION PUBLIC CREATE PUBLIC.
       RAISING   zcx_abapgit_exception.
     METHODS: deserialize
       IMPORTING it_json_path     TYPE string_table
-      RETURNING VALUE(rv_result) TYPE xstring
+      RETURNING VALUE(rv_result) TYPE string
       RAISING   zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
+
+
 CLASS zcl_abapgit_json_path IMPLEMENTATION.
+
+
+  METHOD deserialize.
+
+    rv_result = lcl_json_path=>deserialize( it_json_path ).
+
+  ENDMETHOD.
+
 
   METHOD serialize.
     DATA: lo_json_path    TYPE REF TO lcl_json_path,
@@ -39,11 +49,4 @@ CLASS zcl_abapgit_json_path IMPLEMENTATION.
                                            it_path       = lt_root_path
                                  CHANGING  ct_json_paths = rt_result ).
   ENDMETHOD.
-
-  METHOD deserialize.
-
-    rv_result = lcl_json_path=>deserialize( it_json_path ).
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/aff/zcl_abapgit_json_path.clas.locals_imp.abap
+++ b/src/objects/aff/zcl_abapgit_json_path.clas.locals_imp.abap
@@ -13,7 +13,7 @@ CLASS lcl_json_path DEFINITION CREATE PUBLIC.
 
     CLASS-METHODS: deserialize
       IMPORTING it_json_path     TYPE string_table
-      RETURNING VALUE(rv_result) TYPE xstring
+      RETURNING VALUE(rv_result) TYPE string
       RAISING   zcx_abapgit_exception.
 
   PROTECTED SECTION.
@@ -343,8 +343,7 @@ CLASS lcl_json_path IMPLEMENTATION.
     DATA: lo_merged                 TYPE REF TO zif_abapgit_ajson,
           lv_json_path              TYPE string,
           lo_deserialization_result TYPE REF TO zif_abapgit_ajson,
-          lx_ajson                  TYPE REF TO zcx_abapgit_ajson_error,
-          lv_result_as_string       TYPE string.
+          lx_ajson                  TYPE REF TO zcx_abapgit_ajson_error.
 
     TRY.
         lo_merged = zcl_abapgit_ajson=>parse( `` ).
@@ -374,8 +373,7 @@ CLASS lcl_json_path IMPLEMENTATION.
     ENDLOOP.
 
     TRY.
-        lv_result_as_string = lo_merged->stringify( 2 ).
-        rv_result = zcl_abapgit_convert=>string_to_xstring( lv_result_as_string ).
+        rv_result = lo_merged->stringify( 2 ).
       CATCH zcx_abapgit_ajson_error INTO lx_ajson.
         zcx_abapgit_exception=>raise_with_text( lx_ajson ).
     ENDTRY.

--- a/src/objects/aff/zcl_abapgit_json_path.clas.testclasses.abap
+++ b/src/objects/aff/zcl_abapgit_json_path.clas.testclasses.abap
@@ -145,7 +145,6 @@ CLASS ltcl_json_path IMPLEMENTATION.
   METHOD deserialize_nested_arrays.
     DATA: lt_file     TYPE string_table,
           lo_cut      TYPE REF TO zcl_abapgit_json_path,
-          lv_xact     TYPE xstring,
           lv_act      TYPE string,
           lv_exp      TYPE string,
           lt_exp      TYPE string_table,
@@ -156,7 +155,7 @@ CLASS ltcl_json_path IMPLEMENTATION.
     APPEND `$.descriptions.methods[?(@.name=='METH1')].parameters[?(@.name=='param2')].description=ABC` TO lt_file.
 
     CREATE OBJECT lo_cut.
-    lv_xact = lo_cut->deserialize( lt_file ).
+    lv_act = lo_cut->deserialize( lt_file ).
 
     APPEND `{  "header": { "description": "Text" } ,` TO lt_exp.
     APPEND `"descriptions": {` TO lt_exp.
@@ -170,8 +169,6 @@ CLASS ltcl_json_path IMPLEMENTATION.
     lv_exp = concat_lines_of( table = lt_exp
                               sep   = cl_abap_char_utilities=>newline ).
 
-    lv_act = zcl_abapgit_convert=>xstring_to_string_utf8( lv_xact ).
-
     lv_is_equal = zcl_abapgit_ajson_utilities=>new( )->is_equal( iv_json_a = lv_act
                                                                  iv_json_b = lv_exp ).
 
@@ -183,16 +180,13 @@ CLASS ltcl_json_path IMPLEMENTATION.
   METHOD deserialize_simple.
     DATA: lt_file     TYPE string_table,
           lo_cut      TYPE REF TO zcl_abapgit_json_path,
-          lv_xact     TYPE xstring,
-
           lv_act      TYPE string,
           lv_is_equal TYPE abap_bool.
 
     APPEND `$.header.description=Text` TO lt_file.
 
     CREATE OBJECT lo_cut.
-    lv_xact = lo_cut->deserialize( lt_file ).
-    lv_act = zcl_abapgit_convert=>xstring_to_string_utf8( lv_xact ).
+    lv_act = lo_cut->deserialize( lt_file ).
 
     lv_is_equal = zcl_abapgit_ajson_utilities=>new( )->is_equal(
       iv_json_a = lv_act
@@ -206,7 +200,6 @@ CLASS ltcl_json_path IMPLEMENTATION.
   METHOD deserialize_with_comments.
     DATA: lt_file     TYPE string_table,
           lo_cut      TYPE REF TO zcl_abapgit_json_path,
-          lv_xact     TYPE xstring,
           lv_act      TYPE string.
 
     APPEND `# comment = abc` TO lt_file.
@@ -214,9 +207,7 @@ CLASS ltcl_json_path IMPLEMENTATION.
     APPEND `` TO lt_file.
 
     CREATE OBJECT lo_cut.
-    lv_xact = lo_cut->deserialize( lt_file ).
-    lv_act = zcl_abapgit_convert=>xstring_to_string_utf8( lv_xact ).
-
+    lv_act = lo_cut->deserialize( lt_file ).
 
     cl_abap_unit_assert=>assert_initial( lv_act ).
 

--- a/src/objects/core/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_files.clas.abap
@@ -105,11 +105,6 @@ CLASS zcl_abapgit_objects_files DEFINITION
         VALUE(rt_i18n_files) TYPE zif_abapgit_i18n_file=>ty_table_of
       RAISING
         zcx_abapgit_exception .
-    METHODS get_i18n_properties_file
-      RETURNING
-        VALUE(rt_result) TYPE zif_abapgit_git_definitions=>ty_files_tt
-      RAISING
-        zcx_abapgit_exception .
 
   PROTECTED SECTION.
 
@@ -294,39 +289,6 @@ CLASS zcl_abapgit_objects_files IMPLEMENTATION.
     " Escape special characters for use with 'covers pattern' (CP)
     REPLACE ALL OCCURRENCES OF '#' IN rv_pattern WITH '##'.
     REPLACE ALL OCCURRENCES OF '+' IN rv_pattern WITH '#+'.
-  ENDMETHOD.
-
-
-  METHOD get_i18n_properties_file.
-
-    " TODO: replace this method with read_i18n_files
-
-    DATA lv_lang TYPE laiso.
-    DATA lv_ext TYPE string.
-    FIELD-SYMBOLS <ls_file> LIKE LINE OF mt_files.
-
-    LOOP AT mt_files ASSIGNING <ls_file>.
-
-      zcl_abapgit_filename_logic=>i18n_file_to_object(
-        EXPORTING
-          iv_path     = <ls_file>-path
-          iv_filename = <ls_file>-filename
-        IMPORTING
-          ev_lang     = lv_lang
-          ev_ext      = lv_ext ).
-
-      IF lv_ext = 'properties'.
-
-        APPEND <ls_file> TO rt_result.
-        mark_accessed(
-          iv_path = <ls_file>-path
-          iv_file = <ls_file>-filename
-          iv_sha1 = <ls_file>-sha1 ).
-
-      ENDIF.
-
-    ENDLOOP.
-
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -262,11 +262,11 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
 
   METHOD read_json.
-    DATA lv_json_data TYPE xstring.
+    DATA lv_json_data TYPE string.
     DATA ls_intf_aff TYPE zif_abapgit_aff_intf_v1=>ty_main.
     DATA lo_aff_mapper TYPE REF TO zif_abapgit_aff_type_mapping.
 
-    lv_json_data = mo_files->read_raw( 'json' ).
+    lv_json_data = mo_files->read_string( 'json' ).
     ls_intf_aff = lcl_aff_metadata_handler=>deserialize( lv_json_data ).
 
     CREATE OBJECT lo_aff_mapper TYPE lcl_aff_type_mapping.
@@ -535,6 +535,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
         lcl_aff_metadata_handler=>deserialize_translation(
           EXPORTING
             io_files           = mo_files
+            is_item            = ms_item
           IMPORTING
             et_description     = lt_description
             et_description_sub = lt_description_sub ).

--- a/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
@@ -363,7 +363,6 @@ CLASS ltcl_aff_metadata IMPLEMENTATION.
   METHOD deserialize_non_defaults.
     DATA:
       lv_source                  TYPE string,
-      lv_source_xstring          TYPE xstring,
       ls_description_type        TYPE zif_abapgit_aff_oo_types_v1=>ty_component_description,
       ls_description_attr        TYPE zif_abapgit_aff_oo_types_v1=>ty_component_description,
       ls_description_meth_param  TYPE zif_abapgit_aff_oo_types_v1=>ty_component_description,
@@ -447,10 +446,8 @@ CLASS ltcl_aff_metadata IMPLEMENTATION.
       `  }` && cl_abap_char_utilities=>newline &&
       `}` && cl_abap_char_utilities=>newline.
 
-    lv_source_xstring = cl_abap_codepage=>convert_to( lv_source ).
-
     " cut
-    ls_actual = lcl_aff_metadata_handler=>deserialize( lv_source_xstring ).
+    ls_actual = lcl_aff_metadata_handler=>deserialize( lv_source ).
 
     cl_abap_unit_assert=>assert_equals( act = ls_actual
                                         exp = ls_expected ).
@@ -459,7 +456,6 @@ CLASS ltcl_aff_metadata IMPLEMENTATION.
   METHOD deserialize_defaults.
     DATA:
       lv_source         TYPE string,
-      lv_source_xstring TYPE xstring,
       ls_actual         TYPE zif_abapgit_aff_intf_v1=>ty_main,
       ls_expected       TYPE zif_abapgit_aff_intf_v1=>ty_main.
 
@@ -480,10 +476,8 @@ CLASS ltcl_aff_metadata IMPLEMENTATION.
       `  }` && cl_abap_char_utilities=>newline &&
       `}` && cl_abap_char_utilities=>newline.
 
-    lv_source_xstring = cl_abap_codepage=>convert_to( lv_source ).
-
     " cut
-    ls_actual = lcl_aff_metadata_handler=>deserialize( lv_source_xstring ).
+    ls_actual = lcl_aff_metadata_handler=>deserialize( lv_source ).
 
     cl_abap_unit_assert=>assert_equals( act = ls_actual
                                         exp = ls_expected ).


### PR DESCRIPTION
This consolidates the handling of `po` and `properties` files as mentioned in #6892.

- Replace `zcl_abapgit_objects_files=>get_i18n_properties_file` with `read_i18n_files`
- Move JSON path and JSON handling to `zcl_abapgit_properties_file=>get_translations`
- Remove unnecessary conversions between string -> xstring -> string