### PR TITLE
Fix "Maximum number of GUI sessions reached"

### DIFF
--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -128,6 +128,12 @@ CLASS zcl_abapgit_serialize DEFINITION
       RETURNING
         VALUE(rv_result) TYPE abap_bool.
 
+    METHODS is_no_parallel
+      IMPORTING
+        !iv_object_type  TYPE tadir-object
+      RETURNING
+        VALUE(rv_result) TYPE abap_bool.
+
 ENDCLASS.
 
 
@@ -515,6 +521,18 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD is_no_parallel.
+
+    " Currently know object types that do not support parallel processing:
+    " ECTC/ECTD - ECATT Test Config/Data (see #7148)
+    " Should this list become longer, it should become a flag of the object type serializer
+    IF iv_object_type = 'ECTC' OR iv_object_type = 'ECTD'.
+      rv_result = abap_true.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD is_parallelization_possible.
 
     rv_result = boolc( zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_false
@@ -684,7 +702,7 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       iv_count = lv_count )->start( ).
 
     LOOP AT lt_tadir ASSIGNING <ls_tadir>.
-      IF lv_max = 1.
+      IF lv_max = 1 OR is_no_parallel( <ls_tadir>-object ) = abap_true.
         li_progress->show(
           iv_current = sy-tabix
           iv_text    = |Serialize { <ls_tadir>-obj_name }, { lv_max } thread| ).


### PR DESCRIPTION
ECATT Test Config and Data object types (`ECTC`/`ECTD`) do not support parallel serializer since they trigger user sessions by calling `cl_gui_frontend_services=>get_sapgui_workdir`. This can lead to "Maximum number of GUI sessions reached" error. 

This change processed these two object types in sequentially.

Closes #7148