### PR TITLE
STVI: Fix unstable diff when shdtvsvciu or shdfvguicu are not initial

### DIFF
--- a/src/objects/zcl_abapgit_object_scvi.clas.abap
+++ b/src/objects/zcl_abapgit_object_scvi.clas.abap
@@ -193,6 +193,9 @@ CLASS zcl_abapgit_object_scvi IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
+    SORT ls_screen_variant-shdsvfvci ASCENDING.
+    SORT ls_screen_variant-shdguixt ASCENDING.
+
 *   Clear all user details
     CLEAR: ls_screen_variant-shdsvci-crdate,
            ls_screen_variant-shdsvci-cruser,

--- a/src/objects/zcl_abapgit_object_stvi.clas.abap
+++ b/src/objects/zcl_abapgit_object_stvi.clas.abap
@@ -197,6 +197,9 @@ CLASS zcl_abapgit_object_stvi IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
+    SORT ls_transaction_variant-shdtvsvciu ASCENDING.
+    SORT ls_transaction_variant-shdfvguicu ASCENDING.
+
 *   Clear all user details
     CLEAR: ls_transaction_variant-shdtvciu-crdate,
            ls_transaction_variant-shdtvciu-cruser,


### PR DESCRIPTION
I discovered the problem with unstable diffs under HANA also exists for STVI objects