### PR TITLE
Fix color of selector

### DIFF
--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -512,9 +512,6 @@ table.settings_tab input:focus {
   border-color: #ddd;
   background-color: #fff;
 }
-.dialog .radio-container input[type="radio"] + label {
-  color: #808080;
-}
 .dialog .radio-container input[type="radio"]:checked + label {
   background-color: #64a8ff;
   color: #fff;


### PR DESCRIPTION
Changed the color so it does not look disabled anymore

Before:

![image](https://github.com/user-attachments/assets/294a9f2a-889b-44dd-b112-97f1149c90c3)

![image](https://github.com/user-attachments/assets/afed213f-a80b-49eb-ac9b-5ce863cc2f6c)

After:

![image](https://github.com/user-attachments/assets/538f8c70-2f2a-4c99-b076-f9fcd743f30f)

![image](https://github.com/user-attachments/assets/9b067f56-00dc-42de-abad-1f70c62da554)
