### PR TITLE
Add support for Software Component Relations

### DIFF
--- a/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
+++ b/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
@@ -46,21 +46,22 @@ CLASS ZCL_ABAPGIT_AFF_REGISTRY IMPLEMENTATION.
 
 
   METHOD initialize_registry_table.
-    register( 'BGQC' ).
     register( 'CDBO' ).
     register( 'CHKC' ).
     register( 'CHKO' ).
     register( 'CHKV' ).
     register( 'DRTY' ).
     register( 'DTEB' ).
-    register( 'DRAS' ).
     register( 'DSFD' ).
+    register( 'DSFI' ).
+    register( 'DRAS' ).
     register( 'EVTB' ).
     register( 'EEEC' ).
     register( 'GSMP' ).
     register( iv_obj_type     = 'INTF'
               iv_experimental = abap_true ).
     register( 'SMBC' ).
+    register( 'SWCR' ).
     register( 'NONT' ).
     register( 'RONT' ).
     register( 'UIAD' ).

--- a/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
+++ b/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
@@ -46,15 +46,15 @@ CLASS ZCL_ABAPGIT_AFF_REGISTRY IMPLEMENTATION.
 
 
   METHOD initialize_registry_table.
+    register( 'BGQC' ).
     register( 'CDBO' ).
     register( 'CHKC' ).
     register( 'CHKO' ).
     register( 'CHKV' ).
     register( 'DRTY' ).
     register( 'DTEB' ).
-    register( 'DSFD' ).
-    register( 'DSFI' ).
     register( 'DRAS' ).
+    register( 'DSFD' ).
     register( 'EVTB' ).
     register( 'EEEC' ).
     register( 'GSMP' ).

--- a/src/objects/aff/zcl_abapgit_object_swcr.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_swcr.clas.abap
@@ -1,0 +1,61 @@
+CLASS zcl_abapgit_object_swcr DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_object_common_aff
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    METHODS: zif_abapgit_object~changed_by REDEFINITION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_object_swcr IMPLEMENTATION.
+  METHOD zif_abapgit_object~changed_by.
+
+    DATA: lr_data        TYPE REF TO data,
+          lo_swcr_db_api TYPE REF TO object,
+          lv_name        TYPE c LENGTH 30,
+          lx_error       TYPE REF TO cx_root.
+
+    FIELD-SYMBOLS: <ls_swcr_header> TYPE any,
+                   <ls_swcr_user>   TYPE any.
+
+    TRY.
+        CALL METHOD ('CL_SCR_DB_ACCESS')=>('CREATE_INSTANCE')
+          RECEIVING
+            result = lo_swcr_db_api.
+        CREATE DATA lr_data TYPE ('IF_SCR_TYPES=>TY_S_HEADER').
+        ASSIGN lr_data->* TO <ls_swcr_header>.
+
+        lv_name = ms_item-obj_name.
+
+        TRY.
+            CALL METHOD lo_swcr_db_api->('IF_SCR_DB_ACCESS~READ_HEADER')
+              EXPORTING
+                software_component = lv_name
+                version            = 'A'
+              RECEIVING
+                result             = <ls_swcr_header>.
+          CATCH cx_root. " no active version found, try to find an inactive version
+            CALL METHOD lo_swcr_db_api->('IF_SCR_DB_ACCESS~READ_HEADER')
+              EXPORTING
+                software_component = lv_name
+                version            = 'I'
+              RECEIVING
+                result             = <ls_swcr_header>.
+        ENDTRY.
+
+        ASSIGN COMPONENT 'LAST_CHANGED_BY' OF STRUCTURE <ls_swcr_header> TO <ls_swcr_user>.
+        rv_user = <ls_swcr_user>.
+
+      CATCH cx_root INTO lx_error.
+        zcx_abapgit_exception=>raise( iv_text     = lx_error->get_text( )
+                                     ix_previous = lx_error ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/aff/zcl_abapgit_object_swcr.clas.xml
+++ b/src/objects/aff/zcl_abapgit_object_swcr.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECT_SWCR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - SWCR - Software Component Relations</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This PR contains the abapGit handler to support the object type SWCR.
This object type is already maintained in the AFF https://github.com/SAP/abap-file-formats/pull/539.