### PR TITLE
Debug info: Fix exit list in standalone

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -427,11 +427,11 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
     cv_clsname = c_exit_class.
 
     DO.
-      FIND REGEX 'CLASS (.*) DEFINITION' IN TABLE ct_source SUBMATCHES cv_clsname IGNORING CASE.
+      FIND REGEX 'CLASS\s+(.*)\s+DEFINITION' IN TABLE ct_source SUBMATCHES cv_clsname IGNORING CASE.
       IF sy-subrc = 0.
         RETURN.
       ENDIF.
-      FIND REGEX 'INCLUDE (.*)\.' IN TABLE ct_source SUBMATCHES lv_include IGNORING CASE.
+      FIND REGEX 'INCLUDE\s+(.*)\s*\.' IN TABLE ct_source SUBMATCHES lv_include IGNORING CASE.
       IF sy-subrc = 0.
         TRY.
             ct_source = zcl_abapgit_factory=>get_sap_report( )->read_report( lv_include ).

--- a/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -62,6 +62,10 @@ CLASS zcl_abapgit_gui_page_debuginfo DEFINITION
         !iv_obj_name   TYPE csequence
       RETURNING
         VALUE(rv_html) TYPE string .
+    METHODS resolve_exit_include
+      CHANGING
+        !cv_clsname TYPE seoclsname
+        !ct_source  TYPE string_table.
 ENDCLASS.
 
 
@@ -187,10 +191,16 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
       " Standalone version
       lt_source = zcl_abapgit_factory=>get_sap_report( )->read_report( c_exit_standalone ).
       IF sy-subrc = 0.
+        resolve_exit_include(
+          CHANGING
+            cv_clsname = ls_class_key-clsname
+            ct_source  = lt_source ).
         ri_html->add( |<div>User exits are active (include { get_jump_object(
           iv_obj_type = 'PROG'
           iv_obj_name = c_exit_standalone ) } found)</div><br>| ).
-        ri_html->add( render_exit_info_methods( lt_source ) ).
+        ri_html->add( render_exit_info_methods(
+                        it_source  = lt_source
+                        iv_clsname = to_upper( ls_class_key-clsname ) ) ).
       ELSE.
         ri_html->add( |<div>No user exits implemented (include { c_exit_standalone } not found)</div><br>| ).
       ENDIF.
@@ -406,6 +416,32 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
     rv_html = rv_html && |</tbody></table>|.
     rv_html = rv_html && |<br>|.
+
+  ENDMETHOD.
+
+
+  METHOD resolve_exit_include.
+
+    DATA lv_include TYPE progname.
+
+    cv_clsname = c_exit_class.
+
+    DO.
+      FIND REGEX 'CLASS (.*) DEFINITION' IN TABLE ct_source SUBMATCHES cv_clsname IGNORING CASE.
+      IF sy-subrc = 0.
+        RETURN.
+      ENDIF.
+      FIND REGEX 'INCLUDE (.*)\.' IN TABLE ct_source SUBMATCHES lv_include IGNORING CASE.
+      IF sy-subrc = 0.
+        TRY.
+            ct_source = zcl_abapgit_factory=>get_sap_report( )->read_report( lv_include ).
+          CATCH zcx_abapgit_exception.
+            RETURN. " rely on original include
+        ENDTRY.
+      ELSE.
+        RETURN.
+      ENDIF.
+    ENDDO.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Resolve include that is used in the exit for the standalone version.

Example:

![image](https://github.com/user-attachments/assets/1e694fc4-25ca-4e1c-a764-10d77f784ed0)

Before:

![image](https://github.com/user-attachments/assets/1c530e1e-85e3-44a7-9c31-a5b98325d106)

After:

![image](https://github.com/user-attachments/assets/01d84108-fb97-49d5-a389-845d5ae62363)
