### PR TITLE
Refactor: Data loss check - Table comparison

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -1,8 +1,10 @@
 CLASS zcl_abapgit_objects_check DEFINITION
   PUBLIC
-  CREATE PUBLIC .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
+
+    CLASS-METHODS class_constructor.
 
     CLASS-METHODS deserialize_checks
       IMPORTING
@@ -10,8 +12,8 @@ CLASS zcl_abapgit_objects_check DEFINITION
       RETURNING
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
       RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS class_constructor.
+        zcx_abapgit_exception.
+
     CLASS-METHODS checks_adjust
       IMPORTING
         !ii_repo    TYPE REF TO zif_abapgit_repo
@@ -19,11 +21,22 @@ CLASS zcl_abapgit_objects_check DEFINITION
       CHANGING
         !ct_results TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
-        zcx_abapgit_exception .
-  PROTECTED SECTION.
+        zcx_abapgit_exception.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
-    CLASS-DATA: gi_exit TYPE REF TO zif_abapgit_exit.
+
+    CLASS-DATA gi_exit TYPE REF TO zif_abapgit_exit.
+
+    CLASS-METHODS adjust_result
+      IMPORTING
+        !iv_txt           TYPE string
+        !it_overwrite_old TYPE zif_abapgit_definitions=>ty_overwrite_tt
+        !it_overwrite_new TYPE zif_abapgit_definitions=>ty_overwrite_tt
+      CHANGING
+        !ct_results       TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception.
 
     CLASS-METHODS warning_overwrite_adjust
       IMPORTING
@@ -32,11 +45,13 @@ CLASS zcl_abapgit_objects_check DEFINITION
         !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception.
+
     CLASS-METHODS warning_overwrite_find
       IMPORTING
         !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
       RETURNING
         VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt.
+
     CLASS-METHODS warning_package_adjust
       IMPORTING
         !ii_repo      TYPE REF TO zif_abapgit_repo
@@ -45,6 +60,7 @@ CLASS zcl_abapgit_objects_check DEFINITION
         !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception.
+
     CLASS-METHODS warning_package_find
       IMPORTING
         !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
@@ -53,17 +69,38 @@ CLASS zcl_abapgit_objects_check DEFINITION
         VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt
       RAISING
         zcx_abapgit_exception.
+
+    CLASS-METHODS warning_data_loss_adjust
+      IMPORTING
+        !ii_repo      TYPE REF TO zif_abapgit_repo
+        !it_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt
+      CHANGING
+        !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception.
+
+    CLASS-METHODS warning_data_loss_find
+      IMPORTING
+        !ii_repo            TYPE REF TO zif_abapgit_repo
+        !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
+      RETURNING
+        VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt
+      RAISING
+        zcx_abapgit_exception.
+
     CLASS-METHODS determine_transport_request
       IMPORTING
         ii_repo                     TYPE REF TO zif_abapgit_repo
         iv_transport_type           TYPE zif_abapgit_definitions=>ty_transport_type
       RETURNING
         VALUE(rv_transport_request) TYPE trkorr.
+
     CLASS-METHODS check_multiple_files
       IMPORTING
         !it_results TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -71,7 +108,35 @@ ENDCLASS.
 CLASS zcl_abapgit_objects_check IMPLEMENTATION.
 
 
+  METHOD adjust_result.
+
+    DATA ls_overwrite TYPE zif_abapgit_definitions=>ty_overwrite.
+
+    FIELD-SYMBOLS <ls_overwrite> TYPE zif_abapgit_definitions=>ty_overwrite.
+
+    LOOP AT it_overwrite_new ASSIGNING <ls_overwrite>.
+
+      READ TABLE it_overwrite_old INTO ls_overwrite WITH TABLE KEY object_type_and_name
+        COMPONENTS obj_type = <ls_overwrite>-obj_type obj_name = <ls_overwrite>-obj_name.
+      IF sy-subrc <> 0 OR ls_overwrite-decision IS INITIAL.
+        zcx_abapgit_exception=>raise( |{ iv_txt } { <ls_overwrite>-obj_type } { <ls_overwrite>-obj_name } undecided| ).
+      ENDIF.
+
+      IF ls_overwrite-decision = zif_abapgit_definitions=>c_no.
+        DELETE ct_results WHERE obj_type = <ls_overwrite>-obj_type AND obj_name = <ls_overwrite>-obj_name.
+        ASSERT sy-subrc = 0.
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD checks_adjust.
+
+    " Make sure to get the current status, as something might have changed in the meanwhile
+    " - Remove objects from results that were deselected in confirmation popup
+    " - Raise exception if an object has no decision of what to do
 
     warning_overwrite_adjust(
       EXPORTING
@@ -83,6 +148,13 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       EXPORTING
         ii_repo      = ii_repo
         it_overwrite = is_checks-warning_package
+      CHANGING
+        ct_results   = ct_results ).
+
+    warning_data_loss_adjust(
+      EXPORTING
+        ii_repo      = ii_repo
+        it_overwrite = is_checks-data_loss
       CHANGING
         ct_results   = ct_results ).
 
@@ -144,6 +216,10 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
       ii_repo    = ii_repo
       it_results = lt_results ).
 
+    rs_checks-data_loss = warning_data_loss_find(
+      ii_repo    = ii_repo
+      it_results = lt_results ).
+
     IF lines( lt_results ) > 0.
       li_package = zcl_abapgit_factory=>get_sap_package( ii_repo->get_package( ) ).
       rs_checks-transport-required = li_package->are_changes_recorded_in_tr_req( ).
@@ -174,36 +250,82 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD warning_overwrite_adjust.
+  METHOD warning_data_loss_adjust.
 
-    DATA: lt_overwrite LIKE it_overwrite,
-          ls_overwrite LIKE LINE OF lt_overwrite.
+    DATA lt_overwrite LIKE it_overwrite.
 
-    FIELD-SYMBOLS: <ls_overwrite> LIKE LINE OF lt_overwrite.
+    lt_overwrite = warning_data_loss_find(
+      it_results = ct_results
+      ii_repo    = ii_repo ).
+
+    adjust_result(
+      EXPORTING
+        iv_txt           = 'Potential data loss for'
+        it_overwrite_old = it_overwrite
+        it_overwrite_new = lt_overwrite
+      CHANGING
+        ct_results       = ct_results ).
+
+  ENDMETHOD.
 
 
-* make sure to get the current status, as something might have changed in the meanwhile
-    lt_overwrite = warning_overwrite_find( ct_results ).
+  METHOD warning_data_loss_find.
 
-    LOOP AT lt_overwrite ASSIGNING <ls_overwrite>.
+    DATA:
+      ls_item       TYPE zif_abapgit_definitions=>ty_item,
+      li_comparator TYPE REF TO zif_abapgit_comparator,
+      lv_result     TYPE string.
 
-      READ TABLE it_overwrite INTO ls_overwrite
-                              WITH TABLE KEY object_type_and_name
-                              COMPONENTS obj_type = <ls_overwrite>-obj_type
-                                         obj_name = <ls_overwrite>-obj_name.
-      IF sy-subrc <> 0 OR ls_overwrite-decision IS INITIAL.
-        zcx_abapgit_exception=>raise( |Overwrite { <ls_overwrite>-obj_type } {
-          <ls_overwrite>-obj_name } undecided| ).
+    FIELD-SYMBOLS:
+      <ls_result>    LIKE LINE OF it_results,
+      <ls_overwrite> LIKE LINE OF rt_overwrite.
+
+    " For optimal performance, we limit here by object type since we know that only TABL has a comparator
+    " If there are other object types in the future, extend the where clause or remove the check on object type.
+    LOOP AT it_results ASSIGNING <ls_result> WHERE match IS INITIAL AND filename CP '*.xml'
+      AND obj_type ='TABL' ##PRIMKEY[SEC_KEY].
+
+      CLEAR ls_item.
+      MOVE-CORRESPONDING <ls_result> TO ls_item.
+
+      li_comparator = zcl_abapgit_objects_compare=>get_comparator( ls_item ).
+      IF NOT li_comparator IS BOUND.
+        RETURN.
       ENDIF.
 
-      IF ls_overwrite-decision = zif_abapgit_definitions=>c_no.
-        DELETE ct_results WHERE
-          obj_type = <ls_overwrite>-obj_type AND
-          obj_name = <ls_overwrite>-obj_name.
-        ASSERT sy-subrc = 0.
+      lv_result = zcl_abapgit_objects_compare=>get_result(
+        ii_comparator = li_comparator
+        iv_filename   = <ls_result>-filename
+        it_local      = ii_repo->get_files_local( )
+        it_remote     = ii_repo->get_files_remote( iv_ignore_files = abap_true ) ).
+
+      IF lv_result IS NOT INITIAL.
+        APPEND INITIAL LINE TO rt_overwrite ASSIGNING <ls_overwrite>.
+        MOVE-CORRESPONDING <ls_result> TO <ls_overwrite>.
+        <ls_overwrite>-devclass = <ls_result>-package.
+        <ls_overwrite>-action   = zif_abapgit_objects=>c_deserialize_action-data_loss.
+        <ls_overwrite>-icon     = icon_warning.
+        <ls_overwrite>-text     = lv_result.
       ENDIF.
 
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD warning_overwrite_adjust.
+
+    DATA lt_overwrite LIKE it_overwrite.
+
+    lt_overwrite = warning_overwrite_find( ct_results ).
+
+    adjust_result(
+      EXPORTING
+        iv_txt           = 'Overwrite of object'
+        it_overwrite_old = it_overwrite
+        it_overwrite_new = lt_overwrite
+      CHANGING
+        ct_results       = ct_results ).
 
   ENDMETHOD.
 
@@ -301,36 +423,19 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
 
   METHOD warning_package_adjust.
 
-    DATA: lt_overwrite LIKE it_overwrite,
-          ls_overwrite LIKE LINE OF lt_overwrite.
+    DATA lt_overwrite LIKE it_overwrite.
 
-    FIELD-SYMBOLS: <ls_overwrite> LIKE LINE OF lt_overwrite.
-
-
-* make sure to get the current status, as something might have changed in the meanwhile
     lt_overwrite = warning_package_find(
-      it_results   = ct_results
-      ii_repo      = ii_repo ).
+      it_results = ct_results
+      ii_repo    = ii_repo ).
 
-    LOOP AT lt_overwrite ASSIGNING <ls_overwrite>.
-
-      READ TABLE it_overwrite INTO ls_overwrite
-                              WITH TABLE KEY object_type_and_name
-                              COMPONENTS obj_type = <ls_overwrite>-obj_type
-                                         obj_name = <ls_overwrite>-obj_name.
-      IF sy-subrc <> 0 OR ls_overwrite-decision IS INITIAL.
-        zcx_abapgit_exception=>raise( |Overwrite of package { <ls_overwrite>-obj_type } {
-          <ls_overwrite>-obj_name } undecided| ).
-      ENDIF.
-
-      IF ls_overwrite-decision = zif_abapgit_definitions=>c_no.
-        DELETE ct_results WHERE
-          obj_type = <ls_overwrite>-obj_type AND
-          obj_name = <ls_overwrite>-obj_name.
-        ASSERT sy-subrc = 0.
-      ENDIF.
-
-    ENDLOOP.
+    adjust_result(
+      EXPORTING
+        iv_txt           = 'Overwrite of package'
+        it_overwrite_old = it_overwrite
+        it_overwrite_new = lt_overwrite
+      CHANGING
+        ct_results       = ct_results ).
 
   ENDMETHOD.
 
@@ -361,7 +466,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
         iv_obj_name = <ls_result>-obj_name ).
 
       IF NOT ls_tadir IS INITIAL AND ls_tadir-devclass <> lv_package.
-* overwriting object from different package than expected
+        " overwriting object from different package than expected
         CLEAR ls_overwrite.
         CONCATENATE <ls_result>-lstate <ls_result>-rstate INTO ls_overwrite-state RESPECTING BLANKS.
         REPLACE ALL OCCURRENCES OF ` ` IN ls_overwrite-state WITH '_'.

--- a/src/objects/core/zcl_abapgit_objects_check.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_check.clas.abap
@@ -283,7 +283,7 @@ CLASS zcl_abapgit_objects_check IMPLEMENTATION.
     " For optimal performance, we limit here by object type since we know that only TABL has a comparator
     " If there are other object types in the future, extend the where clause or remove the check on object type.
     LOOP AT it_results ASSIGNING <ls_result> WHERE match IS INITIAL AND filename CP '*.xml'
-      AND obj_type ='TABL' ##PRIMKEY[SEC_KEY].
+      AND obj_type = 'TABL' ##PRIMKEY[SEC_KEY].
 
       CLEAR ls_item.
       MOVE-CORRESPONDING <ls_result> TO ls_item.

--- a/src/objects/core/zcl_abapgit_objects_compare.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_compare.clas.abap
@@ -1,0 +1,114 @@
+CLASS zcl_abapgit_objects_compare DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get_comparator
+      IMPORTING
+        is_item              TYPE zif_abapgit_definitions=>ty_item
+      RETURNING
+        VALUE(ri_comparator) TYPE REF TO zif_abapgit_comparator.
+
+    CLASS-METHODS get_result
+      IMPORTING
+        ii_comparator    TYPE REF TO zif_abapgit_comparator
+        iv_filename      TYPE string
+        it_local         TYPE zif_abapgit_definitions=>ty_files_item_tt
+        it_remote        TYPE zif_abapgit_git_definitions=>ty_files_tt
+      RETURNING
+        VALUE(rv_result) TYPE string
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_objects_compare IMPLEMENTATION.
+
+
+  METHOD get_comparator.
+
+    DATA lv_class_name TYPE seoclsname.
+
+    CONCATENATE 'ZCL_ABAPGIT_OBJECT_' is_item-obj_type '_COMPAR' INTO lv_class_name.
+
+    IF zcl_abapgit_factory=>get_environment( )->is_merged( ) = abap_true.
+      " Prevent accidental usage of object handlers in the developer version
+      lv_class_name = |\\PROGRAM={ sy-repid }\\CLASS={ lv_class_name }|.
+    ENDIF.
+
+    TRY.
+        CREATE OBJECT ri_comparator TYPE (lv_class_name)
+          EXPORTING
+            is_item = is_item.
+      CATCH cx_sy_create_object_error ##NO_HANDLER.
+        " No instance, no comparator for this object type
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD get_result.
+
+    " this method is used for comparing local with remote objects
+    " before pull, this is useful eg. when overwriting a TABL object.
+    " only the main XML file is used for comparison
+
+    DATA:
+      ls_remote_file    TYPE zif_abapgit_git_definitions=>ty_file,
+      ls_local_file     TYPE zif_abapgit_definitions=>ty_file_item,
+      li_remote_version TYPE REF TO zif_abapgit_xml_input,
+      li_local_version  TYPE REF TO zif_abapgit_xml_input,
+      li_log            TYPE REF TO zif_abapgit_log,
+      ls_msg            TYPE zif_abapgit_log=>ty_log_out,
+      lt_msg            TYPE zif_abapgit_log=>ty_log_outs,
+      ls_result         TYPE zif_abapgit_comparator=>ty_result.
+
+    " REMOTE
+    " if file does not exist in remote, we don't need to validate
+    READ TABLE it_remote WITH KEY file COMPONENTS filename = iv_filename INTO ls_remote_file.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    CREATE OBJECT li_remote_version TYPE zcl_abapgit_xml_input
+      EXPORTING
+        iv_xml      = zcl_abapgit_convert=>xstring_to_string_utf8( ls_remote_file-data )
+        iv_filename = iv_filename.
+
+    " LOCAL
+    " if file does not exist locally, we don't need to validate
+    READ TABLE it_local WITH KEY file-filename = iv_filename INTO ls_local_file.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
+
+    CREATE OBJECT li_local_version TYPE zcl_abapgit_xml_input
+      EXPORTING
+        iv_xml      = zcl_abapgit_convert=>xstring_to_string_utf8( ls_local_file-file-data )
+        iv_filename = iv_filename.
+
+    " COMPARE
+    CREATE OBJECT li_log TYPE zcl_abapgit_log.
+
+    ls_result = ii_comparator->compare(
+      ii_local  = li_local_version
+      ii_remote = li_remote_version
+      ii_log    = li_log ).
+
+    rv_result = ls_result-text.
+
+    " To keep it simple, append the log messages to the result
+    lt_msg = li_log->get_messages( ).
+
+    LOOP AT lt_msg INTO ls_msg.
+      rv_result = |{ rv_result }, { ls_msg-text }|.
+    ENDLOOP.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/objects/core/zcl_abapgit_objects_compare.clas.xml
+++ b/src/objects/core/zcl_abapgit_objects_compare.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECTS_COMPARE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Objects Comparator</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
@@ -850,24 +850,8 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_comparator.
-
-    DATA: li_local_version_output TYPE REF TO zif_abapgit_xml_output,
-          li_local_version_input  TYPE REF TO zif_abapgit_xml_input.
-
-
-    CREATE OBJECT li_local_version_output TYPE zcl_abapgit_xml_output.
-
-    zif_abapgit_object~serialize( li_local_version_output ).
-
-    CREATE OBJECT li_local_version_input
-      TYPE zcl_abapgit_xml_input
-      EXPORTING
-        iv_xml = li_local_version_output->render( ).
-
-    CREATE OBJECT ri_comparator TYPE zcl_abapgit_object_tabl_compar
-      EXPORTING
-        ii_local = li_local_version_input.
-
+    " Moved to zcl_abapgit_objects_compare
+    RETURN.
   ENDMETHOD.
 
 

--- a/src/objects/zif_abapgit_comparator.intf.abap
+++ b/src/objects/zif_abapgit_comparator.intf.abap
@@ -9,6 +9,7 @@ INTERFACE zif_abapgit_comparator
 
   METHODS compare
     IMPORTING
+      !ii_local        TYPE REF TO zif_abapgit_xml_input
       !ii_remote       TYPE REF TO zif_abapgit_xml_input
       !ii_log          TYPE REF TO zif_abapgit_log
     RETURNING

--- a/src/objects/zif_abapgit_objects.intf.abap
+++ b/src/objects/zif_abapgit_objects.intf.abap
@@ -43,6 +43,7 @@ INTERFACE zif_abapgit_objects PUBLIC.
       delete     TYPE i VALUE 4,
       delete_add TYPE i VALUE 5,
       packmove   TYPE i VALUE 6,
+      data_loss  TYPE i VALUE 7,
     END OF c_deserialize_action.
 
 ENDINTERFACE.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -78,6 +78,7 @@ INTERFACE zif_abapgit_definitions
     BEGIN OF ty_deserialize_checks,
       overwrite       TYPE ty_overwrite_tt,
       warning_package TYPE ty_overwrite_tt,
+      data_loss       TYPE ty_overwrite_tt,
       requirements    TYPE ty_requirements,
       dependencies    TYPE ty_dependencies,
       transport       TYPE ty_transport,


### PR DESCRIPTION
I finally found time to tackle #1284 (from 2018). This change removes the popups that ask from confirmation of potential data loss when changing a table (or structure contained in a table) from the deserialize process to the preceding check phase.

The table comparison is now done upfront. If you select a table in the pull dialog and the changes could lead to data loss, for example if a field is removed, then a second popup will be shown. You will have to confirm overwriting the table. If not, the table remains unchanged.

![saplogon_2281](https://github.com/user-attachments/assets/6fbbe71d-4a15-4c9c-9139-a984962e8eb4)

Closes #1284

It should fix #6746 as well since the check does not depend on the local/remote state anymore (@larshp). 

PS: Although this introduces a new popup, the change moves it to the UI layer. This paves the way for refactoring the pull process into a HTML page. This page will show the results of the deserialize check with checkboxes. You select objects to process and confirm to trigger the import.