### PR TITLE
ENHO: Fix diff in generated comments of class enhancements

### DIFF
--- a/src/objects/enh/zcl_abapgit_object_enho_class.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_class.clas.abap
@@ -1,15 +1,20 @@
-CLASS zcl_abapgit_object_enho_class DEFINITION PUBLIC.
+CLASS zcl_abapgit_object_enho_class DEFINITION
+  PUBLIC
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
-    METHODS:
-      constructor
-        IMPORTING
-          is_item  TYPE zif_abapgit_definitions=>ty_item
-          io_files TYPE REF TO zcl_abapgit_objects_files.
-    INTERFACES: zif_abapgit_object_enho.
 
+    INTERFACES zif_abapgit_object_enho.
+
+    METHODS constructor
+      IMPORTING
+        !is_item  TYPE zif_abapgit_definitions=>ty_item
+        !io_files TYPE REF TO zcl_abapgit_objects_files.
   PROTECTED SECTION.
   PRIVATE SECTION.
+    CLASS-METHODS adjust_generated_comments
+      CHANGING
+        ct_source TYPE rswsourcet.
     METHODS:
       serialize_includes
         IMPORTING
@@ -31,6 +36,24 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_enho_class IMPLEMENTATION.
+
+
+  METHOD adjust_generated_comments.
+
+    FIELD-SYMBOLS <lv_source> LIKE LINE OF ct_source.
+
+    " Enhancements contain comments that end in '.' or ' .' depending on release
+    " This routine replaces the space-dot with just dot
+    LOOP AT ct_source ASSIGNING <lv_source>.
+      IF strlen( <lv_source> ) > 2.
+        <lv_source> = replace(
+          val   = <lv_source>
+          regex = '^(\*".*) \.$'
+          with  = '$1.' ).
+      ENDIF.
+    ENDLOOP.
+
+  ENDMETHOD.
 
 
   METHOD constructor.
@@ -230,6 +253,8 @@ CLASS zcl_abapgit_object_enho_class IMPLEMENTATION.
                  ig_data = lt_pre ).
     ii_xml->add( iv_name = 'POST_METHODS'
                  ig_data = lt_post ).
+
+    adjust_generated_comments( CHANGING ct_source = lt_source ).
 
     mo_files->add_abap( lt_source ).
 

--- a/src/objects/enh/zcl_abapgit_object_enho_class.clas.testclasses.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_class.clas.testclasses.abap
@@ -1,0 +1,41 @@
+CLASS ltcl_enho_class DEFINITION FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT FINAL.
+
+  PRIVATE SECTION.
+    METHODS adjust_generated_comments FOR TESTING.
+
+ENDCLASS.
+
+CLASS zcl_abapgit_object_enho_class DEFINITION LOCAL FRIENDS ltcl_enho_class.
+
+CLASS ltcl_enho_class IMPLEMENTATION.
+
+  METHOD adjust_generated_comments.
+
+    DATA lt_source_act TYPE rswsourcet.
+    DATA lt_source_exp TYPE rswsourcet.
+
+    INSERT `  METHOD run.` INTO TABLE lt_source_act.
+    INSERT `*"------------------------------------------------------------------------*` INTO TABLE lt_source_act.
+    INSERT `*"METHODS run .` INTO TABLE lt_source_act.
+    INSERT `*"` INTO TABLE lt_source_act.
+    INSERT `*"METHODS test.` INTO TABLE lt_source_act.
+    INSERT `*"------------------------------------------------------------------------*` INTO TABLE lt_source_act.
+    INSERT `    BREAK-POINT .` INTO TABLE lt_source_act.
+    INSERT `  ENDMETHOD.` INTO TABLE lt_source_act.
+
+    lt_source_exp = lt_source_act.
+
+    DELETE lt_source_exp INDEX 3.
+    INSERT `*"METHODS run.` INTO lt_source_exp INDEX 3.  " <<< change only this
+
+    zcl_abapgit_object_enho_class=>adjust_generated_comments( CHANGING ct_source = lt_source_act ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_source_act
+      exp = lt_source_exp ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/enh/zcl_abapgit_object_enho_class.clas.xml
+++ b/src/objects/enh/zcl_abapgit_object_enho_class.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
Depending on release, the generated comments in class enhancements might contain "space-dot" instead of "dot" at the end of method signatures:

![image](https://github.com/abapGit/abapGit/assets/59966492/737d41cd-08ce-41ab-9072-dafee1dc62e2)

The fix replaces the space-dot with just dot. 

Test repo: https://github.com/abapGit-tests/CLAS_with_ENHO

Note: This might impact existing repos but makes them cross-release compatible.