### PR TITLE
Staging issue when folder name is in uppercase 

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -137,7 +137,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
 
   METHOD check_selected.
@@ -154,12 +154,15 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     " Check all added files if the exist in different paths (packages) without being removed
     LOOP AT io_files->mt_entries ASSIGNING <ls_item> WHERE v = zif_abapgit_definitions=>c_method-add.
 
+      " Allow mixed case path, but check filename to lower case
       zcl_abapgit_path=>split_file_location(
         EXPORTING
           iv_fullpath = <ls_item>-k
         IMPORTING
           ev_path     = ls_file-path
           ev_filename = ls_file-filename ).
+
+      ls_file-filename = to_lower( ls_file-filename ).
 
       " Skip packages since they all have identical filenames
       IF ls_file-filename <> 'package.devc.xml'.
@@ -235,11 +238,11 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
     CREATE OBJECT lo_component
       EXPORTING
-        io_repo       = io_repo
-        iv_seed       = iv_seed
-        iv_sci_result = iv_sci_result
+        io_repo          = io_repo
+        iv_seed          = iv_seed
+        iv_sci_result    = iv_sci_result
         ii_force_refresh = ii_force_refresh
-        ii_obj_filter = ii_obj_filter.
+        ii_obj_filter    = ii_obj_filter.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title         = 'Stage'
@@ -738,12 +741,15 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
       "Ignore Files that we don't want to stage, so any errors don't stop the staging process
       WHERE v <> zif_abapgit_definitions=>c_method-skip.
 
+      " Allow mixed case path, but check filename to lower case
       zcl_abapgit_path=>split_file_location(
         EXPORTING
           iv_fullpath = <ls_item>-k
         IMPORTING
           ev_path     = ls_file-path
           ev_filename = ls_file-filename ).
+
+      ls_file-filename = to_lower( ls_file-filename ).
 
       READ TABLE ms_files-status ASSIGNING <ls_status>
         WITH TABLE KEY

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -156,7 +156,7 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
       zcl_abapgit_path=>split_file_location(
         EXPORTING
-          iv_fullpath = to_lower( <ls_item>-k )
+          iv_fullpath = <ls_item>-k
         IMPORTING
           ev_path     = ls_file-path
           ev_filename = ls_file-filename ).
@@ -740,7 +740,7 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
       zcl_abapgit_path=>split_file_location(
         EXPORTING
-          iv_fullpath = to_lower( <ls_item>-k ) " filename is lower cased
+          iv_fullpath = <ls_item>-k
         IMPORTING
           ev_path     = ls_file-path
           ev_filename = ls_file-filename ).

--- a/src/utils/zcl_abapgit_path.clas.abap
+++ b/src/utils/zcl_abapgit_path.clas.abap
@@ -27,6 +27,8 @@ CLASS zcl_abapgit_path DEFINITION
       IMPORTING iv_path            TYPE string
       RETURNING VALUE(rv_filename) TYPE string.
 
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 ENDCLASS.
 
 
@@ -125,7 +127,7 @@ CLASS ZCL_ABAPGIT_PATH IMPLEMENTATION.
       ev_filename = iv_fullpath.
     ENDIF.
 
-    ev_filename = cl_http_utility=>unescape_url( escaped = to_lower( ev_filename ) ).
+    ev_filename = cl_http_utility=>unescape_url( escaped = ev_filename ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_path.clas.abap
+++ b/src/utils/zcl_abapgit_path.clas.abap
@@ -125,7 +125,7 @@ CLASS ZCL_ABAPGIT_PATH IMPLEMENTATION.
       ev_filename = iv_fullpath.
     ENDIF.
 
-    ev_filename = cl_http_utility=>unescape_url( escaped = ev_filename ).
+    ev_filename = cl_http_utility=>unescape_url( escaped = to_lower( ev_filename ) ).
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
I have an older repo, where the code is stored in the folder /CODE/ on github. Because of adaptation in the code of abapgit I cannot stage anymore changes to repo. I don't want to change now the folder to lowercase as, in this case it will show to all people that all objects were deleted and new objects were created (instead of showing the changes only). 

![image](https://github.com/user-attachments/assets/c3c6bfde-2d8a-4f36-b348-3e65fbb1f6de)

The 3 small changes made it work for me. 
