### PR TITLE
longtexts: workaround strange object names dump

### DIFF
--- a/src/objects/texts/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_longtexts.clas.abap
@@ -76,7 +76,7 @@ CLASS zcl_abapgit_longtexts IMPLEMENTATION.
         DELETE lt_dokil WHERE masterlang <> abap_true.
       ENDIF.
 
-    ELSEIF iv_longtext_id IS NOT INITIAL.
+    ELSEIF iv_longtext_id IS NOT INITIAL AND lv_object NA '#'.
       IF iv_main_lang_only = abap_true.
         SELECT * FROM dokil
                  INTO TABLE lt_dokil

--- a/src/objects/texts/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_longtexts.clas.abap
@@ -76,20 +76,22 @@ CLASS zcl_abapgit_longtexts IMPLEMENTATION.
         DELETE lt_dokil WHERE masterlang <> abap_true.
       ENDIF.
 
-    ELSEIF iv_longtext_id IS NOT INITIAL AND lv_object NA '#'.
-      IF iv_main_lang_only = abap_true.
-        SELECT * FROM dokil
-                 INTO TABLE lt_dokil
-                 WHERE id     = iv_longtext_id
-                 AND object LIKE lv_object ESCAPE '#'
-                 AND masterlang = abap_true
-                 ORDER BY PRIMARY KEY.
-      ELSE.
-        SELECT * FROM dokil
-                 INTO TABLE lt_dokil
-                 WHERE id     = iv_longtext_id
-                 AND object LIKE lv_object ESCAPE '#'
-                 ORDER BY PRIMARY KEY.
+    ELSEIF iv_longtext_id IS NOT INITIAL.
+      IF lv_object NA '#'.
+        IF iv_main_lang_only = abap_true.
+          SELECT * FROM dokil
+                   INTO TABLE lt_dokil
+                   WHERE id     = iv_longtext_id
+                   AND object LIKE lv_object ESCAPE '#'
+                   AND masterlang = abap_true
+                   ORDER BY PRIMARY KEY.
+        ELSE.
+          SELECT * FROM dokil
+                   INTO TABLE lt_dokil
+                   WHERE id     = iv_longtext_id
+                   AND object LIKE lv_object ESCAPE '#'
+                   ORDER BY PRIMARY KEY.
+        ENDIF.
       ENDIF.
     ELSE.
 


### PR DESCRIPTION
if the object name contains a `#`, then this SQL dumps

just give up, its not a valid name anyhow, but might exist in a system