### PR TITLE
Remove need to `parallel_generators` server group

### DIFF
--- a/src/env/zcl_abapgit_abap_language_vers.clas.testclasses.abap
+++ b/src/env/zcl_abapgit_abap_language_vers.clas.testclasses.abap
@@ -42,6 +42,8 @@ CLASS lcl_environment IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_environment~init_parallel_processing.
   ENDMETHOD.
+  METHOD zif_abapgit_environment~check_parallel_processing.
+  ENDMETHOD.
 
 ENDCLASS.
 

--- a/src/env/zif_abapgit_environment.intf.abap
+++ b/src/env/zif_abapgit_environment.intf.abap
@@ -41,7 +41,7 @@ INTERFACE zif_abapgit_environment
       VALUE(rv_free_work_processes) TYPE i.
   METHODS check_parallel_processing
     IMPORTING
-      iv_group         TYPE clike
+      iv_group          TYPE clike
     RETURNING
       VALUE(rv_checked) TYPE abap_bool.
   METHODS get_available_user_sessions

--- a/src/env/zif_abapgit_environment.intf.abap
+++ b/src/env/zif_abapgit_environment.intf.abap
@@ -39,6 +39,11 @@ INTERFACE zif_abapgit_environment
       iv_group                      TYPE clike
     RETURNING
       VALUE(rv_free_work_processes) TYPE i.
+  METHODS check_parallel_processing
+    IMPORTING
+      iv_group         TYPE clike
+    RETURNING
+      VALUE(rv_checked) TYPE abap_bool.
   METHODS get_available_user_sessions
     RETURNING
       VALUE(rv_sessions) TYPE i.

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -99,6 +99,11 @@ CLASS zcl_abapgit_serialize DEFINITION
         VALUE(ct_files) TYPE zif_abapgit_definitions=>ty_files_item_tt
       RAISING
         zcx_abapgit_exception .
+    METHODS determine_rfc_server_group
+      RETURNING
+        VALUE(rv_group) TYPE rzlli_apcl
+      RAISING
+        zcx_abapgit_exception.
     METHODS determine_max_processes
       IMPORTING
         !iv_force_sequential TYPE abap_bool DEFAULT abap_false
@@ -255,11 +260,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
   METHOD constructor.
 
-    DATA li_exit TYPE REF TO zif_abapgit_exit.
-
-    mv_group = 'parallel_generators'.
-    li_exit = zcl_abapgit_exit=>get_instance( ).
-    li_exit->change_rfc_server_group( CHANGING cv_group = mv_group ).
+    mv_group = determine_rfc_server_group( ).
 
     mo_dot_abapgit = io_dot_abapgit.
     ms_local_settings = is_local_settings.
@@ -330,6 +331,29 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
     ENDIF.
 
     ASSERT rv_processes >= 1.
+
+  ENDMETHOD.
+
+
+  METHOD determine_rfc_server_group.
+
+    DATA:
+      li_exit   TYPE REF TO zif_abapgit_exit,
+      lv_exists TYPE abap_bool.
+
+    " According to SAP Note 3215918 it's recommended NOT to use this group anymore.
+    " However, we keep it for compatibility. If it does not exist, we switch to the
+    " recommended DEFAULT behaviour.
+    rv_group = 'parallel_generators'.
+
+    li_exit = zcl_abapgit_exit=>get_instance( ).
+    li_exit->change_rfc_server_group( CHANGING cv_group = rv_group ).
+
+    " Check if RFC server group exists and fallback to the default
+    lv_exists = zcl_abapgit_factory=>get_environment( )->check_parallel_processing( rv_group ).
+    IF lv_exists = abap_false.
+      rv_group = ''.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -495,7 +519,6 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
     rv_result = boolc( zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_false
                    AND zcl_abapgit_persist_factory=>get_settings( )->read( )->get_parallel_proc_disabled( ) = abap_false
-                   AND mv_group IS NOT INITIAL
                    " The function module below should always exist here as is_merged evaluated to false above.
                    " It does however not exist in the transpiled version which then causes unit tests to fail.
                    " Therefore the check needs to stay.
@@ -557,6 +580,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
     DO.
       lv_task = |{ iv_task }-{ sy-index }|.
+      " An initial server group is handled like DEFAULT meaning all instances are used
       CALL FUNCTION 'Z_ABAPGIT_SERIALIZE_PARALLEL'
         STARTING NEW TASK lv_task
         DESTINATION IN GROUP mv_group

--- a/src/objects/core/zcl_abapgit_serialize.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.testclasses.abap
@@ -1,5 +1,6 @@
 CLASS ltcl_determine_max_processes DEFINITION DEFERRED.
-CLASS zcl_abapgit_serialize DEFINITION LOCAL FRIENDS ltcl_determine_max_processes.
+CLASS ltcl_determine_server_group DEFINITION DEFERRED.
+CLASS zcl_abapgit_serialize DEFINITION LOCAL FRIENDS ltcl_determine_max_processes ltcl_determine_server_group.
 
 CLASS ltd_settings DEFINITION FINAL FOR TESTING
   DURATION SHORT
@@ -67,6 +68,9 @@ CLASS ltd_environment DEFINITION FINAL FOR TESTING
       zif_abapgit_environment.
 
     METHODS:
+      set_server_group
+        IMPORTING iv_group TYPE rzlli_apcl,
+
       set_is_merged
         IMPORTING iv_is_merged TYPE abap_bool,
 
@@ -78,6 +82,7 @@ CLASS ltd_environment DEFINITION FINAL FOR TESTING
 
   PRIVATE SECTION.
     DATA:
+      mv_group               TYPE rzlli_apcl,
       mv_is_merged           TYPE abap_bool,
       mv_available_sessions  TYPE i,
       mv_free_work_processes TYPE i.
@@ -123,6 +128,14 @@ CLASS ltd_environment IMPLEMENTATION.
     rv_free_work_processes = mv_free_work_processes.
   ENDMETHOD.
 
+  METHOD zif_abapgit_environment~check_parallel_processing.
+    rv_checked = boolc( iv_group = mv_group ).
+  ENDMETHOD.
+
+  METHOD set_server_group.
+    mv_group = iv_group.
+  ENDMETHOD.
+
   METHOD set_is_merged.
     mv_is_merged = iv_is_merged.
   ENDMETHOD.
@@ -147,12 +160,16 @@ CLASS ltd_exit DEFINITION FINAL FOR TESTING
       zif_abapgit_exit.
 
     METHODS:
+      set_server_group
+        IMPORTING iv_group TYPE rzlli_apcl,
+
       set_max_parallel_processes
         IMPORTING
           iv_max_parallel_processes TYPE i.
 
   PRIVATE SECTION.
     DATA:
+      mv_group                  TYPE rzlli_apcl,
       mv_max_parallel_processes TYPE i.
 
 ENDCLASS.
@@ -188,6 +205,9 @@ CLASS ltd_exit IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_abapgit_exit~change_rfc_server_group.
+    IF mv_group IS NOT INITIAL.
+      cv_group = mv_group.
+    ENDIF.
   ENDMETHOD.
 
   METHOD zif_abapgit_exit~change_supported_data_objects.
@@ -241,8 +261,116 @@ CLASS ltd_exit IMPLEMENTATION.
   METHOD zif_abapgit_exit~wall_message_repo.
   ENDMETHOD.
 
+  METHOD set_server_group.
+    mv_group = iv_group.
+  ENDMETHOD.
+
   METHOD set_max_parallel_processes.
     mv_max_parallel_processes = iv_max_parallel_processes.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltcl_determine_server_group DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
+
+  PRIVATE SECTION.
+    DATA:
+      mo_cut                TYPE REF TO zcl_abapgit_serialize,
+      mo_environment_double TYPE REF TO ltd_environment,
+      mo_exit               TYPE REF TO ltd_exit,
+      mv_act_group          TYPE rzlli_apcl.
+
+    METHODS:
+      setup,
+
+      default_server_group FOR TESTING RAISING zcx_abapgit_exception,
+      legacy_server_group FOR TESTING RAISING zcx_abapgit_exception,
+      exit_server_group FOR TESTING RAISING zcx_abapgit_exception,
+      exit_not_exist_server_group FOR TESTING RAISING zcx_abapgit_exception,
+
+      teardown,
+
+      given_db_server_group
+        IMPORTING
+          iv_group TYPE rzlli_apcl,
+
+      given_exit_chg_server_group
+        IMPORTING
+          iv_group TYPE rzlli_apcl,
+
+      when_determine_server_group
+        RAISING
+          zcx_abapgit_exception,
+
+      then_we_shd_have_server_group
+        IMPORTING
+          iv_exp_group TYPE rzlli_apcl.
+
+ENDCLASS.
+
+CLASS ltcl_determine_server_group IMPLEMENTATION.
+
+  METHOD setup.
+
+    CREATE OBJECT mo_environment_double.
+    zcl_abapgit_injector=>set_environment( mo_environment_double ).
+
+    CREATE OBJECT mo_exit.
+    zcl_abapgit_injector=>set_exit( mo_exit ).
+
+    TRY.
+        CREATE OBJECT mo_cut.
+      CATCH zcx_abapgit_exception.
+        cl_abap_unit_assert=>fail( 'Error creating serializer' ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD teardown.
+    CLEAR: mo_cut->mv_group.
+  ENDMETHOD.
+
+  METHOD default_server_group.
+    when_determine_server_group( ).
+    then_we_shd_have_server_group( '' ).
+  ENDMETHOD.
+
+  METHOD legacy_server_group.
+    given_db_server_group( 'parallel_generators' ).
+    when_determine_server_group( ).
+    then_we_shd_have_server_group( 'parallel_generators' ).
+  ENDMETHOD.
+
+  METHOD exit_server_group.
+    given_db_server_group( 'my_group' ).
+    given_exit_chg_server_group( 'my_group' ).
+    when_determine_server_group( ).
+    then_we_shd_have_server_group( 'my_group' ).
+  ENDMETHOD.
+
+  METHOD exit_not_exist_server_group.
+    given_exit_chg_server_group( 'my_servers' ).
+    when_determine_server_group( ).
+    then_we_shd_have_server_group( '' ).
+  ENDMETHOD.
+
+  METHOD given_db_server_group.
+    mo_environment_double->set_server_group( iv_group ).
+  ENDMETHOD.
+
+  METHOD given_exit_chg_server_group.
+    mo_exit->set_server_group( iv_group ).
+  ENDMETHOD.
+
+  METHOD when_determine_server_group.
+    mv_act_group = mo_cut->determine_rfc_server_group( ).
+  ENDMETHOD.
+
+  METHOD then_we_shd_have_server_group.
+    cl_abap_unit_assert=>assert_equals(
+      act = mv_act_group
+      exp = iv_exp_group ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
SAP Note [3215918](https://me.sap.com/notes/3215918) - Parallel RFC group "default" replacing group "parallel_generators"

This change removes the need to maintain the `parallel_generators` server group. The developer version of abapGit will now default to parallel processing (when activated in your abapGit settings). 

The option to set a server group via exit remains the same.

Checks that the server group exists and is pointing to a valid instance have been added.

Ref #7074