### PR TITLE
Improve error message for SUSH objects not being supported.

### DIFF
--- a/src/objects/zcl_abapgit_object_sush.clas.abap
+++ b/src/objects/zcl_abapgit_object_sush.clas.abap
@@ -88,7 +88,7 @@ CLASS zcl_abapgit_object_sush IMPLEMENTATION.
         CREATE DATA lr_data_head TYPE ('IF_SU22_ADT_OBJECT=>TS_SU2X_HEAD').
 
       CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |SUSH is not supported in your release| ).
+        zcx_abapgit_exception=>raise( |SUSH is not supported in your SAP release| ).
     ENDTRY.
 
   ENDMETHOD.


### PR DESCRIPTION
![image](https://github.com/abapGit/abapGit/assets/53078228/25595cfb-de89-45fa-ba87-500f97d7c384)
I saw this error message today for the first time and thought the abapGit release was too low and only figured out it meant the SAP after updating abapGIT.

I would recommend to add this word just to make it clear.

Please check it.

Best regards.