### PR TITLE
Fix syntax errors in lower releases (table keys)

### DIFF
--- a/src/cts/zcl_abapgit_transport_objects.clas.abap
+++ b/src/cts/zcl_abapgit_transport_objects.clas.abap
@@ -38,7 +38,7 @@ CLASS zcl_abapgit_transport_objects IMPLEMENTATION.
 
     LOOP AT mt_transport_objects INTO ls_transport_object.
       LOOP AT it_object_statuses INTO ls_object_status
-          USING KEY sec_key
+          " USING KEY sec_key " syntax error in 754
           WHERE obj_name = ls_transport_object-obj_name
           AND obj_type = ls_transport_object-object
           AND NOT lstate IS INITIAL.

--- a/src/repo/utils/zcl_abapgit_repo_news.clas.abap
+++ b/src/repo/utils/zcl_abapgit_repo_news.clas.abap
@@ -155,7 +155,7 @@ CLASS zcl_abapgit_repo_news IMPLEMENTATION.
     ENDTRY.
 
     LOOP AT lt_remote ASSIGNING <ls_file>
-                      USING KEY file_path
+                      " USING KEY file_path " syntax error in 754
                       WHERE path = lc_log_path
                       AND ( filename CP lc_log_filename OR filename CP lc_log_filename_up ).
 


### PR DESCRIPTION
Unfortunately, lower releases don't like the secondary keys with these where clauses.

@christianguenter2 Is there a pragma to avoid the warnings in newer releases?

Regression #7169

![image](https://github.com/user-attachments/assets/8e45f067-d0f0-4285-9666-300ea849486e)
