### PR TITLE
PROG: Store flow logic as separate ABAP files

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -359,6 +359,9 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
         it_flow = ls_dynpro-flow_logic
         it_spaces = ls_dynpro-spaces ).
 
+      IF ls_dynpro-flow_logic IS INITIAL.
+        ls_dynpro-flow_logic = mo_files->read_abap( iv_extra = 'screen_' && ls_dynpro-header-screen ).
+      ENDIF.
 
       LOOP AT ls_dynpro-fields ASSIGNING <ls_field>.
 * if the DDIC element has a PARAMETER_ID and the flag "from_dict" is active
@@ -913,8 +916,12 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
       ENDLOOP.
 
       APPEND INITIAL LINE TO rt_dynpro ASSIGNING <ls_dynpro>.
-      <ls_dynpro>-header     = ls_header.
-      <ls_dynpro>-flow_logic = lt_flow_logic.
+      <ls_dynpro>-header = ls_header.
+
+      " Store flow logic as separate ABAP files instead of XML
+      mo_files->add_abap(
+        iv_extra = 'screen_' && ls_header-screen
+        it_abap  = lt_flow_logic ).
 
       READ TABLE lt_fieldlist_int TRANSPORTING NO FIELDS WITH KEY fill = 'X'.
       IF ls_header-type = 'N' AND sy-subrc = 0.

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -131,6 +131,8 @@ CLASS zcl_abapgit_objects_program DEFINITION
         inactive TYPE r3state VALUE 'I',
       END OF c_state.
 
+    CONSTANTS c_native_dynpro TYPE c LENGTH 2 VALUE 'IN'.
+
     METHODS:
       uncondense_flow
         IMPORTING it_flow        TYPE swydyflow
@@ -393,7 +395,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 
       ENDLOOP.
 
-      IF ls_dynpro-header-type = 'N' AND ls_dynpro-nat_header IS NOT INITIAL.
+      IF ls_dynpro-header-type CA c_native_dynpro AND ls_dynpro-nat_header IS NOT INITIAL.
         DELETE FROM d021t WHERE prog = ls_dynpro-header-program AND dynr = ls_dynpro-header-screen ##SUBRC_OK.
         INSERT d021t FROM TABLE ls_dynpro-nat_texts ##SUBRC_OK.
 
@@ -924,7 +926,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
         it_abap  = lt_flow_logic ).
 
       READ TABLE lt_fieldlist_int TRANSPORTING NO FIELDS WITH KEY fill = 'X'.
-      IF ls_header-type = 'N' AND sy-subrc = 0.
+      IF ls_header-type CA c_native_dynpro AND sy-subrc = 0.
         " In particular for dynpros with splitter
         <ls_dynpro>-nat_header = <ls_d020s>.
         CLEAR: <ls_dynpro>-nat_header-dgen, <ls_dynpro>-nat_header-tgen.


### PR DESCRIPTION
Before, the screen flow logic was stored in encoded format as part of the XML file ([example](https://github.com/abapGit-tests/PROG_splitter/blob/b41889d35c8fb3c3c6bca2326a772da35dbaaa8a/src/zdemo_dynpro_splitter_control.prog.xml#L24-L62)).

abapGit can still deserialize the old format but serializes the flow logic of each screen in a separate ABAP file.

Test repo: https://github.com/abapGit-tests/PROG_dynp_flow

Example:

![image](https://github.com/user-attachments/assets/48a16ed5-8354-431a-9065-c519ed29ecc1)

[![image](https://github.com/user-attachments/assets/2e9a72a6-0b4f-40ca-a13d-c221d332ce25)](https://github.com/abapGit-tests/PROG_dynp_flow/blob/main/src/zdemo_dynpro_splitter_control.prog.screen_0100.abap)

PS: It looks like GH is missing some of the syntax highlighting. I will get it fixed.