### PR TITLE
SRVB: Clear fields and fix deserialize order

### DIFF
--- a/src/objects/core/zcl_abapgit_dependencies.clas.abap
+++ b/src/objects/core/zcl_abapgit_dependencies.clas.abap
@@ -119,7 +119,7 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
           " AUTH after DCLS
           <ls_tadir>-korrnum = '715000'.
         WHEN 'SUSH'.
-          " SUSH after SUSC
+          " SUSH after SUSC and SRVB
           <ls_tadir>-korrnum = '712000'.
         WHEN 'SUSC'.
           " SUSC after SUSO
@@ -130,6 +130,14 @@ CLASS zcl_abapgit_dependencies IMPLEMENTATION.
         WHEN 'DCLS'.
           " AUTH and SUSO after DCLS
           <ls_tadir>-korrnum = '705000'.
+        WHEN 'G4BA' OR 'G4BS' OR 'IWMO' OR 'IWSV' OR 'IWVB'.
+          " after SRVB
+          <ls_tadir>-korrnum = '610000'.
+        WHEN 'SRVB'.
+          " after SRVD
+          <ls_tadir>-korrnum = '600500'.
+        WHEN 'SRVD'.
+          <ls_tadir>-korrnum = '600000'.
         WHEN 'IASP'.
           <ls_tadir>-korrnum = '552000'.
         WHEN 'IARP'.

--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -245,6 +245,12 @@ CLASS zcl_abapgit_file_deserialize IMPLEMENTATION.
         WHEN 'ENSC'.
           lt_requires = lt_items.
           DELETE lt_requires WHERE obj_type <> 'ENHS'.
+        WHEN 'IWMO' OR 'IWSV' OR 'IWVB' OR 'SUSH'.
+          lt_requires = lt_items.
+          DELETE lt_requires WHERE obj_type <> 'SRVB'.
+        WHEN 'SRVB'.
+          lt_requires = lt_items.
+          DELETE lt_requires WHERE obj_type <> 'SRVD'.
       ENDCASE.
 * TODO: END extract to object handler method
 

--- a/src/objects/zcl_abapgit_object_srvb.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvb.clas.abap
@@ -129,6 +129,18 @@ CLASS zcl_abapgit_object_srvb IMPLEMENTATION.
       CHANGING
         cs_service_binding = cs_service_binding ).
 
+    clear_field(
+      EXPORTING
+        iv_fieldname       = 'METADATA-RESPONSIBLE'
+      CHANGING
+        cs_service_binding = cs_service_binding ).
+
+    clear_field(
+      EXPORTING
+        iv_fieldname       = 'METADATA-MASTER_LANGUAGE'
+      CHANGING
+        cs_service_binding = cs_service_binding ).
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Ref #6281: Clears `responsible` and `master_language`

Ref #6856: Fix order of object types since several objects are generated by `srvb` 

Doesn't close these issues but makes some progress