### PR TITLE
Filter nonexistent FMs from inconsistent FUGR

### DIFF
--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -537,9 +537,9 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     ENDIF.
 
     SELECT * FROM enlfdir
-      INTO TABLE @lt_enlfdir
-      WHERE area = @ms_item-obj_name
-        AND active = @abap_true
+      INTO TABLE lt_enlfdir
+      WHERE area = ms_item-obj_name
+        AND active = abap_true
       ORDER BY funcname.
 
     IF sy-subrc <> 0.

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -541,11 +541,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
       INTO TABLE lt_enlfdir
       WHERE area = ms_item-obj_name
         AND active = abap_true
-      ORDER BY funcname.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Function Group { ms_item-obj_name } not found in table ENLFDIR| ).
-    ENDIF.
+      ORDER BY funcname.   "#EC CI_SUBRC
 
     LOOP AT lt_enlfdir ASSIGNING <ls_enlfdir>.
       TRANSLATE <ls_enlfdir>-funcname TO UPPER CASE.

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -539,7 +539,8 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     SELECT * FROM enlfdir
       INTO TABLE @lt_enlfdir
       WHERE area = @ms_item-obj_name
-        AND active = @abap_true.
+        AND active = @abap_true
+      ORDER BY funcname.
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Function Group { ms_item-obj_name } not found in table ENLFDIR| ).

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -537,11 +537,12 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
+    "FM is not reliable if Function Group is inconsistent, so cross-check results (#7147)
     SELECT * FROM enlfdir
       INTO TABLE lt_enlfdir
       WHERE area = ms_item-obj_name
         AND active = abap_true
-      ORDER BY funcname.   "#EC CI_SUBRC
+      ORDER BY funcname.                                  "#EC CI_SUBRC
 
     LOOP AT lt_enlfdir ASSIGNING <ls_enlfdir>.
       TRANSLATE <ls_enlfdir>-funcname TO UPPER CASE.
@@ -549,6 +550,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
     SORT lt_enlfdir BY funcname ASCENDING.
 
+    "Remove anything not in FM attributes table
     LOOP AT rt_functab ASSIGNING <ls_functab>.
       TRANSLATE <ls_functab> TO UPPER CASE.
       lv_index = sy-tabix.

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -537,9 +537,9 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     ENDIF.
 
     SELECT * FROM enlfdir
+      INTO TABLE @lt_enlfdir
       WHERE area = @ms_item-obj_name
-        AND active = @abap_true
-      INTO TABLE @lt_enlfdir.
+        AND active = @abap_true.
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Function Group { ms_item-obj_name } not found in table ENLFDIR| ).

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -518,6 +518,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
     DATA: lv_area    TYPE rs38l-area,
           lt_enlfdir TYPE STANDARD TABLE OF enlfdir.
+    DATA lv_index TYPE i.
 
     FIELD-SYMBOLS: <ls_functab> TYPE LINE OF ty_rs38l_incl_tt,
                    <ls_enlfdir> TYPE enlfdir.
@@ -554,9 +555,10 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
     LOOP AT rt_functab ASSIGNING <ls_functab>.
       TRANSLATE <ls_functab> TO UPPER CASE.
+      lv_index = sy-tabix.
       READ TABLE lt_enlfdir WITH KEY funcname = <ls_functab>-funcname TRANSPORTING NO FIELDS.
       IF sy-subrc <> 0.
-        DELETE rt_functab INDEX sy-index.
+        DELETE rt_functab INDEX lv_index.
       ENDIF.
     ENDLOOP.
 


### PR DESCRIPTION
Function groups can be inconsistent, there are many such cases in standard SAP. If you serialise FUGR `F021` on S/4 1909 for example you will get a FM `DEBI_WRITE_DOCUMENT` which actually belongs to FUGR `FA2D`. 

The root of all evil is that `RS_FUNCTION_POOL_CONTENTS` determines the function modules in a FUGR by parsing the comments in the `L...UXX` include. Yes, really! 

So here we will now validate the list of FMs against the active FM attributes in table `ENLFDIR` and throw out anything not found. Tested for `F021`.

This validation could be further expanded by verifying FUGRs with `FUNCTION_PRUEF_ALL_FUGR` and `FUNCTION_PRUEF_ALL_TFDIR`, but that's a fair bit more work and needs a bit of thought on how to deal with inconsistencies. Maybe a todo if more FM-related issues crop up.