### PR TITLE
Remove http-agent from factory

### DIFF
--- a/src/git_platform/zcl_abapgit_pr_enumerator.clas.abap
+++ b/src/git_platform/zcl_abapgit_pr_enumerator.clas.abap
@@ -62,7 +62,7 @@ CLASS zcl_abapgit_pr_enumerator IMPLEMENTATION.
     DATA lv_user TYPE string.
     DATA lv_repo TYPE string.
 
-    li_agent = zcl_abapgit_factory=>get_http_agent( ).
+    li_agent = zcl_abapgit_http_agent=>create( ).
 
     FIND ALL OCCURRENCES OF REGEX 'github\.com\/([^\/]+)\/([^\/]+)'
       IN iv_repo_url

--- a/src/zcl_abapgit_factory.clas.abap
+++ b/src/zcl_abapgit_factory.clas.abap
@@ -18,9 +18,7 @@ CLASS zcl_abapgit_factory DEFINITION
         VALUE(ri_cts_api) TYPE REF TO zif_abapgit_cts_api .
     CLASS-METHODS get_default_transport
       RETURNING
-        VALUE(ri_default_transport) TYPE REF TO zif_abapgit_default_transport
-      RAISING
-        zcx_abapgit_exception.
+        VALUE(ri_default_transport) TYPE REF TO zif_abapgit_default_transport.
     CLASS-METHODS get_environment
       RETURNING
         VALUE(ri_environment) TYPE REF TO zif_abapgit_environment .

--- a/src/zcl_abapgit_factory.clas.abap
+++ b/src/zcl_abapgit_factory.clas.abap
@@ -27,9 +27,6 @@ CLASS zcl_abapgit_factory DEFINITION
     CLASS-METHODS get_longtexts
       RETURNING
         VALUE(ri_longtexts) TYPE REF TO zif_abapgit_longtexts .
-    CLASS-METHODS get_http_agent
-      RETURNING
-        VALUE(ri_http_agent) TYPE REF TO zif_abapgit_http_agent .
     CLASS-METHODS get_lxe_texts
       RETURNING
         VALUE(ri_lxe_texts) TYPE REF TO zif_abapgit_lxe_texts .
@@ -59,7 +56,6 @@ CLASS zcl_abapgit_factory DEFINITION
     CLASS-DATA gi_cts_api TYPE REF TO zif_abapgit_cts_api .
     CLASS-DATA gi_environment TYPE REF TO zif_abapgit_environment .
     CLASS-DATA gi_longtext TYPE REF TO zif_abapgit_longtexts .
-    CLASS-DATA gi_http_agent TYPE REF TO zif_abapgit_http_agent .
     CLASS-DATA gi_lxe_texts TYPE REF TO zif_abapgit_lxe_texts .
     CLASS-DATA gi_sap_namespace TYPE REF TO zif_abapgit_sap_namespace .
     CLASS-DATA gi_sap_report TYPE REF TO zif_abapgit_sap_report.
@@ -107,17 +103,6 @@ CLASS zcl_abapgit_factory IMPLEMENTATION.
     ENDIF.
 
     ri_function_module = gi_function_module.
-
-  ENDMETHOD.
-
-
-  METHOD get_http_agent.
-
-    IF gi_http_agent IS INITIAL.
-      gi_http_agent = zcl_abapgit_http_agent=>create( ).
-    ENDIF.
-
-    ri_http_agent = gi_http_agent.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_injector.clas.abap
+++ b/src/zcl_abapgit_injector.clas.abap
@@ -21,9 +21,6 @@ CLASS zcl_abapgit_injector DEFINITION
     CLASS-METHODS set_longtexts
       IMPORTING
         !ii_longtexts TYPE REF TO zif_abapgit_longtexts .
-    CLASS-METHODS set_http_agent
-      IMPORTING
-        !ii_http_agent TYPE REF TO zif_abapgit_http_agent .
     CLASS-METHODS set_lxe_texts
       IMPORTING
         !ii_lxe_texts TYPE REF TO zif_abapgit_lxe_texts .
@@ -65,11 +62,6 @@ CLASS zcl_abapgit_injector IMPLEMENTATION.
 
   METHOD set_function_module.
     zcl_abapgit_factory=>gi_function_module = ii_function_module.
-  ENDMETHOD.
-
-
-  METHOD set_http_agent.
-    zcl_abapgit_factory=>gi_http_agent = ii_http_agent.
   ENDMETHOD.
 
 

--- a/test/src/zcl_abapgit_gitea.clas.abap
+++ b/test/src/zcl_abapgit_gitea.clas.abap
@@ -23,7 +23,7 @@ CLASS zcl_abapgit_gitea IMPLEMENTATION.
     DATA lv_url      TYPE string.
 
 
-    li_agent = zcl_abapgit_factory=>get_http_agent( ).
+    li_agent = zcl_abapgit_http_agent=>create( ).
 
     li_agent->global_headers( )->set(
       iv_key = 'Accept'


### PR DESCRIPTION
Using the http-agent class as singleton has side-effects (http-headers). Creating the instance from the http-agent class works just fine.

If you used this factory method somewhere else, replace it with `zcl_abapgit_http_agent=>create( )`.