### PR TITLE
Fix `zcl_abapgit_serializer` test

### DIFF
--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -278,9 +278,11 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
       ms_i18n_params-main_language_only = is_local_settings-main_language_only.
     ENDIF.
 
-    CREATE OBJECT mo_abap_language_version
-      EXPORTING
-        io_dot_abapgit = mo_dot_abapgit.
+    IF mo_dot_abapgit IS NOT INITIAL.
+      CREATE OBJECT mo_abap_language_version
+        EXPORTING
+          io_dot_abapgit = mo_dot_abapgit.
+    ENDIF.
 
   ENDMETHOD.
 


### PR DESCRIPTION
If ABAP Language Feature is turned on, one test was failing:

![image](https://github.com/user-attachments/assets/b79b2fbe-9d0c-4bc8-9928-105d0533c8f1)
