### PR TITLE
Fix dump when converting `xstring` to `bintab`

### DIFF
--- a/src/utils/zcl_abapgit_convert.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_convert.clas.testclasses.abap
@@ -107,7 +107,9 @@ CLASS ltcl_convert IMPLEMENTATION.
     DATA lv_size TYPE i.
     DATA lv_xstr TYPE xstring.
 
-    lv_xstr = repeat( val = '1122334455' occ = 200 ).
+    lv_xstr = repeat(
+      val = '1122334455'
+      occ = 200 ).
 
     zcl_abapgit_convert=>xstring_to_bintab(
       EXPORTING

--- a/src/utils/zcl_abapgit_convert.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_convert.clas.testclasses.abap
@@ -19,6 +19,9 @@ CLASS ltcl_convert DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FIN
     METHODS string_to_xstring FOR TESTING RAISING zcx_abapgit_exception.
     METHODS xstring_to_bintab FOR TESTING.
     METHODS xstring_to_bintab_with_field FOR TESTING.
+    METHODS xstring_to_bintab_initial FOR TESTING.
+    METHODS xstring_to_bintab_long FOR TESTING.
+    METHODS xstring_to_bintab_exact FOR TESTING.
 
 ENDCLASS.
 
@@ -74,6 +77,87 @@ CLASS ltcl_convert IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD xstring_to_bintab_initial.
+
+    DATA lt_bintab TYPE TABLE OF w3mime.
+    DATA lv_size TYPE i.
+    DATA lv_xstr TYPE xstring.
+
+    zcl_abapgit_convert=>xstring_to_bintab(
+      EXPORTING
+        iv_xstr   = lv_xstr
+      IMPORTING
+        ev_size   = lv_size
+        et_bintab = lt_bintab ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_size
+      exp = 0 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lt_bintab )
+      exp = 0 ).
+
+  ENDMETHOD.
+
+  METHOD xstring_to_bintab_long.
+
+    DATA lt_bintab TYPE TABLE OF w3mime. " x(255)
+    DATA lv_bin LIKE LINE OF lt_bintab.
+    DATA lv_size TYPE i.
+    DATA lv_xstr TYPE xstring.
+
+    lv_xstr = repeat( val = '1122334455' occ = 200 ).
+
+    zcl_abapgit_convert=>xstring_to_bintab(
+      EXPORTING
+        iv_xstr   = lv_xstr
+      IMPORTING
+        ev_size   = lv_size
+        et_bintab = lt_bintab ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_size
+      exp = 1000 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lt_bintab )
+      exp = 4 ).
+
+    READ TABLE lt_bintab INTO lv_bin INDEX 4.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_bin-line+230(10)
+      exp = '11223344550000000000' ).
+
+  ENDMETHOD.
+
+  METHOD xstring_to_bintab_exact.
+
+    TYPES ty_line TYPE x LENGTH 5.
+    DATA lv_xdata TYPE x LENGTH 10.
+    DATA lt_bintab TYPE TABLE OF ty_line.
+    DATA lv_size TYPE i.
+
+    lv_xdata = '1122334455FFEEDDCCBB'.
+
+    " must not dump if content fits exactly into bintab
+    zcl_abapgit_convert=>xstring_to_bintab(
+      EXPORTING
+        iv_xstr   = lv_xdata
+      IMPORTING
+        ev_size   = lv_size
+        et_bintab = lt_bintab ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_size
+      exp = 10 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lt_bintab )
+      exp = 2 ).
+
+  ENDMETHOD.
 
   METHOD string_to_xstring.
 


### PR DESCRIPTION
Fixes dump `cx_sy_range_out_of_bounds` in `zcl_abapgit_convert=>xstring_to_bintab` if the `xstring` content fits exactly into the final bintab row. Adds some more tests.

Example: xstring len = 20, bintab row len 5, fills exactly 4 rows -> dump

![image](https://github.com/user-attachments/assets/6a11e2c9-c3ce-48fb-b465-5910fc6b5daa)

