### PR TITLE
CLIF: Add missing translations for classes and interfaces

### DIFF
--- a/deps/seoclasstx.tabl.xml
+++ b/deps/seoclasstx.tabl.xml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_TABL" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DD02V>
+    <TABNAME>SEOCLASSTX</TABNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <TABCLASS>TRANSP</TABCLASS>
+    <DDTEXT>SEOCLASSTX</DDTEXT>
+    <CONTFLAG>A</CONTFLAG>
+    <EXCLASS>1</EXCLASS>
+   </DD02V>
+   <DD09L>
+    <TABNAME>SEOCLASSTX</TABNAME>
+    <AS4LOCAL>A</AS4LOCAL>
+    <TABKAT>0</TABKAT>
+    <TABART>APPL0</TABART>
+    <UEBERSETZ>N</UEBERSETZ>
+    <BUFALLOW>N</BUFALLOW>
+   </DD09L>
+   <DD03P_TABLE>
+    <DD03P>
+     <FIELDNAME>CLSNAME</FIELDNAME>
+     <KEYFLAG>X</KEYFLAG>
+     <ROLLNAME>SEOCLSNAME</ROLLNAME>
+     <ADMINFIELD>0</ADMINFIELD>
+     <NOTNULL>X</NOTNULL>
+     <COMPTYPE>E</COMPTYPE>
+    </DD03P>
+    <DD03P>
+     <FIELDNAME>LANGU</FIELDNAME>
+     <KEYFLAG>X</KEYFLAG>
+     <ROLLNAME>LANGU</ROLLNAME>
+     <ADMINFIELD>0</ADMINFIELD>
+     <NOTNULL>X</NOTNULL>
+     <COMPTYPE>E</COMPTYPE>
+     <LANGUFLAG>X</LANGUFLAG>
+    </DD03P>
+    <DD03P>
+     <FIELDNAME>DESCRIPT</FIELDNAME>
+     <ROLLNAME>SEODESCR</ROLLNAME>
+     <ADMINFIELD>0</ADMINFIELD>
+     <COMPTYPE>E</COMPTYPE>
+    </DD03P>
+   </DD03P_TABLE>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/oo/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_base.clas.abap
@@ -284,8 +284,7 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
   METHOD zif_abapgit_oo_object_fnc~update_descriptions_class.
     DATA lt_descriptions LIKE it_descriptions.
-
-    FIELD-SYMBOLS <ls_description> LIKE LINE OF it_descriptions.
+    DATA ls_description LIKE LINE OF it_descriptions.
 
     IF it_descriptions IS INITIAL.
       RETURN.
@@ -296,9 +295,9 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
       WHERE clsname = is_key-clsname AND langu = iv_language
       ORDER BY PRIMARY KEY.
 
-    LOOP AT it_descriptions ASSIGNING <ls_description> WHERE langu <> iv_language.
-      <ls_description>-clsname = is_key-clsname.
-      INSERT <ls_description> INTO TABLE lt_descriptions.
+    LOOP AT it_descriptions INTO ls_description WHERE langu <> iv_language.
+      ls_description-clsname = is_key-clsname.
+      INSERT ls_description INTO TABLE lt_descriptions.
     ENDLOOP.
 
     DELETE FROM seoclasstx WHERE clsname = is_key-clsname. "#EC CI_SUBRC

--- a/src/objects/oo/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_base.clas.abap
@@ -284,12 +284,8 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
   METHOD zif_abapgit_oo_object_fnc~update_descriptions_class.
     DATA lt_descriptions LIKE it_descriptions.
-    DATA lt_components   TYPE STANDARD TABLE OF vseoclass.
-    DATA ls_description  LIKE LINE OF it_descriptions.
-    DATA lv_lang         TYPE tadir-masterlang.
 
     FIELD-SYMBOLS <ls_description> LIKE LINE OF it_descriptions.
-    FIELD-SYMBOLS <ls_component> TYPE vseoclass.
 
     IF it_descriptions IS INITIAL.
       RETURN.
@@ -297,7 +293,8 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
     " Make sure we keep main language
     SELECT * FROM seoclasstx INTO TABLE lt_descriptions
-      WHERE clsname = is_key-clsname AND langu = iv_language.
+      WHERE clsname = is_key-clsname AND langu = iv_language
+      ORDER BY PRIMARY KEY.
 
     LOOP AT it_descriptions ASSIGNING <ls_description> WHERE langu <> iv_language.
       <ls_description>-clsname = is_key-clsname.

--- a/src/objects/oo/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_base.clas.abap
@@ -150,7 +150,23 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_oo_object_fnc~read_descriptions.
+  METHOD zif_abapgit_oo_object_fnc~read_descriptions_class.
+    FIELD-SYMBOLS <ls_description> LIKE LINE OF rt_descriptions.
+
+    " Only translations i.e. not the main language
+    SELECT * FROM seoclasstx INTO TABLE rt_descriptions
+            WHERE clsname   = iv_object_name
+              AND langu    <> iv_language
+              AND descript <> ''
+            ORDER BY PRIMARY KEY.                         "#EC CI_SUBRC
+
+    LOOP AT rt_descriptions ASSIGNING <ls_description>.
+      CLEAR <ls_description>-clsname.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~read_descriptions_compo.
     FIELD-SYMBOLS <ls_description> LIKE LINE OF rt_descriptions.
 
     IF iv_language IS INITIAL.
@@ -174,7 +190,7 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_oo_object_fnc~read_descriptions_sub.
+  METHOD zif_abapgit_oo_object_fnc~read_descriptions_subco.
     FIELD-SYMBOLS <ls_description> LIKE LINE OF rt_descriptions.
 
     IF iv_language IS INITIAL.
@@ -199,8 +215,8 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
 
   METHOD zif_abapgit_oo_object_fnc~read_documentation.
-    DATA: lv_state  TYPE dokstate,
-          lt_lines  TYPE tlinetab.
+    DATA: lv_state TYPE dokstate,
+          lt_lines TYPE tlinetab.
 
     CALL FUNCTION 'DOCU_GET'
       EXPORTING
@@ -261,7 +277,39 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_oo_object_fnc~update_descriptions.
+  METHOD zif_abapgit_oo_object_fnc~syntax_check.
+    ASSERT 0 = 1. "Subclass responsibility
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~update_descriptions_class.
+    DATA lt_descriptions LIKE it_descriptions.
+    DATA lt_components   TYPE STANDARD TABLE OF vseoclass.
+    DATA ls_description  LIKE LINE OF it_descriptions.
+    DATA lv_lang         TYPE tadir-masterlang.
+
+    FIELD-SYMBOLS <ls_description> LIKE LINE OF it_descriptions.
+    FIELD-SYMBOLS <ls_component> TYPE vseoclass.
+
+    IF it_descriptions IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    " Make sure we keep main language
+    SELECT * FROM seoclasstx INTO TABLE lt_descriptions
+      WHERE clsname = is_key-clsname AND langu = iv_language.
+
+    LOOP AT it_descriptions ASSIGNING <ls_description> WHERE langu <> iv_language.
+      <ls_description>-clsname = is_key-clsname.
+      INSERT <ls_description> INTO TABLE lt_descriptions.
+    ENDLOOP.
+
+    DELETE FROM seoclasstx WHERE clsname = is_key-clsname. "#EC CI_SUBRC
+    INSERT seoclasstx FROM TABLE lt_descriptions.         "#EC CI_SUBRC
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~update_descriptions_compo.
     DATA lt_descriptions LIKE it_descriptions.
     DATA lt_components   TYPE seo_components.
     DATA ls_description  LIKE LINE OF it_descriptions.
@@ -285,7 +333,7 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
     IF lt_components IS NOT INITIAL.
       SELECT SINGLE masterlang FROM tadir INTO lv_lang
         WHERE pgmid = 'R3TR' AND ( object = 'CLAS' OR object = 'INTF' )
-          AND obj_name = is_key-clsname.                  "#EC CI_GENBUFF
+          AND obj_name = is_key-clsname.                "#EC CI_GENBUFF
       IF sy-subrc <> 0.
         lv_lang = sy-langu.
       ENDIF.
@@ -304,12 +352,12 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
       ENDLOOP.
     ENDIF.
 
-    DELETE FROM seocompotx WHERE clsname = is_key-clsname."#EC CI_SUBRC
+    DELETE FROM seocompotx WHERE clsname = is_key-clsname. "#EC CI_SUBRC
     INSERT seocompotx FROM TABLE lt_descriptions.         "#EC CI_SUBRC
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_oo_object_fnc~update_descriptions_sub.
+  METHOD zif_abapgit_oo_object_fnc~update_descriptions_subco.
     DATA lt_descriptions  LIKE it_descriptions.
     DATA lt_subcomponents TYPE seo_subcomponents.
     DATA ls_description   LIKE LINE OF it_descriptions.
@@ -331,7 +379,7 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
     IF lt_subcomponents IS NOT INITIAL.
       SELECT SINGLE masterlang FROM tadir INTO lv_lang
         WHERE pgmid = 'R3TR' AND ( object = 'CLAS' OR object = 'INTF' )
-          AND obj_name = is_key-clsname.                   "#EC CI_GENBUFF
+          AND obj_name = is_key-clsname.                "#EC CI_GENBUFF
       IF sy-subrc <> 0.
         lv_lang = sy-langu.
       ENDIF.
@@ -352,13 +400,7 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
       ENDLOOP.
     ENDIF.
 
-    DELETE FROM seosubcotx WHERE clsname = is_key-clsname."#EC CI_SUBRC
+    DELETE FROM seosubcotx WHERE clsname = is_key-clsname. "#EC CI_SUBRC
     INSERT seosubcotx FROM TABLE lt_descriptions.         "#EC CI_SUBRC
   ENDMETHOD.
-
-
-  METHOD zif_abapgit_oo_object_fnc~syntax_check.
-    ASSERT 0 = 1. "Subclass responsibility
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/oo/zif_abapgit_oo_object_fnc.intf.abap
@@ -14,6 +14,8 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
          ty_includes_tt TYPE STANDARD TABLE OF ty_includes WITH DEFAULT KEY.
 
   TYPES:
+    ty_seoclasstx_tt TYPE STANDARD TABLE OF seoclasstx WITH DEFAULT KEY .
+  TYPES:
     ty_seocompotx_tt TYPE STANDARD TABLE OF seocompotx WITH DEFAULT KEY .
   TYPES:
     ty_seosubcotx_tt TYPE STANDARD TABLE OF seosubcotx WITH DEFAULT KEY .
@@ -67,11 +69,16 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
         iv_state      TYPE c DEFAULT 'I'
       RAISING
         zcx_abapgit_exception,
-    update_descriptions
+    update_descriptions_class
+      IMPORTING
+        is_key          TYPE seoclskey
+        iv_language     TYPE spras
+        it_descriptions TYPE ty_seoclasstx_tt,
+    update_descriptions_compo
       IMPORTING
         is_key          TYPE seoclskey
         it_descriptions TYPE ty_seocompotx_tt,
-    update_descriptions_sub
+    update_descriptions_subco
       IMPORTING
         is_key          TYPE seoclskey
         it_descriptions TYPE ty_seosubcotx_tt,
@@ -161,13 +168,19 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
         io_i18n_params TYPE REF TO zcl_abapgit_i18n_params
       RAISING
         zcx_abapgit_exception,
-    read_descriptions
+    read_descriptions_class
+      IMPORTING
+        iv_object_name         TYPE seoclsname
+        iv_language            TYPE spras OPTIONAL
+      RETURNING
+        VALUE(rt_descriptions) TYPE ty_seoclasstx_tt,
+    read_descriptions_compo
       IMPORTING
         iv_object_name         TYPE seoclsname
         iv_language            TYPE spras OPTIONAL
       RETURNING
         VALUE(rt_descriptions) TYPE ty_seocompotx_tt,
-    read_descriptions_sub
+    read_descriptions_subco
       IMPORTING
         iv_object_name         TYPE seoclsname
         iv_language            TYPE spras OPTIONAL
@@ -190,7 +203,7 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
         VALUE(rt_attributes) TYPE ty_obj_attribute_tt,
     syntax_check
       IMPORTING
-        iv_object_name                TYPE seoclsname
+        iv_object_name TYPE seoclsname
       RAISING
         zcx_abapgit_exception.
 ENDINTERFACE.

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -12,6 +12,7 @@ CLASS zcl_abapgit_object_intf DEFINITION PUBLIC FINAL INHERITING FROM zcl_abapgi
       BEGIN OF ty_intf,
         vseointerf      TYPE vseointerf,
         docu            TYPE ty_docu,
+        description_int TYPE zif_abapgit_oo_object_fnc=>ty_seoclasstx_tt,
         description     TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt,
         description_sub TYPE zif_abapgit_oo_object_fnc=>ty_seosubcotx_tt,
       END OF ty_intf.
@@ -44,18 +45,27 @@ CLASS zcl_abapgit_object_intf DEFINITION PUBLIC FINAL INHERITING FROM zcl_abapgi
       RETURNING VALUE(rs_docu)       TYPE ty_docu
       RAISING
                 zcx_abapgit_exception.
-    METHODS serialize_descr
+    METHODS serialize_descr_class
       IMPORTING
-                !iv_clsname           TYPE seoclsname
-      RETURNING VALUE(rs_description) TYPE ty_intf-description
+        !iv_clsname           TYPE seoclsname
+      RETURNING
+        VALUE(rs_description) TYPE ty_intf-description_int
       RAISING
-                zcx_abapgit_exception.
-    METHODS serialize_descr_sub
+        zcx_abapgit_exception.
+    METHODS serialize_descr_compo
       IMPORTING
-                !iv_clsname           TYPE seoclsname
-      RETURNING VALUE(rs_description) TYPE ty_intf-description_sub
+        !iv_clsname           TYPE seoclsname
+      RETURNING
+        VALUE(rs_description) TYPE ty_intf-description
       RAISING
-                zcx_abapgit_exception.
+        zcx_abapgit_exception.
+    METHODS serialize_descr_subco
+      IMPORTING
+        !iv_clsname           TYPE seoclsname
+      RETURNING
+        VALUE(rs_description) TYPE ty_intf-description_sub
+      RAISING
+        zcx_abapgit_exception.
     METHODS serialize_xml
       IMPORTING
         !io_xml TYPE REF TO zif_abapgit_xml_output
@@ -88,10 +98,13 @@ CLASS zcl_abapgit_object_intf DEFINITION PUBLIC FINAL INHERITING FROM zcl_abapgi
       RAISING
         zcx_abapgit_exception.
 
-    METHODS deserialize_descriptions
+    METHODS deserialize_descr_class
+      IMPORTING
+        it_description TYPE zif_abapgit_oo_object_fnc=>ty_seoclasstx_tt OPTIONAL.
+    METHODS deserialize_descr_compo
       IMPORTING
         it_description TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt OPTIONAL.
-    METHODS deserialize_descr_sub
+    METHODS deserialize_descr_subco
       IMPORTING
         it_description TYPE zif_abapgit_oo_object_fnc=>ty_seosubcotx_tt OPTIONAL.
     METHODS read_xml
@@ -130,21 +143,32 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD deserialize_descriptions.
-    DATA:  ls_clskey TYPE seoclskey.
+  METHOD deserialize_descr_class.
+    DATA ls_clskey TYPE seoclskey.
     ls_clskey-clsname = ms_item-obj_name.
 
-    mi_object_oriented_object_fct->update_descriptions(
+    mi_object_oriented_object_fct->update_descriptions_class(
+      is_key          = ls_clskey
+      iv_language     = mv_language
+      it_descriptions = it_description ).
+  ENDMETHOD.
+
+
+  METHOD deserialize_descr_compo.
+    DATA ls_clskey TYPE seoclskey.
+    ls_clskey-clsname = ms_item-obj_name.
+
+    mi_object_oriented_object_fct->update_descriptions_compo(
       is_key          = ls_clskey
       it_descriptions = it_description ).
   ENDMETHOD.
 
 
-  METHOD deserialize_descr_sub.
-    DATA:  ls_clskey TYPE seoclskey.
+  METHOD deserialize_descr_subco.
+    DATA ls_clskey TYPE seoclskey.
     ls_clskey-clsname = ms_item-obj_name.
 
-    mi_object_oriented_object_fct->update_descriptions_sub(
+    mi_object_oriented_object_fct->update_descriptions_subco(
       is_key          = ls_clskey
       it_descriptions = it_description ).
   ENDMETHOD.
@@ -279,6 +303,8 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
   METHOD read_xml.
     ii_xml->read( EXPORTING iv_name = 'VSEOINTERF'
                   CHANGING  cg_data = rs_intf-vseointerf ).
+    ii_xml->read( EXPORTING iv_name = 'DESCRIPTIONS_INTERFACE'
+                  CHANGING  cg_data = rs_intf-description_int ).
     ii_xml->read( EXPORTING iv_name = 'DESCRIPTIONS'
                   CHANGING  cg_data = rs_intf-description ).
     ii_xml->read( EXPORTING iv_name = 'DESCRIPTIONS_SUB'
@@ -290,7 +316,34 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD serialize_descr.
+  METHOD serialize_descr_class.
+
+    DATA: lt_descriptions    TYPE zif_abapgit_oo_object_fnc=>ty_seoclasstx_tt,
+          lt_language_filter TYPE zif_abapgit_environment=>ty_system_language_filter.
+
+    " Main language is already in VSEOCLASS so we serialize only translations
+    IF mo_i18n_params->ms_params-main_language_only = abap_true.
+      RETURN.
+    ENDIF.
+
+    lt_descriptions = mi_object_oriented_object_fct->read_descriptions_class(
+      iv_object_name = iv_clsname
+      iv_language    = mv_language ).
+
+    " Remove technical languages
+    lt_language_filter = mo_i18n_params->build_language_filter( ).
+    DELETE lt_descriptions WHERE NOT langu IN lt_language_filter AND langu <> mv_language.
+
+    IF lines( lt_descriptions ) = 0.
+      RETURN.
+    ENDIF.
+
+    rs_description = lt_descriptions.
+
+  ENDMETHOD.
+
+
+  METHOD serialize_descr_compo.
 
     DATA: lt_descriptions    TYPE zif_abapgit_oo_object_fnc=>ty_seocompotx_tt,
           lv_language        TYPE spras,
@@ -300,7 +353,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
       lv_language = mv_language.
     ENDIF.
 
-    lt_descriptions = mi_object_oriented_object_fct->read_descriptions(
+    lt_descriptions = mi_object_oriented_object_fct->read_descriptions_compo(
       iv_object_name = iv_clsname
       iv_language    = lv_language ).
 
@@ -317,7 +370,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD serialize_descr_sub.
+  METHOD serialize_descr_subco.
 
     DATA: lt_descriptions    TYPE zif_abapgit_oo_object_fnc=>ty_seosubcotx_tt,
           lv_language        TYPE spras,
@@ -327,7 +380,7 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
       lv_language = mv_language.
     ENDIF.
 
-    lt_descriptions = mi_object_oriented_object_fct->read_descriptions_sub(
+    lt_descriptions = mi_object_oriented_object_fct->read_descriptions_subco(
       iv_object_name = iv_clsname
       iv_language    = lv_language ).
 
@@ -416,8 +469,9 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
       iv_clsname          = ls_clskey-clsname
       it_langu_additional = lt_langu_additional ).
 
-    ls_intf-description = serialize_descr( ls_clskey-clsname ).
-    ls_intf-description_sub = serialize_descr_sub( ls_clskey-clsname ).
+    ls_intf-description_int = serialize_descr_class( ls_clskey-clsname ).
+    ls_intf-description     = serialize_descr_compo( ls_clskey-clsname ).
+    ls_intf-description_sub = serialize_descr_subco( ls_clskey-clsname ).
 
     " HERE: switch with feature flag for XML or JSON file format
     IF mv_aff_enabled = abap_true.
@@ -434,6 +488,8 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
     ELSE.
       io_xml->add( iv_name = 'VSEOINTERF'
                    ig_data = ls_intf-vseointerf ).
+      io_xml->add( iv_name = 'DESCRIPTIONS_INTERFACE'
+                   ig_data = ls_intf-description_int ).
       io_xml->add( iv_name = 'DESCRIPTIONS'
                    ig_data = ls_intf-description ).
       io_xml->add( iv_name = 'DESCRIPTIONS_SUB'
@@ -570,9 +626,11 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
           iv_version = ls_intf-vseointerf-unicode
           it_source  = lt_source ).
 
-        deserialize_descriptions( ls_intf-description ).
+        deserialize_descr_class( ls_intf-description_int ).
 
-        deserialize_descr_sub( ls_intf-description_sub ).
+        deserialize_descr_compo( ls_intf-description ).
+
+        deserialize_descr_subco( ls_intf-description_sub ).
 
         deserialize_docu(
           is_docu = ls_intf-docu

--- a/src/objects/zcl_abapgit_object_intf.clas.locals_imp.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.locals_imp.abap
@@ -726,7 +726,8 @@ CLASS lcl_aff_metadata_handler IMPLEMENTATION.
         IMPORTING
           es_data        = ls_ag_data ).
 
-      APPEND LINES OF ls_ag_data-description TO et_description.
+      APPEND LINES OF ls_ag_data-description_int TO et_description_int.
+      APPEND LINES OF ls_ag_data-description     TO et_description.
       APPEND LINES OF ls_ag_data-description_sub TO et_description_sub.
 
     ENDLOOP.

--- a/src/objects/zcl_abapgit_object_intf.clas.locals_imp.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.locals_imp.abap
@@ -514,7 +514,8 @@ CLASS lcl_aff_metadata_handler DEFINITION.
     CLASS-METHODS deserialize_translation
       IMPORTING io_files           TYPE REF TO zcl_abapgit_objects_files
                 is_item            TYPE zif_abapgit_definitions=>ty_item
-      EXPORTING et_description     TYPE zcl_abapgit_object_intf=>ty_intf-description
+      EXPORTING et_description_int TYPE zcl_abapgit_object_intf=>ty_intf-description_int
+                et_description     TYPE zcl_abapgit_object_intf=>ty_intf-description
                 et_description_sub TYPE zcl_abapgit_object_intf=>ty_intf-description_sub
       RAISING   zcx_abapgit_exception.
   PRIVATE SECTION.

--- a/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.testclasses.abap
@@ -75,10 +75,13 @@ CLASS lth_oo_object_fnc IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~read_attributes.
   ENDMETHOD.
 
-  METHOD zif_abapgit_oo_object_fnc~read_descriptions.
+  METHOD zif_abapgit_oo_object_fnc~read_descriptions_class.
   ENDMETHOD.
 
-  METHOD zif_abapgit_oo_object_fnc~read_descriptions_sub.
+  METHOD zif_abapgit_oo_object_fnc~read_descriptions_compo.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_oo_object_fnc~read_descriptions_subco.
   ENDMETHOD.
 
   METHOD zif_abapgit_oo_object_fnc~read_documentation.
@@ -96,12 +99,15 @@ CLASS lth_oo_object_fnc IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~serialize_abap.
   ENDMETHOD.
 
-  METHOD zif_abapgit_oo_object_fnc~update_descriptions.
+  METHOD zif_abapgit_oo_object_fnc~update_descriptions_class.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_oo_object_fnc~update_descriptions_compo.
     ms_descriptions_key = is_key.
     mt_descriptions     = it_descriptions.
   ENDMETHOD.
 
-  METHOD zif_abapgit_oo_object_fnc~update_descriptions_sub.
+  METHOD zif_abapgit_oo_object_fnc~update_descriptions_subco.
   ENDMETHOD.
 
   METHOD zif_abapgit_oo_object_fnc~syntax_check.


### PR DESCRIPTION
Closes a long-time gap and now handles the translation of class and interface descriptions :-)

New test repos:
https://github.com/abapGit-tests/CLAS_i18n
https://github.com/abapGit-tests/INTF_i18n

@albertmink, it should be ready for AFF now (#6846)