### PR TITLE
Added enhanced method resolution for bg exit #7057

### DIFF
--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -30,7 +30,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_background IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
 
 
   METHOD dequeue.
@@ -59,36 +59,76 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
 
   METHOD list_methods.
 
-    DATA: ls_method       LIKE LINE OF rt_methods,
-          ls_key          TYPE seoclskey,
-          lt_implementing TYPE seor_implementing_keys,
-          ls_implementing LIKE LINE OF lt_implementing.
+    CONSTANTS: BEGIN OF c_name,
+                 interface TYPE seoclskey VALUE 'ZIF_ABAPGIT_BACKGROUND',
+                 report    TYPE syrepid VALUE 'ZABAPGIT_STANDALONE',
+               END OF c_name.
 
-    FIELD-SYMBOLS: <ls_method> LIKE LINE OF rt_methods.
+    DATA: ls_method          LIKE LINE OF rt_methods,
+          lt_implementing    TYPE seor_implementing_keys,
+          ls_implementing    LIKE LINE OF lt_implementing,
+          lt_interf          TYPE abap_intfdescr_tab,
+          lt_local_classes   TYPE STANDARD TABLE OF scompo,
+          lv_classname       TYPE string,
+          lr_typedescr       TYPE REF TO cl_abap_typedescr,
+          lr_typedescr_class TYPE REF TO cl_abap_classdescr.
+
+    FIELD-SYMBOLS: <fs_local_class> LIKE LINE OF lt_local_classes,
+                   <ls_method>      LIKE LINE OF rt_methods.
 
 
-* in order to handle local classes in the compiled report
-    ls_method-class = 'ZCL_ABAPGIT_BACKGROUND_PULL'.
-    INSERT ls_method INTO TABLE rt_methods.
-    ls_method-class = 'ZCL_ABAPGIT_BACKGROUND_PUSH_AU'.
-    INSERT ls_method INTO TABLE rt_methods.
-    ls_method-class = 'ZCL_ABAPGIT_BACKGROUND_PUSH_FI'.
-    INSERT ls_method INTO TABLE rt_methods.
+    IF sy-repid = c_name-report.
+      " Assume the standalone version runs.
+      CALL FUNCTION 'WB_TREE_GET_OBJECTS'
+        EXPORTING
+          include = ' '
+          otype   = 'L'
+          program = c_name-report
+        TABLES
+          olist   = lt_local_classes.
 
-    ls_key-clsname = 'ZIF_ABAPGIT_BACKGROUND'.
+      LOOP AT lt_local_classes ASSIGNING <fs_local_class>.
+        lv_classname = |\\PROGRAM={ c_name-report }\\CLASS={ <fs_local_class>-name }|.
+        cl_abap_typedescr=>describe_by_name(
+         EXPORTING
+           p_name         = lv_classname
+         RECEIVING
+           p_descr_ref    = lr_typedescr
+         EXCEPTIONS
+           type_not_found = 1
+           OTHERS         = 2
+       ).
 
-    CALL FUNCTION 'SEO_INTERFACE_IMPLEM_GET_ALL'
-      EXPORTING
-        intkey       = ls_key
-      IMPORTING
-        impkeys      = lt_implementing
-      EXCEPTIONS
-        not_existing = 1
-        OTHERS       = 2 ##FM_SUBRC_OK.
-    LOOP AT lt_implementing INTO ls_implementing.
-      ls_method-class = ls_implementing-clsname.
-      INSERT ls_method INTO TABLE rt_methods.
-    ENDLOOP.
+        IF ( sy-subrc = 0 ) AND ( lr_typedescr IS BOUND ).
+          lr_typedescr_class ?= lr_typedescr.
+          IF lr_typedescr_class IS BOUND.
+            lt_interf = lr_typedescr_class->interfaces.
+            READ TABLE lt_interf WITH TABLE KEY name = c_name-interface TRANSPORTING NO FIELDS.
+            IF sy-subrc = 0.
+              ls_method-class = <fs_local_class>-name.
+              INSERT ls_method INTO TABLE rt_methods.
+            ENDIF.
+          ENDIF.
+        ENDIF.
+      ENDLOOP.
+
+    ELSE.
+      " Assume the developer version runs.
+      CALL FUNCTION 'SEO_INTERFACE_IMPLEM_GET_ALL'
+        EXPORTING
+          intkey       = c_name-interface
+        IMPORTING
+          impkeys      = lt_implementing
+        EXCEPTIONS
+          not_existing = 1
+          OTHERS       = 2.
+      IF sy-subrc = 0.
+        LOOP AT lt_implementing INTO ls_implementing.
+          ls_method-class = ls_implementing-clsname.
+          INSERT ls_method INTO TABLE rt_methods.
+        ENDLOOP.
+      ENDIF.
+    ENDIF.
 
     LOOP AT rt_methods ASSIGNING <ls_method>.
       CALL METHOD (<ls_method>-class)=>zif_abapgit_background~get_description
@@ -136,12 +176,16 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
             iv_username = <ls_list>-username
             iv_password = <ls_list>-password ).
 
-          CREATE OBJECT li_background TYPE (<ls_list>-method).
+          TRY.
+              CREATE OBJECT li_background TYPE (<ls_list>-method).
 
-          li_background->run(
-            io_repo     = lo_repo
-            ii_log      = li_log
-            it_settings = <ls_list>-settings ).
+              li_background->run(
+                io_repo     = lo_repo
+                ii_log      = li_log
+                it_settings = <ls_list>-settings ).
+            CATCH cx_sy_create_object_error.
+              li_log->add_warning( |{ <ls_list>-method } could not be executed, as it is not accessible (local/global class).| ).
+          ENDTRY.
 
           " Decrease memory usage for repository already processed (but keep log)
           lo_repo->refresh(

--- a/src/ui/pages/sett/zcl_abapgit_gui_page_sett_bckg.clas.abap
+++ b/src/ui/pages/sett/zcl_abapgit_gui_page_sett_bckg.clas.abap
@@ -66,7 +66,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_BCKG IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -210,9 +210,13 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
 
       " skip invalid values, from old background logic
       IF ls_per-method <> 'push' AND ls_per-method <> 'pull' AND ls_per-method <> 'nothing'.
-        CALL METHOD (ls_per-method)=>zif_abapgit_background~get_settings
-          CHANGING
-            ct_settings = lt_settings.
+        TRY.
+            CALL METHOD (ls_per-method)=>zif_abapgit_background~get_settings
+              CHANGING
+                ct_settings = lt_settings.
+          CATCH cx_sy_dyn_call_illegal_class.
+            CLEAR lt_settings.
+        ENDTRY.
       ENDIF.
 
       LOOP AT lt_settings INTO ls_settings.

--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -44,6 +44,11 @@ INCLUDE zabapgit_authorizations_exit IF FOUND.
 * place the object in a different package than ZABAPGIT
 INCLUDE zabapgit_user_exit IF FOUND.
 
+* place all implementations of ZIF_ABAPGIT_BACKGROUND in following include,
+* if using the development version of abapGit create a global classes instead
+* place the object in a different package than ZABAPGIT
+INCLUDE zabapgit_background_user_exit IF FOUND.
+
 INCLUDE zabapgit_gui_pages_userexit IF FOUND.
 
 INCLUDE zabapgit_forms.


### PR DESCRIPTION
Background user exit method resolution.
This implementation:
fixes #7057:
- missing error handling for dynamic method calls
- adding a warning message for not processed calls

enhanced:
- fully dynamic method determination based on ZIF_ABAPGIT_BACKGROUND interface
- new include for local ZIF_ABAPGIT_BACKGROUND implementations ZABAPGIT_BACKGROUND_USER_EXIT