### PR TITLE
SSFO: Store smartform code as separate ABAP files

### DIFF
--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -349,15 +349,15 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
   METHOD zif_abapgit_object~deserialize.
 * see function module FB_UPLOAD_FORM
 
-    DATA: li_node                TYPE REF TO if_ixml_node,
-          lv_formname            TYPE tdsfname,
-          lv_name                TYPE string,
-          li_iterator            TYPE REF TO if_ixml_node_iterator,
-          lo_sf                  TYPE REF TO cl_ssf_fb_smart_form,
-          lo_res                 TYPE REF TO cl_ssf_fb_smart_form,
-          lx_error               TYPE REF TO cx_ssf_fb,
-          lv_text                TYPE string,
-          lv_within_code_section TYPE abap_bool.
+    DATA:
+      li_node     TYPE REF TO if_ixml_node,
+      lv_formname TYPE tdsfname,
+      lv_name     TYPE string,
+      li_iterator TYPE REF TO if_ixml_node_iterator,
+      lo_sf       TYPE REF TO cl_ssf_fb_smart_form,
+      lo_res      TYPE REF TO cl_ssf_fb_smart_form,
+      lx_error    TYPE REF TO cx_ssf_fb,
+      lv_text     TYPE string.
 
     CREATE OBJECT lo_sf.
 

--- a/src/objects/zcl_abapgit_object_ssfo.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssfo.clas.abap
@@ -122,7 +122,7 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
 
     ii_node->set_value( '' ).
     LOOP AT lt_abap INTO ls_abap.
-      li_node = li_xml_doc->create_element( name = 'item' ).
+      li_node = li_xml_doc->create_element( 'item' ).
       li_node->set_value( |{ ls_abap-line }| ).
       ii_node->append_child( li_node ).
     ENDLOOP.
@@ -613,7 +613,6 @@ CLASS zcl_abapgit_object_ssfo IMPLEMENTATION.
 
     DATA: lo_sf       TYPE REF TO cl_ssf_fb_smart_form,
           lv_name     TYPE string,
-          lv_code     TYPE string,
           li_node     TYPE REF TO if_ixml_node,
           li_element  TYPE REF TO if_ixml_element,
           li_iterator TYPE REF TO if_ixml_node_iterator,


### PR DESCRIPTION
Before, the smart form code was stored in an encoded format as part of the XML file (example).

abapGit can still deserialize the old format but serializes the smart form code in a separate ABAP file.

Also removes 5-year-old workaround for [leading spaces](https://github.com/abapGit/abapGit/pull/2642/files).

Test repo: https://github.com/abapGit-tests/SSFO_abap

Example:

![image](https://github.com/user-attachments/assets/c35c6cc1-0600-4210-be79-e10b71a3ac52)

![image](https://github.com/user-attachments/assets/4a84ae2c-ef0a-4025-9a20-7733bdbfb354)
