### PR TITLE
Introducing abapGit Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![REUSE Status](https://api.reuse.software/badge/github.com/abapGit/abapGit?color=success)](https://api.reuse.software/info/github.com/abapGit/abapGit)
 [![Slack](https://img.shields.io/badge/Join-Slack-blue)](https://communityinviter.com/apps/abapgit/abap)
 [![abap package version](https://img.shields.io/endpoint?url=https://shield.abap.space/version-shield-json/github/abapGit/abapGit/src/zif_abapgit_version.intf.abap/c_abap_version&label=version)](https://github.com/abapGit/abapGit/blob/main/src/zif_abapgit_version.intf.abap)
-
+[![](https://img.shields.io/badge/Gurubase-Ask%20abapGit%20Guru-006BFF)](https://gurubase.io/g/abapgit)
 
 <!--
 <picture>


### PR DESCRIPTION
Hello abapGit team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [abapGit Guru](https://gurubase.io/g/abapgit) to Gurubase. abapGit Guru uses the data from this repo and data from the [docs](https://docs.abapgit.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "abapGit Guru" badge, which highlights that abapGit now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable abapGit Guru in Gurubase, just let me know that's totally fine.
