### PR TITLE
DSFI: Updated object handler to match the latest AFF definition

### DIFF
--- a/src/objects/aff/zcl_abapgit_object_dsfi.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_dsfi.clas.abap
@@ -8,7 +8,6 @@ CLASS zcl_abapgit_object_dsfi DEFINITION
     METHODS zif_abapgit_object~changed_by            REDEFINITION.
     METHODS zif_abapgit_object~get_deserialize_steps REDEFINITION.
   PROTECTED SECTION.
-    METHODS get_additional_extensions                REDEFINITION.
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -61,14 +60,5 @@ CLASS zcl_abapgit_object_dsfi IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
-  ENDMETHOD.
-
-  METHOD get_additional_extensions.
-    DATA ls_additional_extension LIKE LINE OF rv_additional_extensions.
-    ls_additional_extension-extension = 'acds'.
-    CALL METHOD ('CL_CDS_AFF_FILE_NAME_MAPPER')=>for_cds
-      RECEIVING
-        result = ls_additional_extension-file_name_mapper.
-    APPEND ls_additional_extension TO rv_additional_extensions.
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
As part of the discussion to set up the ABAP File Format of object type DSFI, the ACDS file has been dropped. The object handler must be updated to match this decision.