### PR TITLE
Show diffs in case of trailing spaces

### DIFF
--- a/src/utils/zcl_abapgit_diff.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_diff.clas.testclasses.abap
@@ -528,12 +528,14 @@ CLASS ltcl_diff IMPLEMENTATION.
     add_new( ` ` ). " one space
     add_new( `   ` ). " some spaces
     add_new( 'E' ).
+    add_new( 'X' ). " no trailing space
 
     add_old( 'A' ).
     add_old( `     ` ). " some spaces
     add_old( `  ` ). " two spaces
     add_old( `` ). " empty line
     add_old( 'E' ).
+    add_old( `X  ` ). " some trailing space
 
     add_expected( iv_new_num = '    1'
                   iv_new     = 'A'
@@ -560,6 +562,11 @@ CLASS ltcl_diff IMPLEMENTATION.
                   iv_result  = zif_abapgit_definitions=>c_diff-unchanged
                   iv_old_num = '    5'
                   iv_old     = 'E' ).
+    add_expected( iv_new_num = '    6'
+                  iv_new     = 'X'
+                  iv_result  = zif_abapgit_definitions=>c_diff-update
+                  iv_old_num = '    6'
+                  iv_old     = `X  ` ).
 
     test( ).
 


### PR DESCRIPTION
Fixes issue when overview is showing a diff

![image](https://github.com/user-attachments/assets/6cf9b41b-ebd6-4360-bfd3-74d65a5af32d)

but the diff view is not

![image](https://github.com/user-attachments/assets/d78248e4-6558-411c-b2fe-c94006108f81)

Now the diff properly shows trailing spaces

![image](https://github.com/user-attachments/assets/f414ca5a-9a0f-48c7-a009-ecdc6c07f9ef)
