### PR TITLE
Change message if local packages got lost

### DIFF
--- a/src/repo/zcl_abapgit_repo_status.clas.locals_imp.abap
+++ b/src/repo/zcl_abapgit_repo_status.clas.locals_imp.abap
@@ -50,7 +50,7 @@ CLASS lcl_status_consistency_checks DEFINITION FINAL.
         zcx_abapgit_exception .
     METHODS check_namespace
       IMPORTING
-        !it_results      TYPE zif_abapgit_definitions=>ty_results_tt
+        !it_results TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception .
 
@@ -227,7 +227,12 @@ CLASS lcl_status_consistency_checks IMPLEMENTATION.
       lv_object = |{ <ls_result>-obj_type } { <ls_result>-obj_name }|.
 
       IF lv_path IS INITIAL.
-        mi_log->add_error( |{ lv_object } already exists outside of { iv_top } package hierarchy| ).
+        IF <ls_result>-package(1) = '$'.
+          mi_log->add_warning( |{ lv_object } exists but package { <ls_result>-package } is missing|
+            && | (might have been lost during an upgrade, SAP Note 2478895)| ).
+        ELSE.
+          mi_log->add_error( |{ lv_object } already exists outside of { iv_top } package hierarchy| ).
+        ENDIF.
       ELSEIF lv_path <> <ls_result>-path.
         mi_log->add_warning( |Package and path do not match for object { lv_object }| ).
       ENDIF.


### PR DESCRIPTION
Local packages might get lost during an upgrade (see #6784 for details). This changes the message raised by abapGit when serializing a repository based on such lost packages.

Before:

![image](https://github.com/abapGit/abapGit/assets/59966492/dae8ec6c-183d-4fb5-b15f-279eb8923db6)

After:

![image](https://github.com/abapGit/abapGit/assets/59966492/09ad6b70-8f68-4d3a-9c32-497575bfffb1)

The general solution is to simply pull the missing packages again from the remote.