### PR TITLE
Small performance improvement in folder logic

### DIFF
--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -137,8 +137,8 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
       rv_path = lv_starting_folder.
     ELSE.
       lv_parentcl = get_parent(
-      iv_top     = iv_top
-      iv_package = iv_package ).
+        iv_top     = iv_top
+        iv_package = iv_package ).
 
       " If the parent package can not be determined, we return an initial path and handle
       " it outside of this class (in zcl_abapgit_file_status)

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -46,6 +46,29 @@ CLASS zcl_abapgit_folder_logic DEFINITION
     TYPES:
       ty_devclass_info_tt TYPE SORTED TABLE OF ty_devclass_info
         WITH UNIQUE KEY devclass .
+
+    TYPES:
+      BEGIN OF ty_buffer_path_to_package,
+        top             TYPE devclass,
+        starting_folder TYPE string,
+        folder_logic    TYPE string,
+        path            TYPE string,
+        package         TYPE devclass,
+      END OF ty_buffer_path_to_package,
+      BEGIN OF ty_buffer_package_to_path,
+        top             TYPE devclass,
+        starting_folder TYPE string,
+        folder_logic    TYPE string,
+        package         TYPE devclass,
+        path            TYPE string,
+      END OF ty_buffer_package_to_path.
+
+    DATA mt_buffer_path_to_package
+      TYPE HASHED TABLE OF ty_buffer_path_to_package
+      WITH UNIQUE KEY top starting_folder folder_logic path.
+    DATA mt_buffer_package_to_path
+      TYPE HASHED TABLE OF ty_buffer_package_to_path
+      WITH UNIQUE KEY top starting_folder folder_logic package.
     DATA mt_top_subpackages TYPE ty_devclass_info_tt .
     DATA mt_parent TYPE ty_devclass_info_tt .
 ENDCLASS.
@@ -89,79 +112,102 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
 
   METHOD package_to_path.
 
-    DATA: lv_len          TYPE i,
-          lv_path         TYPE string,
-          lv_message      TYPE string,
-          lv_parentcl     TYPE tdevc-parentcl,
-          lv_folder_logic TYPE string.
+    DATA: lv_len             TYPE i,
+          lv_path            TYPE string,
+          lv_message         TYPE string,
+          lv_parentcl        TYPE tdevc-parentcl,
+          lv_starting_folder TYPE string,
+          lv_folder_logic    TYPE string,
+          ls_buffer          TYPE ty_buffer_package_to_path.
+
+    lv_starting_folder = io_dot->get_starting_folder( ).
+    lv_folder_logic    = io_dot->get_folder_logic( ).
 
     IF iv_top = iv_package.
-      rv_path = io_dot->get_starting_folder( ).
-    ELSE.
-      lv_parentcl = get_parent(
-        iv_top     = iv_top
-        iv_package = iv_package ).
-
-      " If the parent package can not be determined, we return an initial path and handle
-      " it outside of this class (in zcl_abapgit_file_status)
-      IF lv_parentcl IS NOT INITIAL.
-        lv_folder_logic = io_dot->get_folder_logic( ).
-        CASE lv_folder_logic.
-          WHEN zif_abapgit_dot_abapgit=>c_folder_logic-full.
-            lv_len = 0.
-            IF iv_package(1) = '$'.
-              lv_len = 1.
-            ENDIF.
-          WHEN zif_abapgit_dot_abapgit=>c_folder_logic-prefix.
-            lv_len = strlen( lv_parentcl ).
-
-            IF iv_package(lv_len) <> lv_parentcl.
-              " If abapGit project is installed in package ZZZ, all subpackages should be named
-              " ZZZ_something. This will define the folder name in the zip file to be "something",
-              " similarly with online projects. Alternatively change to FULL folder logic
-              lv_message = |PREFIX: Unexpected package naming |
-                        && |(top: { iv_top }, parent: { lv_parentcl }, child: { iv_package }). |
-                        && |Try using the folder logic FULL|.
-              zcx_abapgit_exception=>raise( lv_message ).
-            ENDIF.
-          WHEN zif_abapgit_dot_abapgit=>c_folder_logic-mixed.
-            lv_len = strlen( iv_top ).
-
-            IF iv_package(lv_len) <> iv_top.
-              lv_message = |MIXED: Unexpected package naming |
-                        && |(top: { iv_top }, parent: { lv_parentcl }, child: { iv_package }). |
-                        && |Try using the folder logic FULL|.
-              zcx_abapgit_exception=>raise( lv_message ).
-            ENDIF.
-          WHEN OTHERS.
-            zcx_abapgit_exception=>raise( |Invalid folder logic: { lv_folder_logic }| ).
-        ENDCASE.
-
-        lv_path = iv_package+lv_len.
-        IF strlen( lv_path ) = 0.
-          zcx_abapgit_exception=>raise( |Folder logic: length = 0, parent: {
-            lv_parentcl }, child: { iv_package }| ).
-        ENDIF.
-
-        IF lv_path(1) = '_'.
-          lv_path = lv_path+1.
-        ENDIF.
-        IF strlen( lv_path ) = 0.
-          zcx_abapgit_exception=>raise( |Folder logic: length = 0, parent: {
-            lv_parentcl }, child: { iv_package }| ).
-        ENDIF.
-
-        TRANSLATE lv_path USING '/#'.
-        TRANSLATE lv_path TO LOWER CASE.
-        CONCATENATE lv_path '/' INTO lv_path.
-
-        rv_path = package_to_path( iv_top     = iv_top
-                                   io_dot     = io_dot
-                                   iv_package = lv_parentcl ).
-
-        CONCATENATE rv_path lv_path INTO rv_path.
-      ENDIF.
+      rv_path = lv_starting_folder.
+      RETURN.
     ENDIF.
+
+    READ TABLE mt_buffer_package_to_path INTO ls_buffer WITH TABLE KEY
+      top             = iv_top
+      starting_folder = lv_starting_folder
+      folder_logic    = lv_folder_logic
+      package         = iv_package.
+    IF sy-subrc = 0.
+      rv_path = ls_buffer-path.
+      RETURN.
+    ENDIF.
+
+    lv_parentcl = get_parent(
+      iv_top     = iv_top
+      iv_package = iv_package ).
+
+    " If the parent package can not be determined, we return an initial path and handle
+    " it outside of this class (in zcl_abapgit_file_status)
+    IF lv_parentcl IS NOT INITIAL.
+      CASE lv_folder_logic.
+        WHEN zif_abapgit_dot_abapgit=>c_folder_logic-full.
+          lv_len = 0.
+          IF iv_package(1) = '$'.
+            lv_len = 1.
+          ENDIF.
+        WHEN zif_abapgit_dot_abapgit=>c_folder_logic-prefix.
+          lv_len = strlen( lv_parentcl ).
+
+          IF iv_package(lv_len) <> lv_parentcl.
+            " If abapGit project is installed in package ZZZ, all subpackages should be named
+            " ZZZ_something. This will define the folder name in the zip file to be "something",
+            " similarly with online projects. Alternatively change to FULL folder logic
+            lv_message = |PREFIX: Unexpected package naming |
+                      && |(top: { iv_top }, parent: { lv_parentcl }, child: { iv_package }). |
+                      && |Try using the folder logic FULL|.
+            zcx_abapgit_exception=>raise( lv_message ).
+          ENDIF.
+        WHEN zif_abapgit_dot_abapgit=>c_folder_logic-mixed.
+          lv_len = strlen( iv_top ).
+
+          IF iv_package(lv_len) <> iv_top.
+            lv_message = |MIXED: Unexpected package naming |
+                      && |(top: { iv_top }, parent: { lv_parentcl }, child: { iv_package }). |
+                      && |Try using the folder logic FULL|.
+            zcx_abapgit_exception=>raise( lv_message ).
+          ENDIF.
+        WHEN OTHERS.
+          zcx_abapgit_exception=>raise( |Invalid folder logic: { lv_folder_logic }| ).
+      ENDCASE.
+
+      lv_path = iv_package+lv_len.
+      IF strlen( lv_path ) = 0.
+        zcx_abapgit_exception=>raise( |Folder logic: length = 0, parent: {
+          lv_parentcl }, child: { iv_package }| ).
+      ENDIF.
+
+      IF lv_path(1) = '_'.
+        lv_path = lv_path+1.
+      ENDIF.
+      IF strlen( lv_path ) = 0.
+        zcx_abapgit_exception=>raise( |Folder logic: length = 0, parent: {
+          lv_parentcl }, child: { iv_package }| ).
+      ENDIF.
+
+      TRANSLATE lv_path USING '/#'.
+      TRANSLATE lv_path TO LOWER CASE.
+      CONCATENATE lv_path '/' INTO lv_path.
+
+      rv_path = package_to_path( iv_top     = iv_top
+                                 io_dot     = io_dot
+                                 iv_package = lv_parentcl ).
+
+      CONCATENATE rv_path lv_path INTO rv_path.
+    ENDIF.
+
+    CLEAR ls_buffer.
+    ls_buffer-top             = iv_top.
+    ls_buffer-starting_folder = lv_starting_folder.
+    ls_buffer-folder_logic    = lv_folder_logic.
+    ls_buffer-package         = iv_package.
+    ls_buffer-path            = rv_path.
+    INSERT ls_buffer INTO TABLE mt_buffer_package_to_path.
 
   ENDMETHOD.
 
@@ -174,12 +220,27 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
           lv_new                  TYPE string,
           lv_path                 TYPE string,
           lv_absolute_name        TYPE string,
+          lv_starting_folder      TYPE string,
           lv_folder_logic         TYPE string,
+          ls_buffer               TYPE ty_buffer_path_to_package,
           lt_unique_package_names TYPE HASHED TABLE OF devclass WITH UNIQUE KEY table_line.
 
-    lv_length = strlen( io_dot->get_starting_folder( ) ).
+    lv_starting_folder = io_dot->get_starting_folder( ).
+    lv_folder_logic    = io_dot->get_folder_logic( ).
+
+    lv_length = strlen( lv_starting_folder ).
     IF lv_length > strlen( iv_path ).
 * treat as not existing locally
+      RETURN.
+    ENDIF.
+
+    READ TABLE mt_buffer_path_to_package INTO ls_buffer WITH TABLE KEY
+      top             = iv_top
+      starting_folder = lv_starting_folder
+      folder_logic    = lv_folder_logic
+      path            = iv_path.
+    IF sy-subrc = 0.
+      rv_package = ls_buffer-package.
       RETURN.
     ENDIF.
 
@@ -205,7 +266,6 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
     WHILE lv_path CA '/'.
       SPLIT lv_path AT '/' INTO lv_new lv_path.
 
-      lv_folder_logic = io_dot->get_folder_logic( ).
       CASE lv_folder_logic.
         WHEN zif_abapgit_dot_abapgit=>c_folder_logic-full.
           lv_absolute_name = lv_new.
@@ -244,6 +304,14 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
 
       lv_parent = rv_package.
     ENDWHILE.
+
+    CLEAR ls_buffer.
+    ls_buffer-top             = iv_top.
+    ls_buffer-starting_folder = lv_starting_folder.
+    ls_buffer-folder_logic    = lv_folder_logic.
+    ls_buffer-path            = iv_path.
+    ls_buffer-package         = rv_package.
+    INSERT ls_buffer INTO TABLE mt_buffer_path_to_package.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.locals_imp.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.locals_imp.abap
@@ -1,0 +1,138 @@
+CLASS lcl_package_to_path DEFINITION.
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get
+      IMPORTING
+        !iv_top        TYPE devclass
+        !io_dot        TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_package    TYPE devclass
+      RETURNING
+        VALUE(rv_path) TYPE string.
+
+    CLASS-METHODS add
+      IMPORTING
+        !iv_top     TYPE devclass
+        !io_dot     TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_package TYPE devclass
+        !iv_path    TYPE string.
+
+  PRIVATE SECTION.
+
+    TYPES:
+      BEGIN OF ty_buffer,
+        top             TYPE devclass,
+        starting_folder TYPE string,
+        folder_logic    TYPE string,
+        package         TYPE devclass,
+        path            TYPE string,
+      END OF ty_buffer.
+
+    CLASS-DATA gt_buffer
+      TYPE HASHED TABLE OF ty_buffer
+      WITH UNIQUE KEY top starting_folder folder_logic package.
+
+ENDCLASS.
+
+CLASS lcl_package_to_path IMPLEMENTATION.
+
+  METHOD get.
+
+    FIELD-SYMBOLS <ls_buffer> LIKE LINE OF gt_buffer.
+
+    READ TABLE gt_buffer ASSIGNING <ls_buffer> WITH TABLE KEY
+      top             = iv_top
+      starting_folder = io_dot->get_starting_folder( )
+      folder_logic    = io_dot->get_folder_logic( )
+      package         = iv_package.
+    IF sy-subrc = 0.
+      rv_path = <ls_buffer>-path.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD add.
+
+    DATA ls_buffer LIKE LINE OF gt_buffer.
+
+    CLEAR ls_buffer.
+    ls_buffer-top             = iv_top.
+    ls_buffer-starting_folder = io_dot->get_starting_folder( ).
+    ls_buffer-folder_logic    = io_dot->get_folder_logic( ).
+    ls_buffer-package         = iv_package.
+    ls_buffer-path            = iv_path.
+    INSERT ls_buffer INTO TABLE gt_buffer.
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+CLASS lcl_path_to_package DEFINITION.
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get
+      IMPORTING
+        !iv_top           TYPE devclass
+        !io_dot           TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_path          TYPE string
+      RETURNING
+        VALUE(rv_package) TYPE devclass.
+
+    CLASS-METHODS add
+      IMPORTING
+        !iv_top     TYPE devclass
+        !io_dot     TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_path    TYPE string
+        !iv_package TYPE devclass.
+
+  PRIVATE SECTION.
+
+    TYPES:
+      BEGIN OF ty_buffer,
+        top             TYPE devclass,
+        starting_folder TYPE string,
+        folder_logic    TYPE string,
+        path            TYPE string,
+        package         TYPE devclass,
+      END OF ty_buffer.
+
+    CLASS-DATA gt_buffer
+      TYPE HASHED TABLE OF ty_buffer
+      WITH UNIQUE KEY top starting_folder folder_logic path.
+
+ENDCLASS.
+
+CLASS lcl_path_to_package IMPLEMENTATION.
+
+  METHOD get.
+
+    FIELD-SYMBOLS <ls_buffer> LIKE LINE OF gt_buffer.
+
+    READ TABLE gt_buffer ASSIGNING <ls_buffer> WITH TABLE KEY
+      top             = iv_top
+      starting_folder = io_dot->get_starting_folder( )
+      folder_logic    = io_dot->get_folder_logic( )
+      path            = iv_path.
+    IF sy-subrc = 0.
+      rv_package = <ls_buffer>-package.
+      RETURN.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD add.
+
+    DATA ls_buffer LIKE LINE OF gt_buffer.
+
+    CLEAR ls_buffer.
+    ls_buffer-top             = iv_top.
+    ls_buffer-starting_folder = io_dot->get_starting_folder( ).
+    ls_buffer-folder_logic    = io_dot->get_folder_logic( ).
+    ls_buffer-path            = iv_path.
+    ls_buffer-package         = iv_package.
+    INSERT ls_buffer INTO TABLE gt_buffer.
+
+  ENDMETHOD.
+
+ENDCLASS.


### PR DESCRIPTION
For larger repositories, `zcl_abapgit_folder_logic` methods `path_to_package` or `package_to_path` are called many times with the same parameters. Once per package/path is sufficient but the calls are once per object/file.

This change introduces a local caching logic which should improve runtimes for serializing and deserializing repos.

For serializing the abapGit repo the improvement is about 0.2s (but I use 4 processes). With standalone (1 process) it will be more. For deserializing, I expect the improvement to be more noticeable since the logic requires more DB selections.