### PR TITLE
CDBO: Fix missing parameters in `constructor`

### DIFF
--- a/src/objects/aff/zcl_abapgit_object_cdbo.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_cdbo.clas.abap
@@ -7,29 +7,34 @@ CLASS zcl_abapgit_object_cdbo DEFINITION
   PUBLIC SECTION.
 
     METHODS constructor
-    IMPORTING
-      !is_item TYPE zif_abapgit_definitions=>ty_item
-      !iv_language TYPE spras
-    RAISING
-      zcx_abapgit_exception .
+      IMPORTING
+        !is_item     TYPE zif_abapgit_definitions=>ty_item
+        !iv_language TYPE spras
+        !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_exception.
 
-    METHODS zif_abapgit_object~changed_by
-    REDEFINITION .
+    METHODS zif_abapgit_object~changed_by REDEFINITION.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
     CONSTANTS c_table_name TYPE tabname VALUE 'CDB_OBJH' ##NO_TEXT.
+
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CDBO IMPLEMENTATION.
+CLASS zcl_abapgit_object_cdbo IMPLEMENTATION.
 
 
   METHOD constructor.
 
-    super->constructor( is_item     = is_item
-                        iv_language = iv_language ).
+    super->constructor( is_item        = is_item
+                        iv_language    = iv_language
+                        io_files       = io_files
+                        io_i18n_params = io_i18n_params ).
   ENDMETHOD.
 
 


### PR DESCRIPTION
Optional parameters not implemented can cause cx_.. exception or dump if called with files object. 
Also did some minor PP/tidying.