### PR TITLE
Feature: Objects locked in multiple requests

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -141,6 +141,8 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
     CLASS-METHODS render_transport
       IMPORTING
         !iv_transport   TYPE trkorr
+        !iv_obj_type    TYPE zif_abapgit_definitions=>ty_repo_item-obj_type OPTIONAL
+        !iv_obj_name    TYPE zif_abapgit_definitions=>ty_repo_item-obj_name OPTIONAL
         !iv_interactive TYPE abap_bool DEFAULT abap_true
         !iv_icon_only   TYPE abap_bool DEFAULT abap_false
       RETURNING
@@ -204,7 +206,7 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         !is_item       TYPE zif_abapgit_definitions=>ty_repo_item OPTIONAL
         !iv_obj_type   TYPE zif_abapgit_definitions=>ty_repo_item-obj_type OPTIONAL
         !iv_obj_name   TYPE zif_abapgit_definitions=>ty_repo_item-obj_name OPTIONAL
-        PREFERRED PARAMETER is_item
+          PREFERRED PARAMETER is_item
       RETURNING
         VALUE(rv_html) TYPE string.
 
@@ -1278,6 +1280,10 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     lv_title = zcl_abapgit_factory=>get_cts_api( )->read_description( iv_transport ).
 
     lv_jump = |{ zif_abapgit_definitions=>c_action-jump_transport }?transport={ iv_transport }|.
+
+    IF iv_obj_type IS NOT INITIAL AND iv_obj_name IS NOT INITIAL.
+      lv_jump = lv_jump && |&type={ iv_obj_type }&name={ iv_obj_name }|.
+    ENDIF.
 
     IF iv_icon_only = abap_true.
       ri_html->add_a( iv_act   = lv_jump

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -981,7 +981,10 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
 
     ri_html->add( '<td class="transport">' ).
 
-    ri_html->add( zcl_abapgit_gui_chunk_lib=>render_transport( is_item-transport ) ).
+    ri_html->add( zcl_abapgit_gui_chunk_lib=>render_transport(
+      iv_transport = is_item-transport
+      iv_obj_type  = is_item-obj_type
+      iv_obj_name  = is_item-obj_name ) ).
 
     ri_html->add( '</td>' ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -134,6 +134,7 @@ ENDCLASS.
 
 CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
+
   METHOD constructor.
 
     DATA lv_ts TYPE timestamp.
@@ -439,7 +440,10 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ri_html->add( '</td>' ).
 
     ri_html->add( '<td class="transport">' ).
-    ri_html->add( zcl_abapgit_gui_chunk_lib=>render_transport( iv_transport ) ).
+    ri_html->add( zcl_abapgit_gui_chunk_lib=>render_transport(
+      iv_transport = iv_transport
+      iv_obj_type  = is_item-obj_type
+      iv_obj_name  = is_item-obj_name ) ).
     ri_html->add( '</td>' ).
 
     ri_html->add( '<td class="status">?</td>' ).

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -120,6 +120,8 @@ CLASS zcl_abapgit_gui_router DEFINITION
     CLASS-METHODS jump_display_transport
       IMPORTING
         !iv_transport TYPE trkorr
+        iv_obj_type   TYPE tadir-object OPTIONAL
+        iv_obj_name   TYPE tadir-obj_name OPTIONAL
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS jump_display_user
@@ -498,20 +500,38 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
   METHOD jump_display_transport.
 
     DATA:
+      ls_e071 TYPE e071,
       lv_adt_link         TYPE string,
       lv_adt_jump_enabled TYPE abap_bool.
 
     lv_adt_jump_enabled = zcl_abapgit_persist_factory=>get_settings( )->read( )->get_adt_jump_enabled( ).
-    IF lv_adt_jump_enabled = abap_true.
+    IF lv_adt_jump_enabled = abap_true AND iv_transport <> zif_abapgit_definitions=>c_multiple_transports.
       TRY.
           lv_adt_link = zcl_abapgit_adt_link=>link_transport( iv_transport ).
           zcl_abapgit_ui_factory=>get_frontend_services( )->execute( iv_document = lv_adt_link ).
+          RETURN.
         CATCH zcx_abapgit_exception.
           " Fallback if ADT link execution failed or was cancelled
-          CALL FUNCTION 'TR_DISPLAY_REQUEST'
-            EXPORTING
-              i_trkorr = iv_transport.
       ENDTRY.
+    ENDIF.
+
+    IF iv_transport = zif_abapgit_definitions=>c_multiple_transports.
+      ls_e071-pgmid    = 'R3TR'.
+      ls_e071-object   = iv_obj_type.
+      ls_e071-obj_name = iv_obj_name.
+
+      CALL FUNCTION 'TR_SHOW_OBJECT_LOCKS'
+        EXPORTING
+          iv_e071             = ls_e071
+        EXCEPTIONS
+          object_not_lockable = 1
+          empty_key           = 2
+          unknown_object      = 3
+          unallowed_locks     = 4
+          OTHERS              = 5.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
     ELSE.
       CALL FUNCTION 'TR_DISPLAY_REQUEST'
         EXPORTING
@@ -732,7 +752,10 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
 
       WHEN zif_abapgit_definitions=>c_action-jump_transport.
-        jump_display_transport( |{ ii_event->query( )->get( 'TRANSPORT' ) }| ).
+        jump_display_transport(
+          iv_transport = |{ ii_event->query( )->get( 'TRANSPORT' ) }|
+          iv_obj_type  = |{ ii_event->query( )->get( 'TYPE' ) }|
+          iv_obj_name  = |{ ii_event->query( )->get( 'NAME' ) }| ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
 
       WHEN zif_abapgit_definitions=>c_action-jump_user.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -415,4 +415,7 @@ INTERFACE zif_abapgit_definitions
       use_lxe               TYPE abap_bool,
     END OF ty_i18n_params .
   TYPES ty_trrngtrkor_tt TYPE RANGE OF trkorr.
+
+  CONSTANTS c_multiple_transports TYPE trkorr VALUE 'MULTIPLE'.
+
 ENDINTERFACE.


### PR DESCRIPTION
If an object contains several parts (`LIMU` objects), for example, a function group with includes and several functions, it's possible that changes land in different transports. In such case, abapGit would show only one of the transport requests which is misleading.

The change will show "MULTIPLE" instead of a transport number. Clicking on the link will display all involved transports requests and tasks in a popup. You can double click on the transports in the popup as well to see details.

The feature is available in the repo view as well as in staging.

Closes #2961

Test case: https://github.com/abapGit/abapGit/issues/2961#issuecomment-541340833

![image](https://github.com/user-attachments/assets/cad40185-b106-4f89-a4a7-479ab099bc3e)

![image](https://github.com/user-attachments/assets/4f3d561b-673c-4427-9da3-dd91d133d2d8)

![image](https://github.com/user-attachments/assets/8e03176f-6e5c-4d9e-9548-93f4eb733446)
