### PR TITLE
Fix indent of `<pre>` tags in HTML

### DIFF
--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -48,6 +48,7 @@ CLASS zcl_abapgit_html DEFINITION
         within_style    TYPE abap_bool,
         within_js       TYPE abap_bool,
         within_textarea TYPE abap_bool,
+        within_pre      TYPE abap_bool,
         indent          TYPE i,
         indent_str      TYPE string,
       END OF ty_indent_context .
@@ -59,6 +60,8 @@ CLASS zcl_abapgit_html DEFINITION
         script_close   TYPE abap_bool,
         textarea_open  TYPE abap_bool,
         textarea_close TYPE abap_bool,
+        pre_open       TYPE abap_bool,
+        pre_close      TYPE abap_bool,
         tag_close      TYPE abap_bool,
         curly_close    TYPE abap_bool,
         openings       TYPE i,
@@ -85,7 +88,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
+CLASS zcl_abapgit_html IMPLEMENTATION.
 
 
   METHOD checkbox.
@@ -120,10 +123,6 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD set_debug_mode.
-    gv_debug_mode = iv_mode.
-  ENDMETHOD.
-
   METHOD create.
     CREATE OBJECT ri_instance TYPE zcl_abapgit_html.
     IF iv_initial_chunk IS NOT INITIAL.
@@ -134,11 +133,11 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
 
   METHOD icon.
 
-    DATA: lv_hint       TYPE string,
-          lv_name       TYPE string,
-          lv_color      TYPE string,
-          lv_class      TYPE string,
-          lv_onclick    TYPE string.
+    DATA: lv_hint    TYPE string,
+          lv_name    TYPE string,
+          lv_color   TYPE string,
+          lv_class   TYPE string,
+          lv_onclick TYPE string.
 
     SPLIT iv_name AT '/' INTO lv_name lv_color.
 
@@ -178,6 +177,17 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       cs_context-within_textarea = abap_false.
       RETURN.
     ELSEIF cs_context-within_textarea = abap_true.
+      RETURN.
+    ENDIF.
+
+    " No indent for pre tags
+    IF ls_study-pre_open = abap_true.
+      cs_context-within_pre = abap_true.
+      RETURN.
+    ELSEIF ls_study-pre_close = abap_true.
+      cs_context-within_pre = abap_false.
+      RETURN.
+    ELSEIF cs_context-within_pre = abap_true.
       RETURN.
     ENDIF.
 
@@ -236,6 +246,11 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       CLEAR rs_data_attr.
     ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD set_debug_mode.
+    gv_debug_mode = iv_mode.
   ENDMETHOD.
 
 
@@ -306,6 +321,16 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       FIND FIRST OCCURRENCE OF '</TEXTAREA' IN lv_line.
       IF sy-subrc > 0. " Not found
         rs_result-textarea_open = abap_true.
+      ENDIF.
+    ENDIF.
+
+    " Pre (same assumptions as above)
+    IF is_context-within_pre = abap_true AND lv_len >= 5 AND lv_line(5) = '</PRE'.
+      rs_result-pre_close = abap_true.
+    ELSEIF is_context-within_pre = abap_false AND lv_len >= 4 AND lv_line(4) = '<PRE'.
+      FIND FIRST OCCURRENCE OF '</PRE' IN lv_line.
+      IF sy-subrc > 0. " Not found
+        rs_result-pre_open = abap_true.
       ENDIF.
     ENDIF.
 
@@ -564,10 +589,10 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
     DATA lv_close_tag TYPE string.
     DATA ls_data_attr LIKE LINE OF it_data_attrs.
 
-    DATA: lv_class TYPE string,
-          lv_id    TYPE string,
+    DATA: lv_class     TYPE string,
+          lv_id        TYPE string,
           lv_data_attr TYPE string,
-          lv_title TYPE string.
+          lv_title     TYPE string.
 
     IF iv_id IS NOT INITIAL.
       lv_id = | id="{ iv_id }"|.

--- a/src/ui/core/zcl_abapgit_html.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.testclasses.abap
@@ -34,6 +34,8 @@ CLASS ltcl_html DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
       indent3 FOR TESTING RAISING zcx_abapgit_exception,
       indent4 FOR TESTING RAISING zcx_abapgit_exception,
       indent5 FOR TESTING RAISING zcx_abapgit_exception,
+      indent6 FOR TESTING RAISING zcx_abapgit_exception,
+      indent7 FOR TESTING RAISING zcx_abapgit_exception,
       style1  FOR TESTING RAISING zcx_abapgit_exception.
 
     METHODS:
@@ -129,6 +131,59 @@ CLASS ltcl_html IMPLEMENTATION.
     mo_html->render( ).
 
   ENDMETHOD.
+
+  METHOD indent6.
+
+    " Content of textarea must not be indented
+    DATA lv_exp TYPE string.
+
+    mo_html->add( '<td>' ).
+    mo_html->add( '<textarea name="body" rows="10" cols="72">' ).
+    mo_html->add( 'Some default' ).
+    mo_html->add( 'content' ).
+    mo_html->add( '</textarea>' ).
+    mo_html->add( '</td>' ).
+
+    lv_exp = '<td>' && cl_abap_char_utilities=>newline &&
+             '<textarea name="body" rows="10" cols="72">' && cl_abap_char_utilities=>newline &&
+             'Some default' && cl_abap_char_utilities=>newline &&
+             'content' && cl_abap_char_utilities=>newline &&
+             '</textarea>' && cl_abap_char_utilities=>newline &&
+             '</td>'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_html->render( )
+      exp = lv_exp ).
+
+  ENDMETHOD.
+
+  METHOD indent7.
+
+    " Content of pre tag must not be indented
+    DATA lv_exp TYPE string.
+
+    mo_html->add( '<td>' ).
+    mo_html->add( '<pre>' ).
+    mo_html->add( 'Do not change' ).
+    mo_html->add( '  the indent' ).
+    mo_html->add( '    here' ).
+    mo_html->add( '</pre>' ).
+    mo_html->add( '</td>' ).
+
+    lv_exp = '<td>' && cl_abap_char_utilities=>newline &&
+             '<pre>' && cl_abap_char_utilities=>newline &&
+             'Do not change' && cl_abap_char_utilities=>newline &&
+             '  the indent' && cl_abap_char_utilities=>newline &&
+             '    here' && cl_abap_char_utilities=>newline &&
+             '</pre>' && cl_abap_char_utilities=>newline &&
+             '</td>'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_html->render( )
+      exp = lv_exp ).
+
+  ENDMETHOD.
+
 
   METHOD style1.
 


### PR DESCRIPTION
`<pre>...</pre>` sections do not render correctly since the HTML is indented, which leads to extra whitespace.

abapGit is not impacted but tooling on top of abapGit is.

Before:

![image](https://github.com/user-attachments/assets/098c66af-7e0f-4aa4-af56-04635b66902b)

After:

![image](https://github.com/user-attachments/assets/be1fc1d2-094a-4a4d-bb43-362e1818f6c1)
