### PR TITLE
New error handling for not supported object types

### DIFF
--- a/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_common_aff.clas.abap
@@ -30,7 +30,7 @@ CLASS zcl_abapgit_object_common_aff DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
     TYPES: BEGIN OF ty_extension_mapper_pair,
@@ -106,7 +106,7 @@ CLASS zcl_abapgit_object_common_aff IMPLEMENTATION.
     ENDTRY.
 
     IF lv_is_supported IS INITIAL.
-      zcx_abapgit_exception=>raise( |Object type { is_item-obj_type } is not supported by this system| ).
+      RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDIF.
 
   ENDMETHOD.

--- a/src/objects/aff/zcl_abapgit_object_smbc.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_smbc.clas.abap
@@ -6,13 +6,44 @@ CLASS zcl_abapgit_object_smbc DEFINITION
 
   PUBLIC SECTION.
     METHODS zif_abapgit_object~changed_by REDEFINITION.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_SMBC IMPLEMENTATION.
+CLASS zcl_abapgit_object_smbc IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lo_handler TYPE REF TO object,
+          lo_db_api  TYPE REF TO object,
+          lr_data    TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CREATE OBJECT lo_handler TYPE ('CL_SMBC_AFF_OBJECT_HANDLER').
+        CREATE OBJECT lo_db_api TYPE ('CL_MBC_BUSINESS_CONFIG_DB').
+        CREATE DATA lr_data TYPE ('SMBC_CONFIG').
+      CATCH cx_sy_create_object_error
+            cx_sy_create_data_error.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -24,15 +55,12 @@ CLASS ZCL_ABAPGIT_OBJECT_SMBC IMPLEMENTATION.
 
     FIELD-SYMBOLS: <ls_smbc_config>     TYPE any,
                    <lv_smbc_changed_by> TYPE any.
-    TRY.
-        CREATE OBJECT lo_handler TYPE ('CL_SMBC_AFF_OBJECT_HANDLER').
-        CREATE OBJECT lo_db_api TYPE ('CL_MBC_BUSINESS_CONFIG_DB').
-        CREATE DATA lr_data TYPE ('SMBC_CONFIG').
-        ASSIGN lr_data->* TO <ls_smbc_config>.
-      CATCH cx_sy_create_object_error
-            cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( 'SMBC not supported' ).
-    ENDTRY.
+
+    CREATE OBJECT lo_handler TYPE ('CL_SMBC_AFF_OBJECT_HANDLER').
+    CREATE OBJECT lo_db_api TYPE ('CL_MBC_BUSINESS_CONFIG_DB').
+    CREATE DATA lr_data TYPE ('SMBC_CONFIG').
+    ASSIGN lr_data->* TO <ls_smbc_config>.
+
     lv_technical_id = ms_item-obj_name.
     CALL METHOD lo_db_api->('IF_MBC_BUSINESS_CONFIG_DB~READ')
       EXPORTING

--- a/src/objects/aff/zcl_abapgit_object_uiad.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_uiad.clas.abap
@@ -8,13 +8,44 @@ CLASS zcl_abapgit_object_uiad DEFINITION
 
     METHODS zif_abapgit_object~changed_by
         REDEFINITION .
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_UIAD IMPLEMENTATION.
+CLASS zcl_abapgit_object_uiad IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lo_db_api TYPE REF TO object,
+          lr_data   TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CALL METHOD ('CL_SUI_UIAD_DB_ACCESS')=>('GET_INSTANCE')
+          RECEIVING
+            ro_instance = lo_db_api.
+        CREATE DATA lr_data TYPE ('CL_BLUE_AFF_WB_ACCESS=>TY_METADATA').
+      CATCH cx_sy_dyn_call_error
+            cx_sy_create_data_error.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -27,16 +58,11 @@ CLASS ZCL_ABAPGIT_OBJECT_UIAD IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_metadata>   TYPE any,
                    <lv_changed_by> TYPE any.
 
-    TRY.
-        CALL METHOD ('CL_SUI_UIAD_DB_ACCESS')=>('GET_INSTANCE')
-          RECEIVING
-            ro_instance = lo_db_api.
-        CREATE DATA lr_data TYPE ('CL_BLUE_AFF_WB_ACCESS=>TY_METADATA').
-        ASSIGN lr_data->* TO <ls_metadata>.
-      CATCH cx_sy_create_object_error
-              cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( 'Object UIAD not supported' ).
-    ENDTRY.
+    CALL METHOD ('CL_SUI_UIAD_DB_ACCESS')=>('GET_INSTANCE')
+      RECEIVING
+        ro_instance = lo_db_api.
+    CREATE DATA lr_data TYPE ('CL_BLUE_AFF_WB_ACCESS=>TY_METADATA').
+    ASSIGN lr_data->* TO <ls_metadata>.
 
     TRY.
         lv_object_key = ms_item-obj_name.
@@ -46,7 +72,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UIAD IMPLEMENTATION.
             iv_version  = 'A'
             iv_language = mv_language
           RECEIVING
-            rs_metadata      = <ls_metadata>.
+            rs_metadata = <ls_metadata>.
 
         ASSIGN COMPONENT 'CHANGED_BY' OF STRUCTURE <ls_metadata> TO <lv_changed_by>.
         rv_user = <lv_changed_by>.

--- a/src/objects/aff/zcl_abapgit_object_uipg.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_uipg.clas.abap
@@ -8,13 +8,44 @@ CLASS zcl_abapgit_object_uipg DEFINITION
 
     METHODS zif_abapgit_object~changed_by
         REDEFINITION .
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_UIPG IMPLEMENTATION.
+CLASS zcl_abapgit_object_uipg IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lo_db_api TYPE REF TO object,
+          lr_data   TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CALL METHOD ('/UI2/CL_UIPG_DB_ACCESS')=>('GET_INSTANCE')
+          RECEIVING
+            ro_instance = lo_db_api.
+        CREATE DATA lr_data TYPE ('CL_BLUE_AFF_WB_ACCESS=>TY_METADATA').
+      CATCH cx_sy_dyn_call_error
+            cx_sy_create_data_error.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.

--- a/src/objects/aff/zcl_abapgit_object_uist.clas.abap
+++ b/src/objects/aff/zcl_abapgit_object_uist.clas.abap
@@ -8,13 +8,42 @@ CLASS zcl_abapgit_object_uist DEFINITION
 
     METHODS zif_abapgit_object~changed_by
         REDEFINITION .
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_UIST IMPLEMENTATION.
+CLASS zcl_abapgit_object_uist IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lo_db_api TYPE REF TO object,
+          lr_data   TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CREATE OBJECT lo_db_api TYPE ('/UI2/CL_UIST_SVAL_SQL').
+        CREATE DATA lr_data TYPE ('CL_BLUE_AFF_WB_ACCESS=>TY_METADATA').
+      CATCH cx_sy_create_object_error
+            cx_sy_create_data_error.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.

--- a/src/objects/zcl_abapgit_object_aifc.clas.abap
+++ b/src/objects/zcl_abapgit_object_aifc.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_aifc DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
     TYPES:
@@ -112,7 +112,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD authorization_check.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
     DATA: lx_root TYPE REF TO cx_root.
 
     rv_success = abap_false.
@@ -121,9 +120,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
           RECEIVING
             rv_success = rv_success.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise_with_text( lx_root ).
     ENDTRY.
@@ -147,7 +143,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD compress_interface.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
     DATA: lx_root TYPE REF TO cx_root.
 
     TRY.
@@ -157,9 +152,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
           RECEIVING
             rv_success = rv_success.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise_with_text( lx_root ).
     ENDTRY.
@@ -183,7 +175,7 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
             rr_abapgit_aifc_util = mo_abapgit_util.
 
       CATCH cx_sy_dyn_call_error INTO lx_exc_ref.
-        zcx_abapgit_exception=>raise( 'AIFC not supported' ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
   ENDMETHOD.
 
@@ -198,7 +190,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
     FIELD-SYMBOLS <ls_table> TYPE any.
     FIELD-SYMBOLS: <lv_value> TYPE any.
 
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
     DATA: lx_root TYPE REF TO cx_root.
 
     lr_structdescr ?= cl_abap_typedescr=>describe_by_name( p_name = '/AIF/T_FINF' ).
@@ -241,9 +232,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
               rv_success = rv_success.
         ENDIF.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise_with_text( lx_root ).
     ENDTRY.
@@ -251,7 +239,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD get_content_compress.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
     DATA: lx_root TYPE REF TO cx_root.
     DATA: lo_log TYPE REF TO object.
 
@@ -267,9 +254,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
             iv_package = iv_package
             iv_depl_id = ms_icd_data_key-depl_scenario.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise_with_text( lx_root ).
     ENDTRY.
@@ -277,7 +261,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD handle_table_data.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
     DATA: lx_root TYPE REF TO cx_root.
 
     TRY.
@@ -286,9 +269,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
             iv_tabname = iv_tabname
             it_data    = it_data.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise_with_text( lx_root ).
     ENDTRY.
@@ -296,7 +276,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD validate_interface.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
     DATA: lx_root TYPE REF TO cx_root.
 
     rv_success = abap_false.
@@ -307,9 +286,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
           RECEIVING
             rv_success = rv_success.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise_with_text( lx_root ).
     ENDTRY.
@@ -317,25 +293,18 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
-    DATA lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
-
     DATA ls_icd_data_key TYPE ty_icd_data_key.
     ls_icd_data_key-depl_scenario = ms_icd_data_key-depl_scenario.
     ls_icd_data_key-ns = ms_icd_data_key-ns.
     ls_icd_data_key-ifname = ms_icd_data_key-ifname.
     ls_icd_data_key-ifver2 = ms_icd_data_key-ifver2.
 
-    TRY.
-        CALL METHOD mo_abapgit_util->('/AIF/IF_ABAPGIT_AIFC_UTIL~CHANGED_BY')
-          EXPORTING
-            is_key  = ls_icd_data_key
-          RECEIVING
-            rv_user = rv_user.
+    CALL METHOD mo_abapgit_util->('/AIF/IF_ABAPGIT_AIFC_UTIL~CHANGED_BY')
+      EXPORTING
+        is_key  = ls_icd_data_key
+      RECEIVING
+        rv_user = rv_user.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
-    ENDTRY.
   ENDMETHOD.
 
 
@@ -458,8 +427,6 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~exists.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
-
     DATA ls_icd_data_key TYPE ty_icd_data_key.
 
     ls_icd_data_key-depl_scenario = ms_icd_data_key-depl_scenario.
@@ -469,17 +436,12 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
     rv_bool = abap_false.
 
-    TRY.
-        CALL METHOD mo_abapgit_util->('/AIF/IF_ABAPGIT_AIFC_UTIL~EXISTS')
-          EXPORTING
-            is_key  = ls_icd_data_key
-          RECEIVING
-            rv_bool = rv_bool.
+    CALL METHOD mo_abapgit_util->('/AIF/IF_ABAPGIT_AIFC_UTIL~EXISTS')
+      EXPORTING
+        is_key  = ls_icd_data_key
+      RECEIVING
+        rv_bool = rv_bool.
 
-      CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-        zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                      ix_previous = lx_dyn_call_error ).
-    ENDTRY.
   ENDMETHOD.
 
 
@@ -549,9 +511,7 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~serialize.
-    DATA: lx_root TYPE REF TO cx_root.
-    DATA: lx_dyn_call_error TYPE REF TO cx_sy_dyn_call_error.
-
+    DATA lx_root TYPE REF TO cx_root.
     DATA ls_icd_data_key TYPE ty_icd_data_key.
     DATA lt_ifdata TYPE ty_table_data_t.
 
@@ -575,17 +535,11 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
         ls_icd_data_key-ifname = ms_icd_data_key-ifname.
         ls_icd_data_key-ifver2 = ms_icd_data_key-ifver2.
 
-        TRY.
-            CALL METHOD mo_abapgit_util->('/AIF/IF_ABAPGIT_AIFC_UTIL~GET_IF_DATA')
-              EXPORTING
-                is_key    = ls_icd_data_key
-              RECEIVING
-                rt_ifdata = lt_ifdata.
-
-          CATCH cx_sy_dyn_call_error INTO lx_dyn_call_error.
-            zcx_abapgit_exception=>raise( iv_text = 'AIFC not supported'
-                                          ix_previous = lx_dyn_call_error ).
-        ENDTRY.
+        CALL METHOD mo_abapgit_util->('/AIF/IF_ABAPGIT_AIFC_UTIL~GET_IF_DATA')
+          EXPORTING
+            is_key    = ls_icd_data_key
+          RECEIVING
+            rt_ifdata = lt_ifdata.
 
         LOOP AT lt_ifdata REFERENCE INTO lr_ifdata.
 
@@ -610,7 +564,7 @@ CLASS zcl_abapgit_object_aifc IMPLEMENTATION.
 
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise( iv_text = 'Serialize not possible'
-                                      ix_previous = lx_dyn_call_error ).
+                                      ix_previous = lx_root ).
     ENDTRY.
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_amsd.clas.abap
+++ b/src/objects/zcl_abapgit_object_amsd.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_amsd DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -106,7 +106,7 @@ CLASS zcl_abapgit_object_amsd IMPLEMENTATION.
         CREATE OBJECT mi_persistence TYPE ('CL_AMDP_SCHEMA_OBJECT_PERSIST').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |AMSD not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_apis.clas.abap
+++ b/src/objects/zcl_abapgit_object_apis.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_apis DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -42,7 +42,7 @@ CLASS zcl_abapgit_object_apis IMPLEMENTATION.
     TRY.
         CREATE DATA lr_data TYPE (c_model).
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |APIS not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_bdef.clas.abap
+++ b/src/objects/zcl_abapgit_object_bdef.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_bdef DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -208,7 +208,7 @@ CLASS zcl_abapgit_object_bdef IMPLEMENTATION.
         CREATE OBJECT mi_persistence TYPE ('CL_BDEF_OBJECT_PERSIST').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |BDEF not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_dcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_dcls.clas.abap
@@ -2,6 +2,14 @@ CLASS zcl_abapgit_object_dcls DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -9,6 +17,27 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_dcls IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lo_dcl TYPE REF TO object.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CALL METHOD ('CL_ACM_DCL_HANDLER_FACTORY')=>('CREATE')
+          RECEIVING
+            ro_handler = lo_dcl.
+
+      CATCH cx_sy_ref_creation.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.

--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_ddls DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
     METHODS open_adt_stob
@@ -51,7 +51,7 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
           RECEIVING
             handler = lo_ddl.
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'Object type DDLS is not supported by this system' ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_ddlx.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddlx.clas.abap
@@ -2,6 +2,14 @@ CLASS zcl_abapgit_object_ddlx DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA mi_persistence TYPE REF TO if_wb_object_persist .
@@ -23,6 +31,22 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_ddlx IMPLEMENTATION.
+
+  METHOD constructor.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        get_persistence( ).
+      CATCH zcx_abapgit_exception.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD clear_field.

--- a/src/objects/zcl_abapgit_object_drul.clas.abap
+++ b/src/objects/zcl_abapgit_object_drul.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_drul DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -130,7 +130,7 @@ CLASS zcl_abapgit_object_drul IMPLEMENTATION.
         CREATE OBJECT mi_persistence TYPE ('CL_DRUL_WB_OBJECT_PERSIST').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |DRUL not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_dtdc.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtdc.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_dtdc DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -151,7 +151,7 @@ CLASS zcl_abapgit_object_dtdc IMPLEMENTATION.
         CREATE OBJECT mi_persistence TYPE ('CL_DTDC_OBJECT_PERSIST').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |DTDC not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_ftgl.clas.abap
+++ b/src/objects/zcl_abapgit_object_ftgl.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_ftgl DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -60,7 +60,7 @@ CLASS zcl_abapgit_object_ftgl IMPLEMENTATION.
     TRY.
         CREATE DATA mr_toggle TYPE ('FTGL_S_WB_FEATURE_TOGGLE').
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( |FTGL not supported in your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_http.clas.abap
+++ b/src/objects/zcl_abapgit_object_http.clas.abap
@@ -14,7 +14,7 @@ CLASS zcl_abapgit_object_http DEFINITION
         io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -66,7 +66,7 @@ CLASS zcl_abapgit_object_http IMPLEMENTATION.
     TRY.
         CREATE DATA lr_dummy TYPE ('UCONHTTPSERVHEAD').
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'HTTP not supported' ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.
@@ -74,14 +74,10 @@ CLASS zcl_abapgit_object_http IMPLEMENTATION.
 
   METHOD zif_abapgit_object~changed_by.
 
-    TRY.
-        SELECT SINGLE changedby FROM ('UCONHTTPSERVHEAD') INTO rv_user WHERE id = ms_item-obj_name.
-        IF sy-subrc <> 0.
-          rv_user = c_user_unknown.
-        ENDIF.
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'HTTP not supported' ).
-    ENDTRY.
+    SELECT SINGLE changedby FROM ('UCONHTTPSERVHEAD') INTO rv_user WHERE id = ms_item-obj_name.
+    IF sy-subrc <> 0.
+      rv_user = c_user_unknown.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -91,14 +87,11 @@ CLASS zcl_abapgit_object_http IMPLEMENTATION.
     DATA lv_name TYPE c LENGTH 30.
 
     lv_name = ms_item-obj_name.
-    TRY.
-        CALL METHOD ('CL_UCON_API_FACTORY')=>('DELETE_HTTP_SERVICE')
-          EXPORTING
-            name     = lv_name
-            devclass = iv_package.
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'HTTP not supported' ).
-    ENDTRY.
+
+    CALL METHOD ('CL_UCON_API_FACTORY')=>('DELETE_HTTP_SERVICE')
+      EXPORTING
+        name     = lv_name
+        devclass = iv_package.
 
   ENDMETHOD.
 
@@ -211,12 +204,8 @@ CLASS zcl_abapgit_object_http IMPLEMENTATION.
 
     DATA lv_id TYPE c LENGTH 30.
 
-    TRY.
-        SELECT SINGLE id FROM ('UCONHTTPSERVHEAD') INTO lv_id WHERE id = ms_item-obj_name AND version = 'A'.
-        rv_bool = boolc( sy-subrc = 0 ).
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'HTTP not supported' ).
-    ENDTRY.
+    SELECT SINGLE id FROM ('UCONHTTPSERVHEAD') INTO lv_id WHERE id = ms_item-obj_name AND version = 'A'.
+    rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_iobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_iobj.clas.abap
@@ -2,6 +2,14 @@ CLASS zcl_abapgit_object_iobj DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
     METHODS:
@@ -16,6 +24,24 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA lr_viobj TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
+      CATCH cx_sy_create_data_error.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD clear_field.
@@ -43,12 +69,7 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
 
     lv_objna = ms_item-obj_name.
 
-    TRY.
-        CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |IOBJ is not supported on this system| ).
-    ENDTRY.
-
+    CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
     ASSIGN lr_viobj->* TO <lg_viobj>.
 
     CALL FUNCTION 'RSD_IOBJ_GET'
@@ -61,7 +82,7 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
         iobj_not_found   = 1
         illegal_input    = 2
         bct_comp_invalid = 3
-*        not_authorized   = 4 " not in lower releases
+*       not_authorized   = 4 " not in lower releases
         OTHERS           = 5.
     IF sy-subrc = 0.
       ASSIGN COMPONENT 'TSTPNM' OF STRUCTURE <lg_viobj> TO <lg_tstpnm>.
@@ -134,20 +155,16 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
       <lg_infoobject>               TYPE data,
       <lt_infoobjects>              TYPE STANDARD TABLE.
 
-    TRY.
-        CREATE DATA lr_details TYPE ('BAPI6108').
-        CREATE DATA lr_compounds TYPE STANDARD TABLE OF ('BAPI6108CM').
-        CREATE DATA lr_attributes TYPE STANDARD TABLE OF ('BAPI6108AT').
-        CREATE DATA lr_navigationattributes TYPE STANDARD TABLE OF ('BAPI6108AN').
-        CREATE DATA lr_atrnavinfoprovider TYPE STANDARD TABLE OF ('BAPI6108NP').
-        CREATE DATA lr_hierarchycharacteristics TYPE STANDARD TABLE OF ('BAPI6108HC').
-        CREATE DATA lr_elimination TYPE STANDARD TABLE OF ('BAPI6108IE').
-        CREATE DATA lr_hanafieldsmapping TYPE STANDARD TABLE OF ('BAPI6108HANA_MAP').
-        CREATE DATA lr_xxlattributes TYPE STANDARD TABLE OF ('BAPI6108ATXXL').
-        CREATE DATA lr_infoobj TYPE STANDARD TABLE OF ('BAPI6108').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |IOBJ is not supported on this system| ).
-    ENDTRY.
+    CREATE DATA lr_details TYPE ('BAPI6108').
+    CREATE DATA lr_compounds TYPE STANDARD TABLE OF ('BAPI6108CM').
+    CREATE DATA lr_attributes TYPE STANDARD TABLE OF ('BAPI6108AT').
+    CREATE DATA lr_navigationattributes TYPE STANDARD TABLE OF ('BAPI6108AN').
+    CREATE DATA lr_atrnavinfoprovider TYPE STANDARD TABLE OF ('BAPI6108NP').
+    CREATE DATA lr_hierarchycharacteristics TYPE STANDARD TABLE OF ('BAPI6108HC').
+    CREATE DATA lr_elimination TYPE STANDARD TABLE OF ('BAPI6108IE').
+    CREATE DATA lr_hanafieldsmapping TYPE STANDARD TABLE OF ('BAPI6108HANA_MAP').
+    CREATE DATA lr_xxlattributes TYPE STANDARD TABLE OF ('BAPI6108ATXXL').
+    CREATE DATA lr_infoobj TYPE STANDARD TABLE OF ('BAPI6108').
 
     ASSIGN lr_details->* TO <lg_details>.
     ASSIGN lr_compounds->* TO <lt_compounds>.
@@ -335,11 +352,7 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
 
     lv_objna = ms_item-obj_name.
 
-    TRY.
-        CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |IOBJ is not supported on this system| ).
-    ENDTRY.
+    CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
 
     ASSIGN lr_viobj->* TO <lg_viobj>.
 
@@ -414,19 +427,15 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
       <lt_hanafieldsmapping>        TYPE STANDARD TABLE,
       <lt_xxlattributes>            TYPE STANDARD TABLE.
 
-    TRY.
-        CREATE DATA lr_details TYPE ('BAPI6108').
-        CREATE DATA lr_compounds TYPE STANDARD TABLE OF ('BAPI6108CM').
-        CREATE DATA lr_attributes TYPE STANDARD TABLE OF ('BAPI6108AT').
-        CREATE DATA lr_navigationattributes TYPE STANDARD TABLE OF ('BAPI6108AN').
-        CREATE DATA lr_atrnavinfoprovider TYPE STANDARD TABLE OF ('BAPI6108NP').
-        CREATE DATA lr_hierarchycharacteristics TYPE STANDARD TABLE OF ('BAPI6108HC').
-        CREATE DATA lr_elimination TYPE STANDARD TABLE OF ('BAPI6108IE').
-        CREATE DATA lr_hanafieldsmapping TYPE STANDARD TABLE OF ('BAPI6108HANA_MAP').
-        CREATE DATA lr_xxlattributes TYPE STANDARD TABLE OF ('BAPI6108ATXXL').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |IOBJ is not supported on this system| ).
-    ENDTRY.
+    CREATE DATA lr_details TYPE ('BAPI6108').
+    CREATE DATA lr_compounds TYPE STANDARD TABLE OF ('BAPI6108CM').
+    CREATE DATA lr_attributes TYPE STANDARD TABLE OF ('BAPI6108AT').
+    CREATE DATA lr_navigationattributes TYPE STANDARD TABLE OF ('BAPI6108AN').
+    CREATE DATA lr_atrnavinfoprovider TYPE STANDARD TABLE OF ('BAPI6108NP').
+    CREATE DATA lr_hierarchycharacteristics TYPE STANDARD TABLE OF ('BAPI6108HC').
+    CREATE DATA lr_elimination TYPE STANDARD TABLE OF ('BAPI6108IE').
+    CREATE DATA lr_hanafieldsmapping TYPE STANDARD TABLE OF ('BAPI6108HANA_MAP').
+    CREATE DATA lr_xxlattributes TYPE STANDARD TABLE OF ('BAPI6108ATXXL').
 
     ASSIGN lr_details->* TO <lg_details>.
     ASSIGN lr_compounds->* TO <lt_compounds>.

--- a/src/objects/zcl_abapgit_object_jobd.clas.abap
+++ b/src/objects/zcl_abapgit_object_jobd.clas.abap
@@ -2,6 +2,14 @@ CLASS zcl_abapgit_object_jobd DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -12,6 +20,24 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_jobd IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lr_job_definition TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CREATE DATA lr_job_definition TYPE ('CL_JR_JOB_DEFINITION=>TY_JOB_DEFINITION').
+      CATCH cx_sy_ref_creation.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -121,16 +147,11 @@ CLASS zcl_abapgit_object_jobd IMPLEMENTATION.
 
     lv_name = ms_item-obj_name.
 
-    TRY.
-        CALL METHOD ('CL_JR_JD_MANAGER')=>('CHECK_JD_EXISTENCE')
-          EXPORTING
-            im_jd_name     = lv_name
-          IMPORTING
-            ex_is_existing = rv_bool.
-
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( |JOBD not supported| ).
-    ENDTRY.
+    CALL METHOD ('CL_JR_JD_MANAGER')=>('CHECK_JD_EXISTENCE')
+      EXPORTING
+        im_jd_name     = lv_name
+      IMPORTING
+        ex_is_existing = rv_bool.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_odso.clas.abap
+++ b/src/objects/zcl_abapgit_object_odso.clas.abap
@@ -7,6 +7,14 @@ CLASS zcl_abapgit_object_odso DEFINITION
   PUBLIC SECTION.
 
     INTERFACES zif_abapgit_object .
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -21,6 +29,24 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_odso IMPLEMENTATION.
+
+  METHOD constructor.
+
+    DATA: lr_details TYPE REF TO data.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    TRY.
+        CREATE DATA lr_details TYPE ('BAPI6116').
+      CATCH cx_sy_create_data_error.
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD clear_field.
@@ -46,11 +72,7 @@ CLASS zcl_abapgit_object_odso IMPLEMENTATION.
     FIELD-SYMBOLS: <lg_details> TYPE any,
                    <lg_tstpnm>  TYPE any.
 
-    TRY.
-        CREATE DATA lr_details TYPE ('BAPI6116').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |ODSO is not supported on this system| ).
-    ENDTRY.
+    CREATE DATA lr_details TYPE ('BAPI6116').
 
     ASSIGN lr_details->* TO <lg_details>.
 
@@ -82,11 +104,7 @@ CLASS zcl_abapgit_object_odso IMPLEMENTATION.
           lt_msg        TYPE STANDARD TABLE OF bal_s_msg,
           ls_msg        TYPE bal_s_msg.
 
-    TRY.
-        CREATE OBJECT lo_collection TYPE ('CL_RSD_ODSO_COLLECTION').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |ODSO is not supported on this system| ).
-    ENDTRY.
+    CREATE OBJECT lo_collection TYPE ('CL_RSD_ODSO_COLLECTION').
 
     lv_odsonam = ms_item-obj_name.
     lv_objname = ms_item-obj_name.
@@ -136,15 +154,11 @@ CLASS zcl_abapgit_object_odso IMPLEMENTATION.
       <lt_indexes>     TYPE STANDARD TABLE,
       <lt_index_iobj>  TYPE STANDARD TABLE.
 
-    TRY.
-        CREATE DATA lr_details     TYPE ('BAPI6116').
-        CREATE DATA lr_infoobjects TYPE STANDARD TABLE OF ('BAPI6116IO').
-        CREATE DATA lr_navigation  TYPE STANDARD TABLE OF ('BAPI6116NA').
-        CREATE DATA lr_indexes     TYPE STANDARD TABLE OF ('BAPI6116IN').
-        CREATE DATA lr_index_iobj  TYPE STANDARD TABLE OF ('BAPI6116II').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |ODSO is not supported on this system| ).
-    ENDTRY.
+    CREATE DATA lr_details     TYPE ('BAPI6116').
+    CREATE DATA lr_infoobjects TYPE STANDARD TABLE OF ('BAPI6116IO').
+    CREATE DATA lr_navigation  TYPE STANDARD TABLE OF ('BAPI6116NA').
+    CREATE DATA lr_indexes     TYPE STANDARD TABLE OF ('BAPI6116IN').
+    CREATE DATA lr_index_iobj  TYPE STANDARD TABLE OF ('BAPI6116II').
 
     ASSIGN lr_details->* TO <lg_details>.
     ASSIGN lr_infoobjects->* TO <lt_infoobjects>.
@@ -326,15 +340,11 @@ CLASS zcl_abapgit_object_odso IMPLEMENTATION.
       <lt_indexes>     TYPE STANDARD TABLE,
       <lt_index_iobj>  TYPE STANDARD TABLE.
 
-    TRY.
-        CREATE DATA lr_details     TYPE ('BAPI6116').
-        CREATE DATA lr_infoobjects TYPE STANDARD TABLE OF ('BAPI6116IO').
-        CREATE DATA lr_navigation  TYPE STANDARD TABLE OF ('BAPI6116NA').
-        CREATE DATA lr_indexes     TYPE STANDARD TABLE OF ('BAPI6116IN').
-        CREATE DATA lr_index_iobj  TYPE STANDARD TABLE OF ('BAPI6116II').
-      CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |ODSO is not supported on this system| ).
-    ENDTRY.
+    CREATE DATA lr_details     TYPE ('BAPI6116').
+    CREATE DATA lr_infoobjects TYPE STANDARD TABLE OF ('BAPI6116IO').
+    CREATE DATA lr_navigation  TYPE STANDARD TABLE OF ('BAPI6116NA').
+    CREATE DATA lr_indexes     TYPE STANDARD TABLE OF ('BAPI6116IN').
+    CREATE DATA lr_index_iobj  TYPE STANDARD TABLE OF ('BAPI6116II').
 
     ASSIGN lr_details->* TO <lg_details>.
     ASSIGN lr_infoobjects->* TO <lt_infoobjects>.

--- a/src/objects/zcl_abapgit_object_samc.clas.abap
+++ b/src/objects/zcl_abapgit_object_samc.clas.abap
@@ -5,6 +5,14 @@ CLASS zcl_abapgit_object_samc DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
 
     METHODS get_data_class_name
@@ -19,6 +27,18 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_samc IMPLEMENTATION.
+
+  METHOD constructor.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    create_channel_objects( ).
+
+  ENDMETHOD.
 
 
   METHOD get_data_class_name.

--- a/src/objects/zcl_abapgit_object_sapc.clas.abap
+++ b/src/objects/zcl_abapgit_object_sapc.clas.abap
@@ -5,6 +5,14 @@ CLASS zcl_abapgit_object_sapc DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    METHODS constructor
+      IMPORTING
+        is_item        TYPE zif_abapgit_definitions=>ty_item
+        iv_language    TYPE spras
+        io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
+        io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
+      RAISING
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
 
     METHODS get_data_class_name
@@ -19,6 +27,18 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_object_sapc IMPLEMENTATION.
+
+  METHOD constructor.
+
+    super->constructor(
+        is_item        = is_item
+        iv_language    = iv_language
+        io_files       = io_files
+        io_i18n_params = io_i18n_params ).
+
+    create_channel_objects( ).
+
+  ENDMETHOD.
 
 
   METHOD get_data_class_name.

--- a/src/objects/zcl_abapgit_object_saxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_saxx_super.clas.abap
@@ -23,6 +23,9 @@ CLASS zcl_abapgit_object_saxx_super DEFINITION
       ABSTRACT
       RETURNING
         VALUE(rv_data_structure_name) TYPE string .
+    METHODS create_channel_objects
+      RAISING
+        zcx_abapgit_type_not_supported .
 
   PRIVATE SECTION.
 
@@ -32,9 +35,6 @@ CLASS zcl_abapgit_object_saxx_super DEFINITION
     DATA mv_appl_obj_cls_name TYPE seoclsname .
     DATA mv_persistence_cls_name TYPE seoclsname .
 
-    METHODS create_channel_objects
-      RAISING
-        zcx_abapgit_exception .
     METHODS get_data
       EXPORTING
         !eg_data TYPE any
@@ -53,7 +53,6 @@ ENDCLASS.
 
 CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
 
-
   METHOD create_channel_objects.
 
     get_names( ).
@@ -68,7 +67,7 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
         ENDIF.
 
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( |{ ms_item-obj_type } not supported| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = ms_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.
@@ -76,7 +75,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
 
   METHOD get_data.
 
-    DATA: lv_object_key TYPE seu_objkey.
+    DATA: lv_object_key TYPE seu_objkey,
+          lx_error      TYPE REF TO cx_root.
 
     lv_object_key = ms_item-obj_name.
 
@@ -88,8 +88,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
           CHANGING
             p_object_data = mi_appl_obj_data ).
 
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( |{ ms_item-obj_type } not supported| ).
+      CATCH cx_root INTO lx_error.
+        zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.
 
     mi_appl_obj_data->get_data( IMPORTING p_data = eg_data ).
@@ -119,7 +119,6 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
     DATA: lv_objname    TYPE trobj_name,
           lv_object_key TYPE seu_objkey,
           lv_objtype    TYPE trobjtype.
-
 
     lv_objname    = ms_item-obj_name.
     lv_object_key = ms_item-obj_name.
@@ -167,15 +166,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
                    <lg_header>     TYPE any,
                    <lg_changed_by> TYPE any.
 
-    create_channel_objects( ).
-
-    TRY.
-        CREATE DATA lr_data TYPE (mv_data_structure_name).
-        ASSIGN lr_data->* TO <lg_data>.
-
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( |{ ms_item-obj_name } not supported| ).
-    ENDTRY.
+    CREATE DATA lr_data TYPE (mv_data_structure_name).
+    ASSIGN lr_data->* TO <lg_data>.
 
     get_data( IMPORTING eg_data = <lg_data> ).
 
@@ -196,8 +188,6 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
   METHOD zif_abapgit_object~delete.
 
     DATA: lv_object_key TYPE seu_objkey.
-
-    create_channel_objects( ).
 
     lv_object_key = ms_item-obj_name.
 
@@ -223,15 +213,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
 
     FIELD-SYMBOLS: <lg_data> TYPE any.
 
-    create_channel_objects( ).
-
-    TRY.
-        CREATE DATA lr_data TYPE (mv_data_structure_name).
-        ASSIGN lr_data->* TO <lg_data>.
-
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( |{ ms_item-obj_type } not supported| ).
-    ENDTRY.
+    CREATE DATA lr_data TYPE (mv_data_structure_name).
+    ASSIGN lr_data->* TO <lg_data>.
 
     io_xml->read(
       EXPORTING
@@ -265,8 +248,6 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
   METHOD zif_abapgit_object~exists.
 
     DATA: lv_object_key TYPE seu_objkey.
-
-    create_channel_objects( ).
 
     lv_object_key = ms_item-obj_name.
 
@@ -340,15 +321,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
                    <lg_header> TYPE any,
                    <lg_field>  TYPE any.
 
-    create_channel_objects( ).
-
-    TRY.
-        CREATE DATA lr_data TYPE (mv_data_structure_name).
-        ASSIGN lr_data->* TO <lg_data>.
-
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( |{ ms_item-obj_type } not supported| ).
-    ENDTRY.
+    CREATE DATA lr_data TYPE (mv_data_structure_name).
+    ASSIGN lr_data->* TO <lg_data>.
 
     get_data( IMPORTING eg_data = <lg_data> ).
 

--- a/src/objects/zcl_abapgit_object_sktd.clas.abap
+++ b/src/objects/zcl_abapgit_object_sktd.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_sktd DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -161,7 +161,7 @@ CLASS zcl_abapgit_object_sktd IMPLEMENTATION.
         CREATE OBJECT mi_persistence TYPE ('CL_KTD_OBJECT_PERSIST').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |SKTD not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_smtg.clas.abap
+++ b/src/objects/zcl_abapgit_object_smtg.clas.abap
@@ -67,9 +67,8 @@ CLASS zcl_abapgit_object_smtg IMPLEMENTATION.
       EXCEPTIONS
         type_not_found = 1
         OTHERS         = 2 ).
-
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |SMTG not supported| ).
+      RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = ms_item-obj_type.
     ENDIF.
 
     ls_component-name = iv_fielname.

--- a/src/objects/zcl_abapgit_object_sod1.clas.abap
+++ b/src/objects/zcl_abapgit_object_sod1.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_sod1 DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -191,7 +191,7 @@ CLASS zcl_abapgit_object_sod1 IMPLEMENTATION.
     TRY.
         CREATE OBJECT lo_data_model TYPE (c_data_model_class_name).
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( |Object type { is_item-obj_type } is not supported by this system| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_sod2.clas.abap
+++ b/src/objects/zcl_abapgit_object_sod2.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_sod2 DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -191,7 +191,7 @@ CLASS zcl_abapgit_object_sod2 IMPLEMENTATION.
     TRY.
         CREATE OBJECT lo_data_model TYPE (c_data_model_class_name).
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( |Object type { is_item-obj_type } is not supported by this system| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_sqsc.clas.abap
+++ b/src/objects/zcl_abapgit_object_sqsc.clas.abap
@@ -14,7 +14,7 @@ CLASS zcl_abapgit_object_sqsc DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -134,7 +134,7 @@ CLASS zcl_abapgit_object_sqsc IMPLEMENTATION.
         ASSERT sy-subrc = 0.
 
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( |SQSC not supported| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
     <lv_dbproxyname> = ms_item-obj_name.

--- a/src/objects/zcl_abapgit_object_srfc.clas.abap
+++ b/src/objects/zcl_abapgit_object_srfc.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_srfc DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -39,7 +39,7 @@ CLASS zcl_abapgit_object_srfc IMPLEMENTATION.
     TRY.
         CREATE OBJECT li_srfc_persist TYPE ('CL_UCONRFC_OBJECT_PERSIST').
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'Object type SRFC is not supported by this system' ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_srvb.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvb.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_srvb DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -159,7 +159,7 @@ CLASS zcl_abapgit_object_srvb IMPLEMENTATION.
         CREATE OBJECT mi_persistence TYPE ('CL_SRVB_OBJECT_PERSIST').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |SRVB not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
     mv_is_inactive_supported = is_ai_supported( ).

--- a/src/objects/zcl_abapgit_object_srvd.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvd.clas.abap
@@ -10,7 +10,7 @@ CLASS zcl_abapgit_object_srvd DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
   PROTECTED SECTION.
 
@@ -158,7 +158,7 @@ CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
         CREATE DATA mr_service_definition TYPE ('CL_SRVD_WB_OBJECT_DATA=>TY_SRVD_OBJECT_DATA').
 
       CATCH cx_sy_create_error.
-        zcx_abapgit_exception=>raise( |SRVD not supported by your NW release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_sush.clas.abap
+++ b/src/objects/zcl_abapgit_object_sush.clas.abap
@@ -88,7 +88,7 @@ CLASS zcl_abapgit_object_sush IMPLEMENTATION.
         CREATE DATA lr_data_head TYPE ('IF_SU22_ADT_OBJECT=>TS_SU2X_HEAD').
 
       CATCH cx_sy_create_data_error.
-        zcx_abapgit_exception=>raise( |SUSH is not supported in your SAP release| ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_objects_bridge.clas.abap
+++ b/src/objects/zcl_abapgit_objects_bridge.clas.abap
@@ -8,8 +8,7 @@ CLASS zcl_abapgit_objects_bridge DEFINITION PUBLIC FINAL CREATE PUBLIC INHERITIN
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        cx_sy_create_object_error
-        zcx_abapgit_exception.
+        cx_sy_create_object_error.
 
     INTERFACES zif_abapgit_object.
   PROTECTED SECTION.

--- a/src/objects/zcl_abapgit_objects_generic.clas.abap
+++ b/src/objects/zcl_abapgit_objects_generic.clas.abap
@@ -225,7 +225,7 @@ CLASS zcl_abapgit_objects_generic IMPLEMENTATION.
       WHERE objectname = is_item-obj_type
       AND objecttype = lc_logical_transport_object.
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'Not found in OBJH, or not supported' ).
+      RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDIF.
 
     " object tables

--- a/src/zcx_abapgit_type_not_supported.clas.abap
+++ b/src/zcx_abapgit_type_not_supported.clas.abap
@@ -1,0 +1,51 @@
+CLASS zcx_abapgit_type_not_supported DEFINITION
+  PUBLIC
+  INHERITING FROM zcx_abapgit_exception
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    METHODS constructor
+      IMPORTING
+        textid   LIKE if_t100_message=>t100key OPTIONAL
+        previous LIKE previous OPTIONAL
+        log      TYPE REF TO zif_abapgit_log OPTIONAL
+        msgv1    TYPE symsgv OPTIONAL
+        msgv2    TYPE symsgv OPTIONAL
+        msgv3    TYPE symsgv OPTIONAL
+        msgv4    TYPE symsgv OPTIONAL
+        longtext TYPE csequence OPTIONAL
+        obj_type TYPE trobjtype.
+
+    METHODS get_text REDEFINITION.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    DATA mv_obj_type TYPE trobjtype.
+ENDCLASS.
+
+
+
+CLASS zcx_abapgit_type_not_supported IMPLEMENTATION.
+
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+
+    super->constructor(
+        textid   = textid
+        previous = previous
+        log      = log
+        msgv1    = msgv1
+        msgv2    = msgv2
+        msgv3    = msgv3
+        msgv4    = msgv4
+        longtext = longtext ).
+
+    mv_obj_type = obj_type.
+
+  ENDMETHOD.
+
+
+  METHOD get_text.
+    result = |Object type { mv_obj_type } is not supported by this system|.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/zcx_abapgit_type_not_supported.clas.xml
+++ b/src/zcx_abapgit_type_not_supported.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_ABAPGIT_TYPE_NOT_SUPPORTED</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Object type not supported</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This change introduces a new specialized exception class `zcx_abapgit_type_not_supported` inherited from `zcx_abapgit_exception` replacing the latter in serializer classes.
Additionally all checking whether an object type is supported or not is moved to the constructors of serializer classes, reducing some redundancies and boilerplate 'not supported handling'. Plus make it more obvious if an object type is supported or not: If the serializer can be instantiated it is supported.