### PR TITLE
FDT0: Remove comparator

### DIFF
--- a/src/objects/zcl_abapgit_object_fdt0.clas.abap
+++ b/src/objects/zcl_abapgit_object_fdt0.clas.abap
@@ -594,21 +594,7 @@ CLASS zcl_abapgit_object_fdt0 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_comparator.
-
-    DATA lo_local_version_output TYPE REF TO zcl_abapgit_xml_output.
-    DATA lo_local_version_input  TYPE REF TO zcl_abapgit_xml_input.
-
-    CREATE OBJECT lo_local_version_output.
-    zif_abapgit_object~serialize( lo_local_version_output ).
-
-    CREATE OBJECT lo_local_version_input
-      EXPORTING
-        iv_xml = lo_local_version_output->zif_abapgit_xml_output~render( ).
-
-    CREATE OBJECT ri_comparator TYPE zcl_abapgit_object_tabl_compar
-      EXPORTING
-        ii_local = lo_local_version_input.
-
+    RETURN.
   ENDMETHOD.
 
 


### PR DESCRIPTION
Using the table comparator for BRF objects does not make any sense. Removed it.