### PR TITLE
SFPF: Add syntax highlighting for `xdp` files

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_factory.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_factory.clas.abap
@@ -25,7 +25,7 @@ CLASS zcl_abapgit_syntax_factory IMPLEMENTATION.
     " Create instance of highlighter dynamically dependent on syntax type
     IF iv_filename CP '*.abap'.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_abap.
-    ELSEIF iv_filename CP '*.xml' OR iv_filename CP '*.html'.
+    ELSEIF iv_filename CP '*.xml' OR iv_filename CP '*.html' OR iv_filename CP '*.xdp'.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_xml.
     ELSEIF iv_filename CP '*.css'.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_css.


### PR DESCRIPTION
`xdp` files are in `XML`

Example: https://github.com/abapGit-tests/SFPF_SFPI/blob/main/src/ztest_sfpf.sfpf.xdp