### PR TITLE
delete obsolete objects when pulling in the bgd

### DIFF
--- a/src/background/zcl_abapgit_background_pull.clas.abap
+++ b/src/background/zcl_abapgit_background_pull.clas.abap
@@ -11,7 +11,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_background_pull IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_BACKGROUND_PULL IMPLEMENTATION.
 
 
   METHOD zif_abapgit_background~get_description.
@@ -45,6 +45,13 @@ CLASS zcl_abapgit_background_pull IMPLEMENTATION.
     lv_activation_setting = lo_settings->get_activate_wo_popup( ).
 
     lo_settings->set_activate_wo_popup( abap_true ).
+
+
+    " pass decisions to delete
+    zcl_abapgit_services_repo=>delete_unnecessary_objects(
+      io_repo   = io_repo
+      is_checks = ls_checks
+      ii_log    = ii_log ).
 
     io_repo->deserialize( is_checks = ls_checks
                           ii_log    = ii_log ).

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -69,28 +69,28 @@ CLASS zcl_abapgit_services_repo DEFINITION
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     CLASS-METHODS create_package
       IMPORTING
         !iv_prefill_package TYPE devclass OPTIONAL
       RETURNING
         VALUE(rv_package)   TYPE devclass
       RAISING
-        zcx_abapgit_exception.
-  PROTECTED SECTION.
-  PRIVATE SECTION.
-    CLASS-METHODS check_package_exists
-      IMPORTING
-        !iv_package TYPE devclass
-        !it_remote  TYPE zif_abapgit_git_definitions=>ty_files_tt
-      RAISING
-        zcx_abapgit_exception.
-
+        zcx_abapgit_exception .
     CLASS-METHODS delete_unnecessary_objects
       IMPORTING
         !io_repo   TYPE REF TO zcl_abapgit_repo
         !ii_log    TYPE REF TO zif_abapgit_log
         !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      RAISING
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CLASS-METHODS check_package_exists
+      IMPORTING
+        !iv_package TYPE devclass
+        !it_remote  TYPE zif_abapgit_git_definitions=>ty_files_tt
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS popup_decisions
@@ -118,17 +118,17 @@ CLASS zcl_abapgit_services_repo DEFINITION
         zcx_abapgit_exception .
     CLASS-METHODS raise_error_if_package_exists
       IMPORTING
-        iv_devclass TYPE devclass
+        !iv_devclass TYPE devclass
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     CLASS-METHODS check_for_restart
       IMPORTING
-        !io_repo TYPE REF TO zif_abapgit_repo.
+        !io_repo TYPE REF TO zif_abapgit_repo .
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD activate_objects.


### PR DESCRIPTION
Adding behavior to the default pull implementation of `ZIF_ABAPGIT_BACKGROUND`, `ZCL_ABAPGIT_BACKGROUND_PULL`, to delete obsolete objects.  For this, I made `ZCL_ABAPGIT_SERVICES_REPO=>DELETE_UNNECESSARY_OBJECTS()` public so it can be shared with ZCL_ABAPGIT_BACKGROUND_PULL and customers can leverage it in their own `ZIF_ABAPGIT_BACKGROUND` implementations if desired.

Fixes #7159 