### PR TITLE
Enhance logging with message id and number

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -398,9 +398,18 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
           WHERE type = <ls_message>-show_req->object_type.
       ENDIF.
       LOOP AT <ls_message>-mtext ASSIGNING <lv_msg>.
-        ii_log->add_error(
-          iv_msg  = <lv_msg>
-          is_item = ls_item ).
+        IF sy-tabix = 1.
+          ii_log->add(
+            iv_type   = 'E'
+            iv_msg    = <lv_msg>
+            iv_class  = <ls_message>-message-msgid
+            iv_number = <ls_message>-message-msgno
+            is_item   = ls_item ).
+        ELSE.
+          ii_log->add_error(
+            iv_msg  = <lv_msg>
+            is_item = ls_item ).
+        ENDIF.
       ENDLOOP.
     ENDLOOP.
 
@@ -439,8 +448,10 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
     DELETE lt_lines WHERE class = 'D0' AND number = '319'.
 
     LOOP AT lt_lines ASSIGNING <ls_line>.
-      ii_log->add( iv_msg  = <ls_line>-line
-                   iv_type = <ls_line>-severity ).
+      ii_log->add( iv_msg    = <ls_line>-line
+                   iv_type   = <ls_line>-severity
+                   iv_class  = <ls_line>-class
+                   iv_number = |{ <ls_line>-number }| ).
     ENDLOOP.
 
     ii_log->add_info( |View complete activation log in program RSPUTPRT (type D, log name { iv_logname })| ).

--- a/src/ui/lib/zcl_abapgit_log_viewer.clas.abap
+++ b/src/ui/lib/zcl_abapgit_log_viewer.clas.abap
@@ -30,6 +30,8 @@ CLASS zcl_abapgit_log_viewer DEFINITION
         source    TYPE icon_d,
         callstack TYPE icon_d,
         cell_type TYPE salv_t_int4_column,
+        id        TYPE sy-msgid,
+        number    TYPE sy-msgno,
       END OF ty_log_out.
     TYPES:
       ty_log_outs TYPE STANDARD TABLE OF ty_log_out
@@ -91,7 +93,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_LOG_VIEWER IMPLEMENTATION.
+CLASS zcl_abapgit_log_viewer IMPLEMENTATION.
 
 
   METHOD calculate_cell_type.
@@ -230,7 +232,7 @@ CLASS ZCL_ABAPGIT_LOG_VIEWER IMPLEMENTATION.
 
       CLEAR: ls_log.
 
-      ls_log-msg = lr_message->text.
+      ls_log-msg       = lr_message->text.
       ls_log-exception = lr_message->exception.
 
       CASE lr_message->type.
@@ -268,6 +270,10 @@ CLASS ZCL_ABAPGIT_LOG_VIEWER IMPLEMENTATION.
           CATCH cx_sy_move_cast_error ##NO_HANDLER.
         ENDTRY.
 
+      ELSEIF lr_message->id IS NOT INITIAL AND lr_message->number IS NOT INITIAL.
+        ls_log-id       = lr_message->id.
+        ls_log-number   = lr_message->number.
+        ls_log-longtext = icon_system_help.
       ENDIF.
 
       ls_log-obj_type = lr_message->obj_type.
@@ -424,31 +430,34 @@ CLASS ZCL_ABAPGIT_LOG_VIEWER IMPLEMENTATION.
           lt_dummy2      TYPE TABLE OF dval,
           ls_help_info   TYPE help_info.
 
-    IF is_log-exception IS NOT BOUND.
+    IF is_log-exception IS BOUND.
+      TRY.
+          lx_abapgit ?= is_log-exception.
+        CATCH cx_sy_move_cast_error.
+          RETURN.
+      ENDTRY.
+
+      lv_docu_object = lx_abapgit->if_t100_message~t100key-msgid && lx_abapgit->if_t100_message~t100key-msgno.
+      ls_help_info-messageid  = lx_abapgit->if_t100_message~t100key-msgid.
+      ls_help_info-messagenr  = lx_abapgit->if_t100_message~t100key-msgno.
+      ls_help_info-msgv1      = lx_abapgit->msgv1.
+      ls_help_info-msgv2      = lx_abapgit->msgv2.
+      ls_help_info-msgv3      = lx_abapgit->msgv3.
+      ls_help_info-msgv4      = lx_abapgit->msgv4.
+    ELSEIF is_log-id IS NOT INITIAL AND is_log-number IS NOT INITIAL.
+      lv_docu_object          = is_log-id && is_log-number.
+      ls_help_info-messageid  = is_log-id.
+      ls_help_info-messagenr  = is_log-number.
+    ELSE.
       RETURN.
     ENDIF.
 
-    TRY.
-        lx_abapgit ?= is_log-exception.
-      CATCH cx_sy_move_cast_error.
-        RETURN.
-    ENDTRY.
-
-    lv_docu_object   = lx_abapgit->if_t100_message~t100key-msgid.
-    lv_docu_object+2 = lx_abapgit->if_t100_message~t100key-msgno.
-
     ls_help_info-call       = 'D'.
     ls_help_info-spras      = sy-langu.
-    ls_help_info-messageid  = lx_abapgit->if_t100_message~t100key-msgid.
-    ls_help_info-messagenr  = lx_abapgit->if_t100_message~t100key-msgno.
     ls_help_info-message    = is_log-msg.
     ls_help_info-title      = 'Longtext'.
     ls_help_info-docuid     = 'NA'.
-    ls_help_info-docuobject = lv_docu_object.
-    ls_help_info-msgv1      = lx_abapgit->msgv1.
-    ls_help_info-msgv2      = lx_abapgit->msgv2.
-    ls_help_info-msgv3      = lx_abapgit->msgv3.
-    ls_help_info-msgv4      = lx_abapgit->msgv4.
+    ls_help_info-docuobject = condense( lv_docu_object ).
 
     CALL FUNCTION 'HELP_START'
       EXPORTING

--- a/src/ui/lib/zcl_abapgit_log_viewer.clas.abap
+++ b/src/ui/lib/zcl_abapgit_log_viewer.clas.abap
@@ -393,6 +393,16 @@ CLASS zcl_abapgit_log_viewer IMPLEMENTATION.
           lo_column->set_technical( abap_true ).
         ENDIF.
 
+        LOOP AT gt_log TRANSPORTING NO FIELDS WHERE id IS NOT INITIAL.
+          EXIT.
+        ENDLOOP.
+        IF sy-subrc <> 0.
+          lo_column = lo_columns->get_column( |ID| ).
+          lo_column->set_technical( abap_true ).
+          lo_column = lo_columns->get_column( |NUMBER| ).
+          lo_column->set_technical( abap_true ).
+        ENDIF.
+
         ls_position = zcl_abapgit_popups=>center(
           iv_width  = 125
           iv_height = 20 ).

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -90,10 +90,12 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_log> LIKE LINE OF mt_log.
 
     APPEND INITIAL LINE TO mt_log ASSIGNING <ls_log>.
-    <ls_log>-msg-text  = iv_msg.
-    <ls_log>-msg-type  = iv_type.
-    <ls_log>-item      = is_item.
-    <ls_log>-exception = ix_exc.
+    <ls_log>-msg-text   = iv_msg.
+    <ls_log>-msg-type   = iv_type.
+    <ls_log>-msg-id     = iv_class.
+    <ls_log>-msg-number = iv_number.
+    <ls_log>-item       = is_item.
+    <ls_log>-exception  = ix_exc.
 
     CASE iv_type.
       WHEN 'E' OR 'A' OR 'X'.
@@ -252,6 +254,8 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
     FIELD-SYMBOLS <ls_log> TYPE ty_log.
     LOOP AT mt_log ASSIGNING <ls_log>.
       ls_msg-type      = <ls_log>-msg-type.
+      ls_msg-id        = <ls_log>-msg-id.
+      ls_msg-number    = <ls_log>-msg-number.
       ls_msg-text      = <ls_log>-msg-text.
       ls_msg-obj_type  = <ls_log>-item-obj_type.
       ls_msg-obj_name  = <ls_log>-item-obj_name.

--- a/src/utils/zcl_abapgit_log.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_log.clas.testclasses.abap
@@ -14,7 +14,8 @@ CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
       merge_with_min_level FOR TESTING,
       empty FOR TESTING,
       clone FOR TESTING,
-      add FOR TESTING.
+      add FOR TESTING,
+      add_with_id_number FOR TESTING.
 ENDCLASS.
 
 
@@ -61,6 +62,44 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = ls_message-text
       exp = lv_message ).
+
+  ENDMETHOD.
+
+  METHOD add_with_id_number.
+
+    DATA lv_message TYPE string.
+    DATA lt_messages TYPE zif_abapgit_log=>ty_log_outs.
+    DATA ls_message LIKE LINE OF lt_messages.
+
+    lv_message = 'abracadabra'.
+
+    mi_cut->add(
+      iv_msg    = lv_message
+      iv_type   = 'W'
+      iv_class  = 'SL'
+      iv_number = '123' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->count( )
+      exp = 1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mi_cut->get_status( )
+      exp = 'W' ).
+
+    lt_messages = mi_cut->get_messages( ).
+    READ TABLE lt_messages INDEX 1 INTO ls_message.
+    cl_abap_unit_assert=>assert_subrc( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = ls_message-text
+      exp = lv_message ).
+    cl_abap_unit_assert=>assert_equals(
+      act = ls_message-id
+      exp = 'SL' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = ls_message-number
+      exp = '123' ).
 
   ENDMETHOD.
 

--- a/src/utils/zif_abapgit_log.intf.abap
+++ b/src/utils/zif_abapgit_log.intf.abap
@@ -19,6 +19,8 @@ INTERFACE zif_abapgit_log
   TYPES:
     BEGIN OF ty_log_out,
       type      TYPE sy-msgty,
+      id        TYPE sy-msgid,
+      number    TYPE sy-msgno,
       text      TYPE string,
       obj_type  TYPE tadir-object,
       obj_name  TYPE tadir-obj_name,
@@ -29,9 +31,11 @@ INTERFACE zif_abapgit_log
                 WITH NON-UNIQUE DEFAULT KEY .
   TYPES:
     BEGIN OF ty_msg,
-      text  TYPE string,
-      type  TYPE sy-msgty,
-      level TYPE i,
+      text   TYPE string,
+      type   TYPE sy-msgty,
+      id     TYPE sy-msgid,
+      number TYPE sy-msgno,
+      level  TYPE i,
     END OF ty_msg .
   TYPES:
     ty_msgs TYPE STANDARD TABLE OF ty_msg
@@ -48,10 +52,12 @@ INTERFACE zif_abapgit_log
 
   METHODS add
     IMPORTING
-      !iv_msg  TYPE csequence
-      !iv_type TYPE sy-msgty DEFAULT 'E'
-      !is_item TYPE zif_abapgit_definitions=>ty_item OPTIONAL
-      !ix_exc  TYPE REF TO cx_root OPTIONAL .
+      !iv_msg    TYPE csequence
+      !iv_type   TYPE sy-msgty DEFAULT 'E'
+      !iv_class  TYPE sy-msgid OPTIONAL
+      !iv_number TYPE sy-msgno OPTIONAL
+      !is_item   TYPE zif_abapgit_definitions=>ty_item OPTIONAL
+      !ix_exc    TYPE REF TO cx_root OPTIONAL .
   METHODS add_error
     IMPORTING
       !iv_msg  TYPE csequence


### PR DESCRIPTION
The abapGit log now collects the message ID and number. This allows you to view the long text of the message when displaying the log.

In particular, message-id and number are added for activation errors.

Also fixes a bug that showed the wrong long text, if the message id of an exception was longer than 2 characters.

Example:

![image](https://github.com/user-attachments/assets/d03a8db6-3bad-454e-803f-a10b6383682b)
