### PR TITLE
Exclude files from remote

### DIFF
--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -31,6 +31,7 @@ INTERFACE zif_abapgit_persistence PUBLIC.
       transport_request            TYPE trkorr,
       customizing_request          TYPE trkorr,
       flow                         TYPE abap_bool,
+      exclude_remote_paths         TYPE string_table,
     END OF ty_local_settings.
 
   TYPES: ty_local_checksum_tt TYPE STANDARD TABLE OF ty_local_checksum WITH DEFAULT KEY.

--- a/src/ui/pages/sett/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/sett/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -282,8 +282,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_LOCL IMPLEMENTATION.
 
     ro_form->textarea(
       iv_name        = c_id-exclude_remote_paths
-      iv_label       = 'Exclude Remote Paths'
-      iv_hint        = 'List of files patterns (CP operator) to exclude from deserialization' ).
+      iv_label       = 'Exclude Paths'
+      iv_hint        = 'List of files patterns (CP operator) to exclude from' &&
+                       ' syncronization (e.g. unwanted parts of the package, examples...)' ).
 
     ro_form->start_group(
       iv_name        = c_id-checks

--- a/src/ui/pages/sett/zcl_abapgit_gui_page_sett_locl.clas.abap
+++ b/src/ui/pages/sett/zcl_abapgit_gui_page_sett_locl.clas.abap
@@ -42,6 +42,7 @@ CLASS zcl_abapgit_gui_page_sett_locl DEFINITION
         code_inspector_check_variant TYPE string VALUE 'code_inspector_check_variant',
         block_commit                 TYPE string VALUE 'block_commit',
         flow                         TYPE string VALUE 'flow',
+        exclude_remote_paths         TYPE string VALUE 'exclude_remote_paths',
       END OF c_id .
     CONSTANTS:
       BEGIN OF c_event,
@@ -103,7 +104,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_LOCL IMPLEMENTATION.
 
 
   METHOD choose_check_variant.
@@ -279,6 +280,11 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
       iv_readonly = boolc( li_package->are_changes_recorded_in_tr_req( ) = abap_false )
       iv_label    = 'BETA: Enable abapGit flow for this repository (requires transported packages)' ).
 
+    ro_form->textarea(
+      iv_name        = c_id-exclude_remote_paths
+      iv_label       = 'Exclude Remote Paths'
+      iv_hint        = 'List of files patterns (CP operator) to exclude from deserialization' ).
+
     ro_form->start_group(
       iv_name        = c_id-checks
       iv_label       = 'Local Checks'
@@ -339,7 +345,8 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
 
   METHOD read_settings.
 
-    DATA: li_package TYPE REF TO zif_abapgit_sap_package.
+    DATA li_package TYPE REF TO zif_abapgit_sap_package.
+    DATA lv_excl_rem TYPE string.
 
     li_package = zcl_abapgit_factory=>get_sap_package( mo_repo->get_package( ) ).
 
@@ -389,6 +396,13 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
       iv_key = c_id-block_commit
       iv_val = boolc( ms_settings-block_commit = abap_true ) ) ##TYPE.
 
+    lv_excl_rem = concat_lines_of(
+      table = ms_settings-exclude_remote_paths
+      sep   = cl_abap_char_utilities=>newline ).
+    ro_form_data->set(
+      iv_key = c_id-exclude_remote_paths
+      iv_val = lv_excl_rem ).
+
   ENDMETHOD.
 
 
@@ -405,6 +419,10 @@ CLASS zcl_abapgit_gui_page_sett_locl IMPLEMENTATION.
     ms_settings-only_local_objects           = mo_form_data->get( c_id-only_local_objects ).
     ms_settings-code_inspector_check_variant = mo_form_data->get( c_id-code_inspector_check_variant ).
     ms_settings-block_commit                 = mo_form_data->get( c_id-block_commit ).
+    ms_settings-exclude_remote_paths         =
+      zcl_abapgit_convert=>split_string( mo_form_data->get( c_id-exclude_remote_paths ) ).
+
+    DELETE ms_settings-exclude_remote_paths WHERE table_line IS INITIAL.
 
     mo_repo->set_local_settings( ms_settings ).
 


### PR DESCRIPTION
A feature to exclude certain files (packages) from deployment.

Use case: deploying a part of the package, where some parts of it) or subpackages) were not sold to the client and so should not be installed. Thus, this is a specific local setting and not a global ignore.

There can be more usecases. E.g. installing a library without demo programs or optional features.

How it works: you can define one or more exclude pattern in repo local settings

![image](https://github.com/abapGit/abapGit/assets/15635498/3fbe2d57-3dc6-4fbb-ac15-3336694f29a6)

And the files are excluded

![image](https://github.com/abapGit/abapGit/assets/15635498/ab3fef64-709c-4a09-a2e5-168afaae9d9b)

Technical comments:
- a method in repo that applies the exclude is called in `get_remote` (obviously) and also in `get_local` - because we need to ensure that excluded files are not re-pushed unintentinally (ideally it should even be an error message about a conflict, but I'm lazy to implement it)


