### PR TITLE
abaplint.json move important stuff to start

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -11,11 +11,43 @@
       "folder": "/deps"
     },
     {
+      "url": "https://github.com/abaplint/deps",
       "files": "/src/**/*.*",
-      "folder": "/lint_deps",
-      "url": "https://github.com/abaplint/deps"
+      "folder": "/lint_deps"
     }
   ],
+  "syntax": {
+    "errorNamespace": "^(Z|Y|LT?CL_|TY_|LIF_|C_|.*ABAPGIT)",
+    "globalConstants": [
+      "abap_func_exporting",
+      "abap_func_tables",
+      "cssf_formtype_text",
+      "seok_access_free",
+      "seok_access_modify",
+      "sews_c_vif_version",
+      "skwfc_obtype_folder",
+      "skwfc_obtype_loio",
+      "so2_controller",
+      "srext_ext_class_pool",
+      "srext_ext_interface_pool",
+      "ststc_c_type_dialog",
+      "ststc_c_type_object",
+      "ststc_c_type_parameters",
+      "ststc_c_type_report",
+      "swbm_c_op_delete_no_dialog",
+      "swbm_c_type_ddic_db_tabxinx",
+      "swbm_c_type_wdy_application",
+      "swbm_version_active",
+      "swbm_version_inactive",
+      "swfco_org_standard_task",
+      "swfco_org_workflow_template",
+      "wbmr_c_skwf_folder_class",
+      "wdyn_limu_component_controller",
+      "wdyn_limu_component_definition",
+      "wdyn_limu_component_view"
+    ],
+    "version": "v702"
+  },
   "rules": {
     "7bit_ascii": {
       "exclude": [
@@ -468,37 +500,5 @@
     "when_others_last": true,
     "whitespace_end": true,
     "xml_consistency": true
-  },
-  "syntax": {
-    "errorNamespace": "^(Z|Y|LT?CL_|TY_|LIF_|C_|.*ABAPGIT)",
-    "globalConstants": [
-      "abap_func_exporting",
-      "abap_func_tables",
-      "cssf_formtype_text",
-      "seok_access_free",
-      "seok_access_modify",
-      "sews_c_vif_version",
-      "skwfc_obtype_folder",
-      "skwfc_obtype_loio",
-      "so2_controller",
-      "srext_ext_class_pool",
-      "srext_ext_interface_pool",
-      "ststc_c_type_dialog",
-      "ststc_c_type_object",
-      "ststc_c_type_parameters",
-      "ststc_c_type_report",
-      "swbm_c_op_delete_no_dialog",
-      "swbm_c_type_ddic_db_tabxinx",
-      "swbm_c_type_wdy_application",
-      "swbm_version_active",
-      "swbm_version_inactive",
-      "swfco_org_standard_task",
-      "swfco_org_workflow_template",
-      "wbmr_c_skwf_folder_class",
-      "wdyn_limu_component_controller",
-      "wdyn_limu_component_definition",
-      "wdyn_limu_component_view"
-    ],
-    "version": "v702"
   }
 }


### PR DESCRIPTION
this now follows the normal/default way suggested by abaplint

plus the important configuration settings are first, before all the boring settings