### PR TITLE
Add support for ABAP Language Version for generic

### DIFF
--- a/src/objects/rules/zcl_abapgit_field_rules.clas.abap
+++ b/src/objects/rules/zcl_abapgit_field_rules.clas.abap
@@ -10,8 +10,10 @@ CLASS zcl_abapgit_field_rules DEFINITION
     CLASS-METHODS create
       RETURNING
         VALUE(ro_result) TYPE REF TO zif_abapgit_field_rules.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
+
     TYPES:
       BEGIN OF ty_item,
         tabname   TYPE tabname,
@@ -24,10 +26,12 @@ CLASS zcl_abapgit_field_rules DEFINITION
 
     METHODS fill_value
       IMPORTING
-        iv_rule    TYPE zif_abapgit_field_rules=>ty_fill_rule
-        iv_package TYPE devclass
+        iv_rule                  TYPE zif_abapgit_field_rules=>ty_fill_rule
+        iv_package               TYPE devclass
+        iv_abap_language_version TYPE uccheck OPTIONAL
       CHANGING
-        cv_value   TYPE any.
+        cv_value                 TYPE any.
+
 ENDCLASS.
 
 
@@ -56,6 +60,8 @@ CLASS zcl_abapgit_field_rules IMPLEMENTATION.
         cv_value = sy-mandt.
       WHEN zif_abapgit_field_rules=>c_fill_rule-package.
         cv_value = iv_package.
+      WHEN zif_abapgit_field_rules=>c_fill_rule-abap_language_version.
+        cv_value = iv_abap_language_version.
     ENDCASE.
   ENDMETHOD.
 
@@ -109,10 +115,11 @@ CLASS zcl_abapgit_field_rules IMPLEMENTATION.
         IF sy-subrc = 0.
           fill_value(
             EXPORTING
-              iv_rule    = ls_item-fill_rule
-              iv_package = iv_package
+              iv_rule                  = ls_item-fill_rule
+              iv_package               = iv_package
+              iv_abap_language_version = iv_abap_language_version
             CHANGING
-              cv_value   = <lv_value> ).
+              cv_value                 = <lv_value> ).
         ENDIF.
       ENDLOOP.
     ENDLOOP.

--- a/src/objects/rules/zcl_abapgit_field_rules.clas.testclasses.abap
+++ b/src/objects/rules/zcl_abapgit_field_rules.clas.testclasses.abap
@@ -4,8 +4,9 @@ CLASS ltcl_field_rules DEFINITION FOR TESTING RISK LEVEL HARMLESS
   PRIVATE SECTION.
 
     CONSTANTS:
-      c_package TYPE devclass VALUE '$TMP',
-      c_table   TYPE tabname VALUE 'ZTEST'.
+      c_abap_cloud TYPE uccheck VALUE '5',
+      c_package    TYPE devclass VALUE '$TMP',
+      c_table      TYPE tabname VALUE 'ZTEST'.
 
     TYPES:
       BEGIN OF ty_test,
@@ -15,6 +16,7 @@ CLASS ltcl_field_rules DEFINITION FOR TESTING RISK LEVEL HARMLESS
         time TYPE t,
         ts   TYPE timestamp,
         tl   TYPE timestampl,
+        alav TYPE uccheck,
       END OF ty_test.
 
     DATA mo_cut TYPE REF TO zcl_abapgit_field_rules.
@@ -33,6 +35,7 @@ CLASS ltcl_field_rules DEFINITION FOR TESTING RISK LEVEL HARMLESS
       fill5 FOR TESTING,
       fill6 FOR TESTING,
       fill7 FOR TESTING,
+      fill8 FOR TESTING,
       get_rules
         RETURNING
           VALUE(ri_rules) TYPE REF TO zif_abapgit_field_rules,
@@ -55,10 +58,11 @@ CLASS ltcl_field_rules IMPLEMENTATION.
 
     mo_cut->fill_value(
       EXPORTING
-        iv_rule    = iv_rule
-        iv_package = c_package
+        iv_rule                  = iv_rule
+        iv_package               = c_package
+        iv_abap_language_version = c_abap_cloud
       CHANGING
-        cv_value   = lv_act ).
+        cv_value                 = lv_act ).
 
     IF iv_len IS NOT INITIAL.
       lv_act = lv_act(iv_len).
@@ -116,6 +120,12 @@ CLASS ltcl_field_rules IMPLEMENTATION.
       iv_exp  = '' ).
   ENDMETHOD.
 
+  METHOD fill8.
+    fill_value(
+      iv_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version
+      iv_exp  = |{ c_abap_cloud }| ).
+  ENDMETHOD.
+
   METHOD get_rules.
 
     ri_rules = zcl_abapgit_field_rules=>create( )->add(
@@ -137,7 +147,11 @@ CLASS ltcl_field_rules IMPLEMENTATION.
     )->add(
       iv_table     = c_table
       iv_field     = 'TL'
-      iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
+      iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp
+    )->add(
+      iv_table     = c_table
+      iv_field     = 'ALAV'
+      iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
 
   ENDMETHOD.
 
@@ -159,6 +173,7 @@ CLASS ltcl_field_rules IMPLEMENTATION.
     ls_act-user = 'FRANK'.
     ls_act-date = '20230101'.
     ls_act-time = '000001'.
+    ls_act-alav = '5'. " ABAP Cloud
     INSERT ls_act INTO TABLE lt_act.
 
     li_rules = get_rules( ).
@@ -216,10 +231,11 @@ CLASS ltcl_field_rules IMPLEMENTATION.
 
     li_rules->apply_fill_logic(
       EXPORTING
-        iv_table   = c_table
-        iv_package = c_package
+        iv_table                 = c_table
+        iv_package               = c_package
+        iv_abap_language_version = c_abap_cloud
       CHANGING
-        ct_data    = lt_act ).
+        ct_data                  = lt_act ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lines( lt_act )
@@ -265,6 +281,9 @@ CLASS ltcl_field_rules IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = ls_act-time(4)
       exp = sy-uzeit(4) ). " avoid comparing seconds
+    cl_abap_unit_assert=>assert_equals(
+      act = ls_act-alav
+      exp = c_abap_cloud ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/rules/zif_abapgit_field_rules.intf.abap
+++ b/src/objects/rules/zif_abapgit_field_rules.intf.abap
@@ -1,14 +1,16 @@
-INTERFACE zif_abapgit_field_rules
-  PUBLIC .
+INTERFACE zif_abapgit_field_rules PUBLIC.
+
   TYPES ty_fill_rule TYPE c LENGTH 2.
+
   CONSTANTS:
     BEGIN OF c_fill_rule,
-      date      TYPE ty_fill_rule VALUE 'DT',
-      time      TYPE ty_fill_rule VALUE 'TM',
-      timestamp TYPE ty_fill_rule VALUE 'TS',
-      user      TYPE ty_fill_rule VALUE 'UR',
-      client    TYPE ty_fill_rule VALUE 'CT',
-      package   TYPE ty_fill_rule VALUE 'PK',
+      date                  TYPE ty_fill_rule VALUE 'DT',
+      time                  TYPE ty_fill_rule VALUE 'TM',
+      timestamp             TYPE ty_fill_rule VALUE 'TS',
+      user                  TYPE ty_fill_rule VALUE 'UR',
+      client                TYPE ty_fill_rule VALUE 'CT',
+      package               TYPE ty_fill_rule VALUE 'PK',
+      abap_language_version TYPE ty_fill_rule VALUE 'AL',
     END OF c_fill_rule.
 
   METHODS add
@@ -18,15 +20,19 @@ INTERFACE zif_abapgit_field_rules
       iv_fill_rule   TYPE ty_fill_rule
     RETURNING
       VALUE(ro_self) TYPE REF TO zif_abapgit_field_rules.
+
   METHODS apply_clear_logic
     IMPORTING
       iv_table TYPE tabname
     CHANGING
       ct_data  TYPE STANDARD TABLE.
+
   METHODS apply_fill_logic
     IMPORTING
-      iv_table   TYPE tabname
-      iv_package TYPE devclass
+      iv_table                 TYPE tabname
+      iv_package               TYPE devclass
+      iv_abap_language_version TYPE uccheck OPTIONAL
     CHANGING
-      ct_data    TYPE STANDARD TABLE.
+      ct_data                  TYPE STANDARD TABLE.
+
 ENDINTERFACE.

--- a/src/objects/zcl_abapgit_object_g4ba.clas.abap
+++ b/src/objects/zcl_abapgit_object_g4ba.clas.abap
@@ -60,6 +60,13 @@ CLASS zcl_abapgit_object_g4ba IMPLEMENTATION.
       iv_field     = 'CHANGED_TS'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
 
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWBEP/I_V4_MSGR'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_g4bs.clas.abap
+++ b/src/objects/zcl_abapgit_object_g4bs.clas.abap
@@ -60,6 +60,13 @@ CLASS zcl_abapgit_object_g4bs IMPLEMENTATION.
       iv_field     = 'CHANGED_TS'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
 
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWBEP/I_V4_MSRV'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwmo.clas.abap
@@ -42,6 +42,14 @@ CLASS zcl_abapgit_object_iwmo IMPLEMENTATION.
       iv_table     = '/IWBEP/I_MGW_OHD'
       iv_field     = 'CHANGED_TIMESTMP'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
+
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWBEP/I_MGW_OHD'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwom.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwom.clas.abap
@@ -42,6 +42,14 @@ CLASS zcl_abapgit_object_iwom IMPLEMENTATION.
       iv_table     = '/IWFND/I_MED_OHD'
       iv_field     = 'CHANGED_TIMESTMP'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
+
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWFND/I_MED_OHD'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwsg.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwsg.clas.abap
@@ -44,6 +44,13 @@ CLASS zcl_abapgit_object_iwsg IMPLEMENTATION.
       iv_field     = 'CHANGED_TIMESTMP'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
 
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWFND/I_MED_SRH'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwsv.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwsv.clas.abap
@@ -42,6 +42,14 @@ CLASS zcl_abapgit_object_iwsv IMPLEMENTATION.
       iv_table     = '/IWBEP/I_MGW_SRH'
       iv_field     = 'CHANGED_TIMESTMP'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
+
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWBEP/I_MGW_SRH'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwvb.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwvb.clas.abap
@@ -42,6 +42,14 @@ CLASS zcl_abapgit_object_iwvb IMPLEMENTATION.
       iv_table     = '/IWBEP/I_MGW_VAH'
       iv_field     = 'CHANGED_TIMESTMP'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
+
+   IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+      ro_result->add(
+        iv_table     = '/IWBEP/I_MGW_VAH'
+        iv_field     = 'ABAP_LANGUAGE_VERSION'
+        iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-abap_language_version ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_iwvb.clas.abap
+++ b/src/objects/zcl_abapgit_object_iwvb.clas.abap
@@ -43,7 +43,7 @@ CLASS zcl_abapgit_object_iwvb IMPLEMENTATION.
       iv_field     = 'CHANGED_TIMESTMP'
       iv_fill_rule = zif_abapgit_field_rules=>c_fill_rule-timestamp ).
 
-   IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
+    IF ms_item-abap_language_version = zcl_abapgit_abap_language_vers=>c_no_abap_language_version.
       ro_result->add(
         iv_table     = '/IWBEP/I_MGW_VAH'
         iv_field     = 'ABAP_LANGUAGE_VERSION'


### PR DESCRIPTION
Phase 3 of #6689

Adds support for object types using generic serializer class using a new field mapping rule which clears/sets the ABAP Language Version field. 