### PR TITLE
Enable deserialization of DSFD, DSFI and DRAS

### DIFF
--- a/src/objects/aff/zcl_abapgit_object_dras.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_dras.clas.abap
@@ -31,19 +31,19 @@ CLASS zcl_abapgit_object_dras IMPLEMENTATION.
           RECEIVING
             handler    = lo_dras_handler.
 
-        CALL METHOD lo_dras_handler->('CHECK_EXISTENCE')
+        CALL METHOD lo_dras_handler->('IF_DD_DRAS_WB_HANDLER~CHECK_EXISTENCE')
           EXPORTING
             iv_as4local = 'A'
           RECEIVING
             rv_exists   = lv_exists.
 
         IF lv_exists = abap_true.
-          CALL METHOD lo_dras_handler->('GET_SOURCE_CONTAINER')
+          CALL METHOD lo_dras_handler->('IF_DD_DRAS_WB_HANDLER~GET_SOURCE_CONTAINER')
             EXPORTING
               iv_as4local = 'A'
             RECEIVING
               ro_result   = lo_dras_source_container.
-          CALL METHOD lo_dras_source_container->('GET_AS4USER')
+          CALL METHOD lo_dras_source_container->('IF_DD_DRAS_SOURCE_CONTAINER~GET_AS4USER')
             RECEIVING
               rv_as4user = rv_user.
         ENDIF.

--- a/src/objects/aff/zcl_abapgit_object_dsfd.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_dsfd.clas.abap
@@ -39,8 +39,7 @@ CLASS zcl_abapgit_object_dsfd IMPLEMENTATION.
 
         IF lv_exists = abap_true.
           CALL METHOD lo_dsfd_handler->('IF_DD_DSFD_WB_HANDLER~GET_SOURCE_CONTAINER')
-
-            EXPORTING
+EXPORTING
               iv_as4local = 'A'
             RECEIVING
               ro_result   = lo_dsfd_source_container.

--- a/src/objects/aff/zcl_abapgit_object_dsfd.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_dsfd.clas.abap
@@ -31,20 +31,21 @@ CLASS zcl_abapgit_object_dsfd IMPLEMENTATION.
           RECEIVING
             handler    = lo_dsfd_handler.
 
-        CALL METHOD lo_dsfd_handler->('CHECK_EXISTENCE')
+        CALL METHOD lo_dsfd_handler->('IF_DD_DSFD_WB_HANDLER~CHECK_EXISTENCE')
           EXPORTING
             iv_as4local = 'A'
           RECEIVING
             rv_exists   = lv_exists.
 
         IF lv_exists = abap_true.
-          CALL METHOD lo_dsfd_handler->('GET_SOURCE_CONTAINER')
+          CALL METHOD lo_dsfd_handler->('IF_DD_DSFD_WB_HANDLER~GET_SOURCE_CONTAINER')
+
             EXPORTING
               iv_as4local = 'A'
             RECEIVING
               ro_result   = lo_dsfd_source_container.
 
-          CALL METHOD lo_dsfd_source_container->('GET_AS4USER')
+          CALL METHOD lo_dsfd_source_container->('IF_DD_DSFD_CONTAINER_SRC~GET_AS4USER')
             RECEIVING
               rv_as4user = rv_user.
         ENDIF.

--- a/src/objects/aff/zcl_abapgit_object_dsfi.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_dsfi.clas.abap
@@ -34,22 +34,22 @@ CLASS zcl_abapgit_object_dsfi IMPLEMENTATION.
         ASSIGN ('CE_DD_DSFI_AS4LOCAL=>EN_STATE-ACTIVE')
           TO <lv_active>.
         IF sy-subrc = 0.
-          CALL METHOD lo_dsfi_handler->('CHECK_EXISTENCE')
+          CALL METHOD lo_dsfi_handler->('IF_DD_DSFI_WB_HANDLER~CHECK_EXISTENCE')
             EXPORTING
               iv_as4local = <lv_active>
             RECEIVING
               rv_exists   = lv_exists.
 
           IF lv_exists = abap_true.
-            CALL METHOD lo_dsfi_handler->('GET_SOURCE_CONTAINER')
+            CALL METHOD lo_dsfi_handler->('IF_DD_DSFI_WB_HANDLER~GET_SOURCE_CONTAINER')
               EXPORTING
                 iv_as4local = <lv_active>
               RECEIVING
                 ro_result   = lo_dsfi_source_container.
 
-            CALL METHOD lo_dsfi_source_container->('GET_AS4USER')
+            CALL METHOD lo_dsfi_source_container->('IF_DD_DSFI_SRC_CONTAINER~GET_AS4USER')
               RECEIVING
-                rv_as4user = rv_user.
+                rv_result = rv_user.
           ENDIF.
         ENDIF.
 

--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -56,7 +56,9 @@ CLASS zcl_abapgit_objects_activation DEFINITION
       c_ddls       TYPE c LENGTH 24 VALUE 'DDLS DRUL DTDC DTEB',
       c_switches   TYPE c LENGTH 24 VALUE 'SF01 SF02 SFSW SFBS SFBF',
       c_para       TYPE c LENGTH 4  VALUE 'PARA', " can be referenced by DTEL
-      c_enhd       TYPE c LENGTH 4  VALUE 'ENHD'.
+      c_enhd       TYPE c LENGTH 4  VALUE 'ENHD',
+      c_scalarfunc TYPE c LENGTH 9  VALUE 'DSFD DSFI', 
+      c_aspect     TYPE c LENGTH 4  VALUE 'DRAS.
 
     CLASS-DATA:
       gt_classes TYPE STANDARD TABLE OF ty_classes WITH DEFAULT KEY .
@@ -554,7 +556,8 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
        c_enqueue  NS iv_obj_type AND c_sqsc       NS iv_obj_type AND
        c_stob     NS iv_obj_type AND c_ntab       NS iv_obj_type AND
        c_ddls     NS iv_obj_type AND c_para       NS iv_obj_type AND
-       c_switches NS iv_obj_type AND iv_obj_type <> c_enhd.
+       c_switches NS iv_obj_type AND iv_obj_type <> c_enhd       AND
+       c_aspect   NS iv_obj_type AND c_scalarfunc NS iv_obj_type.
       rv_result = abap_false.
     ENDIF.
 

--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -57,7 +57,7 @@ CLASS zcl_abapgit_objects_activation DEFINITION
       c_switches   TYPE c LENGTH 24 VALUE 'SF01 SF02 SFSW SFBS SFBF',
       c_para       TYPE c LENGTH 4  VALUE 'PARA', " can be referenced by DTEL
       c_enhd       TYPE c LENGTH 4  VALUE 'ENHD',
-      c_scalarfunc TYPE c LENGTH 9  VALUE 'DSFD DSFI', 
+      c_scalarfunc TYPE c LENGTH 9  VALUE 'DSFD DSFI',
       c_aspect     TYPE c LENGTH 4  VALUE 'DRAS'.
 
     CLASS-DATA:

--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -58,7 +58,7 @@ CLASS zcl_abapgit_objects_activation DEFINITION
       c_para       TYPE c LENGTH 4  VALUE 'PARA', " can be referenced by DTEL
       c_enhd       TYPE c LENGTH 4  VALUE 'ENHD',
       c_scalarfunc TYPE c LENGTH 9  VALUE 'DSFD DSFI', 
-      c_aspect     TYPE c LENGTH 4  VALUE 'DRAS.
+      c_aspect     TYPE c LENGTH 4  VALUE 'DRAS'.
 
     CLASS-DATA:
       gt_classes TYPE STANDARD TABLE OF ty_classes WITH DEFAULT KEY .


### PR DESCRIPTION
Object types DSFD, DSFI and DRAS are handled by the data dictionary and must be classified as such in ZCL_ABAPGIT_OBJECTS_ACTIVATION for the deserialization to succeed.