### PR TITLE
Fix `CX_SY_ZERODIVIDE` dump in progress bar

### DIFF
--- a/src/ui/progress/zcl_abapgit_progress.clas.abap
+++ b/src/ui/progress/zcl_abapgit_progress.clas.abap
@@ -40,14 +40,18 @@ CLASS zcl_abapgit_progress IMPLEMENTATION.
 
     DATA: lv_f TYPE f.
 
-    lv_f = ( iv_current / mv_total ) * 100.
-    rv_pct = lv_f.
+    TRY.
+        lv_f = ( iv_current / mv_total ) * 100.
+        rv_pct = lv_f.
 
-    IF rv_pct = 100.
-      rv_pct = 99.
-    ELSEIF rv_pct = 0.
-      rv_pct = 1.
-    ENDIF.
+        IF rv_pct = 100.
+          rv_pct = 99.
+        ELSEIF rv_pct = 0.
+          rv_pct = 1.
+        ENDIF.
+      CATCH cx_sy_zerodivide.
+        rv_pct = 0.
+    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Fix dump in `ZCL_ABAPGIT_PROGRESS->CALC_PCT`.

![image](https://github.com/user-attachments/assets/44a3ddb5-29b3-49e9-a240-2707265174ee)
