### PR TITLE
Exit: Enhance any toolbar

### DIFF
--- a/src/exits/zcl_abapgit_exit.clas.abap
+++ b/src/exits/zcl_abapgit_exit.clas.abap
@@ -328,6 +328,18 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_exit~enhance_any_toolbar.
+
+    IF gi_exit IS NOT INITIAL.
+      TRY.
+          gi_exit->enhance_any_toolbar( io_menu ).
+        CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+      ENDTRY.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_exit~enhance_repo_toolbar.
 
     IF gi_exit IS NOT INITIAL.

--- a/src/exits/zif_abapgit_exit.intf.abap
+++ b/src/exits/zif_abapgit_exit.intf.abap
@@ -1,15 +1,15 @@
 INTERFACE zif_abapgit_exit PUBLIC.
 
-
   TYPES:
     BEGIN OF ty_ci_repo,
       name      TYPE string,
       clone_url TYPE string,
     END OF ty_ci_repo.
-  TYPES:
-    ty_ci_repos TYPE STANDARD TABLE OF ty_ci_repo WITH DEFAULT KEY.
-  TYPES:
-    ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY.
+
+  TYPES ty_ci_repos TYPE STANDARD TABLE OF ty_ci_repo WITH DEFAULT KEY.
+
+  TYPES ty_object_types TYPE STANDARD TABLE OF tadir-object WITH DEFAULT KEY.
+
   TYPES:
     BEGIN OF ty_class_key,
       clsname TYPE abap_classname,
@@ -25,47 +25,58 @@ INTERFACE zif_abapgit_exit PUBLIC.
       !cv_display_url TYPE csequence
     RAISING
       zcx_abapgit_exception.
+
   METHODS adjust_display_filename
     IMPORTING
       !is_repo_meta      TYPE zif_abapgit_persistence=>ty_repo
       !iv_filename       TYPE string
     RETURNING
       VALUE(rv_filename) TYPE string.
+
   METHODS allow_sap_objects
     RETURNING
       VALUE(rv_allowed) TYPE abap_bool.
+
   METHODS change_local_host
     CHANGING
       !ct_hosts TYPE zif_abapgit_definitions=>ty_string_tt.
+
   METHODS change_max_parallel_processes
     IMPORTING
       !iv_package       TYPE devclass
     CHANGING
       !cv_max_processes TYPE i.
+
   METHODS change_proxy_authentication
     IMPORTING
       !iv_repo_url             TYPE csequence
     CHANGING
       !cv_proxy_authentication TYPE abap_bool.
+
   METHODS change_proxy_port
     IMPORTING
       !iv_repo_url   TYPE csequence
     CHANGING
       !cv_proxy_port TYPE string.
+
   METHODS change_proxy_url
     IMPORTING
       !iv_repo_url  TYPE csequence
     CHANGING
       !cv_proxy_url TYPE string.
+
   METHODS change_rfc_server_group
     CHANGING
       !cv_group TYPE rzlli_apcl.
+
   METHODS change_supported_data_objects
     CHANGING
       !ct_objects TYPE zif_abapgit_data_supporter=>ty_objects.
+
   METHODS change_supported_object_types
     CHANGING
       !ct_types TYPE ty_object_types.
+
   METHODS change_tadir
     IMPORTING
       !iv_package            TYPE devclass
@@ -75,6 +86,7 @@ INTERFACE zif_abapgit_exit PUBLIC.
       !iv_only_local_objects TYPE abap_bool DEFAULT abap_false
     CHANGING
       !ct_tadir              TYPE zif_abapgit_definitions=>ty_tadir_tt.
+
   METHODS create_http_client
     IMPORTING
       !iv_url          TYPE string
@@ -82,6 +94,7 @@ INTERFACE zif_abapgit_exit PUBLIC.
       VALUE(ri_client) TYPE REF TO if_http_client
     RAISING
       zcx_abapgit_exception.
+
   METHODS custom_serialize_abap_clif
     IMPORTING
       !is_class_key    TYPE ty_class_key
@@ -90,33 +103,44 @@ INTERFACE zif_abapgit_exit PUBLIC.
       VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
     RAISING
       zcx_abapgit_exception.
+
   METHODS deserialize_postprocess
     IMPORTING
       !is_step TYPE zif_abapgit_objects=>ty_step_data
       !ii_log  TYPE REF TO zif_abapgit_log.
+
   METHODS determine_transport_request
     IMPORTING
       !io_repo              TYPE REF TO zcl_abapgit_repo
       !iv_transport_type    TYPE zif_abapgit_definitions=>ty_transport_type
     CHANGING
       !cv_transport_request TYPE trkorr.
+
+  METHODS enhance_any_toolbar
+    IMPORTING
+      !io_menu TYPE REF TO zcl_abapgit_html_toolbar.
+
   METHODS enhance_repo_toolbar
     IMPORTING
       !io_menu TYPE REF TO zcl_abapgit_html_toolbar
       !iv_key  TYPE zif_abapgit_persistence=>ty_value
       !iv_act  TYPE string.
+
   METHODS get_ci_tests
     IMPORTING
       !iv_object   TYPE tadir-object
     CHANGING
       !ct_ci_repos TYPE ty_ci_repos.
+
   METHODS get_ssl_id
     RETURNING
       VALUE(rv_ssl_id) TYPE ssfapplssl.
+
   METHODS http_client
     IMPORTING
       !iv_url    TYPE string
       !ii_client TYPE REF TO if_http_client.
+
   METHODS on_event
     IMPORTING
       !ii_event         TYPE REF TO zif_abapgit_gui_event
@@ -124,6 +148,7 @@ INTERFACE zif_abapgit_exit PUBLIC.
       VALUE(rs_handled) TYPE zif_abapgit_gui_event_handler=>ty_handling_result
     RAISING
       zcx_abapgit_exception.
+
   METHODS pre_calculate_repo_status
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
@@ -132,12 +157,14 @@ INTERFACE zif_abapgit_exit PUBLIC.
       !ct_remote    TYPE zif_abapgit_git_definitions=>ty_files_tt
     RAISING
       zcx_abapgit_exception.
+
   METHODS serialize_postprocess
     IMPORTING
       !iv_package TYPE devclass
       !ii_log     TYPE REF TO zif_abapgit_log
     CHANGING
       !ct_files   TYPE zif_abapgit_definitions=>ty_files_item_tt.
+
   METHODS validate_before_push
     IMPORTING
       !is_comment TYPE zif_abapgit_git_definitions=>ty_comment
@@ -145,9 +172,11 @@ INTERFACE zif_abapgit_exit PUBLIC.
       !io_repo    TYPE REF TO zcl_abapgit_repo_online
     RAISING
       zcx_abapgit_exception.
+
   METHODS wall_message_list
     IMPORTING
       !ii_html TYPE REF TO zif_abapgit_html.
+
   METHODS wall_message_repo
     IMPORTING
       !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo

--- a/src/objects/core/zcl_abapgit_serialize.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.testclasses.abap
@@ -231,6 +231,9 @@ CLASS ltd_exit IMPLEMENTATION.
   METHOD zif_abapgit_exit~determine_transport_request.
   ENDMETHOD.
 
+  METHOD zif_abapgit_exit~enhance_any_toolbar.
+  ENDMETHOD.
+
   METHOD zif_abapgit_exit~enhance_repo_toolbar.
   ENDMETHOD.
 

--- a/src/test/zcl_abapgit_gui_page_template.clas.abap
+++ b/src/test/zcl_abapgit_gui_page_template.clas.abap
@@ -99,7 +99,7 @@ CLASS zcl_abapgit_gui_page_template IMPLEMENTATION.
 
     " TODO: top level menu; use unique id
 
-    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-id' )->add(
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-template-id' )->add(
       iv_txt = 'Refresh'
       iv_act = c_action-refresh ).
 

--- a/src/test/zcl_abapgit_gui_page_template.clas.abap
+++ b/src/test/zcl_abapgit_gui_page_template.clas.abap
@@ -45,7 +45,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_TEMPLATE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_template IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -97,9 +97,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TEMPLATE IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    " TODO: top level menu
+    " TODO: top level menu; use unique id
 
-    ro_toolbar = zcl_abapgit_html_toolbar=>create( )->add(
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-id' )->add(
       iv_txt = 'Refresh'
       iv_act = c_action-refresh ).
 

--- a/src/ui/flow/zcl_abapgit_gui_page_flow.clas.abap
+++ b/src/ui/flow/zcl_abapgit_gui_page_flow.clas.abap
@@ -53,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_FLOW IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_flow IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -278,7 +278,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_FLOW IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-main'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-flow' ).
 
     ro_toolbar->add(
       iv_txt = 'Refresh'

--- a/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
@@ -152,7 +152,7 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
 
   METHOD settings.
 
-    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-Settings' ).
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-abapgit-settings' ).
 
     ro_menu->add(
       iv_txt = 'Global'

--- a/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_menus.clas.abap
@@ -45,7 +45,7 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
 
   METHOD advanced.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-advanced'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-advanced' ).
 
     ro_menu->add(
       iv_txt = 'Database Utility'
@@ -74,7 +74,7 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
 
   METHOD back.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-back'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-back' ).
 
     ro_menu->add(
       iv_txt = 'Back'
@@ -96,7 +96,7 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
 
   METHOD help.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-help'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-help' ).
 
     ro_menu->add(
       iv_txt = 'Tutorial'
@@ -119,7 +119,7 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
 
   METHOD repo_settings.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-repo-settings'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-repo-settings' ).
 
     ro_menu->add(
       iv_txt = 'Repository'
@@ -152,7 +152,7 @@ CLASS zcl_abapgit_gui_menus IMPLEMENTATION.
 
   METHOD settings.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-settings'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-Settings' ).
 
     ro_menu->add(
       iv_txt = 'Global'

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.abap
@@ -410,6 +410,8 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
       lo_page_menu = ms_control-page_menu_provider->get_menu( ).
     ENDIF.
 
+    zcl_abapgit_exit=>get_instance( )->enhance_any_toolbar( lo_page_menu ).
+
     lv_page_title = ms_control-page_title.
     IF ms_control-page_title_provider IS BOUND.
       lv_page_title = ms_control-page_title_provider->get_page_title( ).

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -168,7 +168,7 @@ CLASS zcl_abapgit_gui_page_codi_base IMPLEMENTATION.
 
   METHOD build_base_menu.
 
-    ro_menu = zcl_abapgit_html_toolbar=>create( )->add(
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'code-inspector' )->add(
       iv_txt = 'Re-Run'
       iv_act = c_actions-rerun ).
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -168,7 +168,7 @@ CLASS zcl_abapgit_gui_page_codi_base IMPLEMENTATION.
 
   METHOD build_base_menu.
 
-    ro_menu = zcl_abapgit_html_toolbar=>create( 'code-inspector' )->add(
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-code-inspector' )->add(
       iv_txt = 'Re-Run'
       iv_act = c_actions-rerun ).
 

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_runit.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_runit.clas.abap
@@ -248,7 +248,7 @@ CLASS zcl_abapgit_gui_page_runit IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-unit-tests' ).
 
     ro_toolbar->add(
       iv_txt = 'Re-Run'

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_whereused.clas.abap
@@ -65,7 +65,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_whereused IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -220,7 +220,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_WHEREUSED IMPLEMENTATION.
       lv_show_used_txt = 'Show Used Type'.
     ENDIF.
 
-    ro_toolbar = zcl_abapgit_html_toolbar=>create(
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-where-used'
       )->add(
         iv_txt    = lv_show_used_txt
         iv_title  = 'Show/Hide used type or object (when available)'

--- a/src/ui/pages/db/zcl_abapgit_gui_page_db.clas.abap
+++ b/src/ui/pages/db/zcl_abapgit_gui_page_db.clas.abap
@@ -595,7 +595,7 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'database-utility' ).
 
     ro_toolbar->add(
       iv_txt = 'Backup'
@@ -658,6 +658,9 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
           )->add(
             iv_txt = 'Delete'
             iv_act = |{ c_action-delete }?{ lv_action }| ).
+
+        zcl_abapgit_exit=>get_instance( )->enhance_any_toolbar( lo_toolbar ).
+
         rs_render-html = lo_toolbar->render( ).
 
     ENDCASE.

--- a/src/ui/pages/db/zcl_abapgit_gui_page_db.clas.abap
+++ b/src/ui/pages/db/zcl_abapgit_gui_page_db.clas.abap
@@ -595,7 +595,7 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'database-utility' ).
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-database-utility' ).
 
     ro_toolbar->add(
       iv_txt = 'Backup'
@@ -648,7 +648,7 @@ CLASS zcl_abapgit_gui_page_db IMPLEMENTATION.
         rs_render-css_class = 'data'.
       WHEN 'cmd'.
         lv_action  = zcl_abapgit_html_action_utils=>dbkey_encode( is_row ).
-        lo_toolbar = zcl_abapgit_html_toolbar=>create(
+        lo_toolbar = zcl_abapgit_html_toolbar=>create( 'actionbar-database-utility'
           )->add(
             iv_txt = 'Display'
             iv_act = |{ zif_abapgit_definitions=>c_action-db_display }?{ lv_action }|

--- a/src/ui/pages/db/zcl_abapgit_gui_page_db_entry.clas.abap
+++ b/src/ui/pages/db/zcl_abapgit_gui_page_db_entry.clas.abap
@@ -18,6 +18,7 @@ CLASS zcl_abapgit_gui_page_db_entry DEFINITION
         VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
       RAISING
         zcx_abapgit_exception .
+
     METHODS constructor
       IMPORTING
         !is_key       TYPE zif_abapgit_persistence=>ty_content
@@ -95,7 +96,7 @@ CLASS zcl_abapgit_gui_page_db_entry IMPLEMENTATION.
 
   METHOD build_toolbar.
 
-    CREATE OBJECT ro_toolbar.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'database-entry' ).
 
     IF mv_edit_mode = abap_true.
       ro_toolbar->add(

--- a/src/ui/pages/db/zcl_abapgit_gui_page_db_entry.clas.abap
+++ b/src/ui/pages/db/zcl_abapgit_gui_page_db_entry.clas.abap
@@ -96,7 +96,7 @@ CLASS zcl_abapgit_gui_page_db_entry IMPLEMENTATION.
 
   METHOD build_toolbar.
 
-    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'database-entry' ).
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-database-entry' ).
 
     IF mv_edit_mode = abap_true.
       ro_toolbar->add(

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -382,7 +382,7 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'advanced-data' ).
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-advanced-data' ).
 
     ro_toolbar->add( iv_txt = 'Add Via Transport'
                      iv_act = c_event-add_via_transport ).

--- a/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_data.clas.abap
@@ -97,31 +97,6 @@ ENDCLASS.
 CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
 
-  METHOD get_form_schema.
-    ro_form = zcl_abapgit_html_form=>create( iv_form_id = 'data-config' ).
-
-    ro_form->text(
-      iv_label       = 'Table'
-      iv_name        = c_id-table
-      iv_required    = abap_true
-      iv_max         = 16 ).
-
-    ro_form->checkbox(
-      iv_label = 'Skip Initial Values'
-      iv_name  = c_id-skip_initial ).
-
-    ro_form->textarea(
-      iv_label       = 'Where'
-      iv_placeholder = 'Conditions separated by newline'
-      iv_name        = c_id-where ).
-
-    ro_form->command(
-      iv_label       = 'Add'
-      iv_cmd_type    = zif_abapgit_html_form=>c_cmd_type-input_main
-      iv_action      = c_event-add ).
-  ENDMETHOD.
-
-
   METHOD add_via_transport.
 
     DATA lv_trkorr  TYPE trkorr.
@@ -297,6 +272,31 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_form_schema.
+    ro_form = zcl_abapgit_html_form=>create( iv_form_id = 'data-config' ).
+
+    ro_form->text(
+      iv_label       = 'Table'
+      iv_name        = c_id-table
+      iv_required    = abap_true
+      iv_max         = 16 ).
+
+    ro_form->checkbox(
+      iv_label = 'Skip Initial Values'
+      iv_name  = c_id-skip_initial ).
+
+    ro_form->textarea(
+      iv_label       = 'Where'
+      iv_placeholder = 'Conditions separated by newline'
+      iv_name        = c_id-where ).
+
+    ro_form->command(
+      iv_label       = 'Add'
+      iv_cmd_type    = zif_abapgit_html_form=>c_cmd_type-input_main
+      iv_action      = c_event-add ).
+  ENDMETHOD.
+
+
   METHOD render_existing.
 
     DATA lo_form TYPE REF TO zcl_abapgit_html_form.
@@ -382,7 +382,7 @@ CLASS zcl_abapgit_gui_page_data IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'advanced-data' ).
 
     ro_toolbar->add( iv_txt = 'Add Via Transport'
                      iv_act = c_event-add_via_transport ).

--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -71,7 +71,7 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
   METHOD build_toolbar.
 
-    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-debug' ).
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-debug-info' ).
 
     ro_menu->add(
       iv_txt = 'Save'

--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -71,7 +71,7 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
   METHOD build_toolbar.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-debug'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-debug' ).
 
     ro_menu->add(
       iv_txt = 'Save'

--- a/src/ui/pages/zcl_abapgit_gui_page_diff_base.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_diff_base.clas.abap
@@ -1374,7 +1374,7 @@ CLASS zcl_abapgit_gui_page_diff_base IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-main'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-diff' ).
 
     add_menu_begin( ro_toolbar ).
     add_jump_sub_menu( ro_toolbar ).

--- a/src/ui/pages/zcl_abapgit_gui_page_merge.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_merge.clas.abap
@@ -155,7 +155,7 @@ CLASS zcl_abapgit_gui_page_merge IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-merge' ).
 
     ro_toolbar->add( iv_txt = 'Merge'
                      iv_act = c_actions-merge

--- a/src/ui/pages/zcl_abapgit_gui_page_merge_res.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_merge_res.clas.abap
@@ -545,7 +545,7 @@ CLASS zcl_abapgit_gui_page_merge_res IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-merge-res' ).
 
     ro_toolbar->add( iv_txt = 'Toggle merge mode'
                      iv_act = c_actions-toggle_mode ).

--- a/src/ui/pages/zcl_abapgit_gui_page_pull.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_pull.clas.abap
@@ -63,7 +63,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_PULL IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_pull IMPLEMENTATION.
 
 
   METHOD choose_transport_request.
@@ -220,7 +220,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PULL IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-main'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-pull' ).
 
     ro_toolbar->add(
       iv_txt = 'Refresh'

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -446,7 +446,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
     DATA lo_toolbar TYPE REF TO zcl_abapgit_html_toolbar.
     DATA lo_toolbar_more_sub TYPE REF TO zcl_abapgit_html_toolbar.
 
-    CREATE OBJECT lo_toolbar EXPORTING iv_id = 'toolbar-ovp'.
+    lo_toolbar = zcl_abapgit_html_toolbar=>create( 'actionbar-repo-list' ).
 
     lo_toolbar->add(
       iv_txt      = |Pull|
@@ -511,6 +511,12 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar_more_sub->add(
+      iv_txt      = |Change Repository Package|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_change_package }{ lc_dummy_key }|
+      iv_class    = |{ lc_action_class } { lc_online_class }|
+      iv_li_class = |{ lc_action_class }| ).
+
+    lo_toolbar_more_sub->add(
       iv_txt = 'Danger'
       iv_typ = zif_abapgit_html=>c_action_type-separator ).
 
@@ -543,6 +549,8 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       io_sub      = lo_toolbar_more_sub
       iv_class    = |{ lc_action_class }|
       iv_li_class = |{ lc_action_class }| ).
+
+    zcl_abapgit_exit=>get_instance( )->enhance_any_toolbar( lo_toolbar ).
 
     ri_html = lo_toolbar->render( iv_right = abap_true ).
 
@@ -1001,7 +1009,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-main'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-repo-list' ).
 
     ro_toolbar->add(
       iv_txt = zcl_abapgit_gui_buttons=>flow( )

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -511,12 +511,6 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar_more_sub->add(
-      iv_txt      = |Change Repository Package|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_change_package }{ lc_dummy_key }|
-      iv_class    = |{ lc_action_class } { lc_online_class }|
-      iv_li_class = |{ lc_action_class }| ).
-
-    lo_toolbar_more_sub->add(
       iv_txt = 'Danger'
       iv_typ = zif_abapgit_html=>c_action_type-separator ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -201,7 +201,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -302,6 +302,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
       ro_advanced_dropdown->add( iv_txt = 'Stage by Transport'
                                  iv_act = |{ zif_abapgit_definitions=>c_action-go_stage_transport }?key={ mv_key }| ).
     ENDIF.
+
+    ro_advanced_dropdown->add( iv_txt = 'Change Repository Package'
+                               iv_act = |{ zif_abapgit_definitions=>c_action-repo_change_package }?key={ mv_key }| ).
 
     ro_advanced_dropdown->add( iv_txt = 'Quality Assurance'
                                iv_typ = zif_abapgit_html=>c_action_type-separator ).
@@ -423,7 +426,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
     DATA:
       li_log TYPE REF TO zif_abapgit_log.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-repo'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'actionbar-repo-view' ).
 
     IF mo_repo->is_offline( ) = abap_false.
       " online repo
@@ -1214,7 +1217,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-main'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-repo-view' ).
 
     ro_toolbar->add(
       iv_txt = zcl_abapgit_gui_buttons=>repo_list( )

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -303,9 +303,6 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                                  iv_act = |{ zif_abapgit_definitions=>c_action-go_stage_transport }?key={ mv_key }| ).
     ENDIF.
 
-    ro_advanced_dropdown->add( iv_txt = 'Change Repository Package'
-                               iv_act = |{ zif_abapgit_definitions=>c_action-repo_change_package }?key={ mv_key }| ).
-
     ro_advanced_dropdown->add( iv_txt = 'Quality Assurance'
                                iv_typ = zif_abapgit_html=>c_action_type-separator ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -870,7 +870,7 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
-    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-main'.
+    ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-staging' ).
 
     IF lines( ms_files-local ) > 0
     OR lines( ms_files-remote ) > 0.

--- a/src/ui/pages/zcl_abapgit_gui_page_tutorial.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_tutorial.clas.abap
@@ -30,7 +30,7 @@ CLASS zcl_abapgit_gui_page_tutorial IMPLEMENTATION.
 
   METHOD build_main_menu.
 
-    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-main'.
+    ro_menu = zcl_abapgit_html_toolbar=>create( 'toolbar-tutorial' ).
 
     ro_menu->add(
       iv_txt = zcl_abapgit_gui_buttons=>repo_list( )


### PR DESCRIPTION
This exit allows you to add your own actions to any of the toolbars in abapGit. It's also possible to rename or remove items using the exit. Each toolbar has a unique id that you can use to identify it in the exit.

Closes #7121