### PR TITLE
Refactor: Persistence factory

### DIFF
--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -31,7 +31,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
+CLASS zcl_abapgit_background IMPLEMENTATION.
 
 
   METHOD dequeue.
@@ -135,14 +135,14 @@ CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
 
   METHOD run.
 
-    DATA: lo_per         TYPE REF TO zcl_abapgit_persist_background,
-          li_repo        TYPE REF TO zif_abapgit_repo,
-          li_repo_online TYPE REF TO zif_abapgit_repo_online,
-          lt_list        TYPE zcl_abapgit_persist_background=>ty_background_keys,
-          li_background  TYPE REF TO zif_abapgit_background,
-          li_log         TYPE REF TO zif_abapgit_log,
-          lx_error       TYPE REF TO zcx_abapgit_exception,
-          lv_repo_name   TYPE string.
+    DATA:
+      li_repo        TYPE REF TO zif_abapgit_repo,
+      li_repo_online TYPE REF TO zif_abapgit_repo_online,
+      lt_list        TYPE zif_abapgit_persist_background=>ty_background_keys,
+      li_background  TYPE REF TO zif_abapgit_background,
+      li_log         TYPE REF TO zif_abapgit_log,
+      lx_error       TYPE REF TO zcx_abapgit_exception,
+      lv_repo_name   TYPE string.
 
     FIELD-SYMBOLS: <ls_list> LIKE LINE OF lt_list.
 
@@ -153,8 +153,7 @@ CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
         RETURN.
     ENDTRY.
 
-    CREATE OBJECT lo_per.
-    lt_list = lo_per->list( ).
+    lt_list = zcl_abapgit_persist_factory=>get_background( )->list( ).
 
     WRITE: / 'Background mode'.
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -465,7 +465,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       ENDIF.
 
       IF lv_package(1) = '$'.
-        zcl_abapgit_persist_packages=>get_instance( )->modify( lv_package ).
+        zcl_abapgit_persist_factory=>get_packages( )->modify( lv_package ).
       ENDIF.
 
       set_lock( ii_package = li_package
@@ -571,7 +571,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
     " For local packages store application component
     IF ls_package_data-devclass(1) = '$'.
-      zcl_abapgit_persist_packages=>get_instance( )->modify(
+      zcl_abapgit_persist_factory=>get_packages( )->modify(
         iv_package    = ls_package_data-devclass
         iv_component  = ls_package_data-component
         iv_comp_posid = ls_package_data-comp_posid ).
@@ -818,7 +818,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
   METHOD zif_abapgit_object~serialize.
     DATA: ls_package_data TYPE scompkdtln,
-          ls_package_comp TYPE zcl_abapgit_persist_packages=>ty_package,
+          ls_package_comp TYPE zif_abapgit_persist_packages=>ty_package,
           li_package      TYPE REF TO if_package,
           lt_intf_usages  TYPE tpak_permission_to_use_list,
           lt_usage_data   TYPE scomppdata,
@@ -847,7 +847,7 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
 
     " For local packages get application component
     IF is_local( ls_package_data-devclass ) = abap_true.
-      ls_package_comp = zcl_abapgit_persist_packages=>get_instance( )->read( ls_package_data-devclass ).
+      ls_package_comp = zcl_abapgit_persist_factory=>get_packages( )->read( ls_package_data-devclass ).
       ls_package_data-component  = ls_package_comp-component.
       ls_package_data-comp_posid = ls_package_comp-comp_posid.
     ENDIF.

--- a/src/persist/zcl_abapgit_persist_factory.clas.abap
+++ b/src/persist/zcl_abapgit_persist_factory.clas.abap
@@ -14,17 +14,53 @@ CLASS zcl_abapgit_persist_factory DEFINITION
     CLASS-METHODS get_settings
       RETURNING
         VALUE(ri_settings) TYPE REF TO zif_abapgit_persist_settings .
+    CLASS-METHODS get_background
+      RETURNING
+        VALUE(ri_background) TYPE REF TO zif_abapgit_persist_background.
+    CLASS-METHODS get_packages
+      RETURNING
+        VALUE(ri_packages) TYPE REF TO zif_abapgit_persist_packages.
+    CLASS-METHODS get_user
+      IMPORTING
+        !iv_user       TYPE sy-uname DEFAULT sy-uname
+      RETURNING
+        VALUE(ri_user) TYPE REF TO zif_abapgit_persist_user.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
     CLASS-DATA gi_repo TYPE REF TO zif_abapgit_persist_repo .
     CLASS-DATA gi_repo_cs TYPE REF TO zif_abapgit_persist_repo_cs .
     CLASS-DATA gi_settings TYPE REF TO zif_abapgit_persist_settings .
+    CLASS-DATA gi_background TYPE REF TO zif_abapgit_persist_background.
+    CLASS-DATA gi_packages TYPE REF TO zif_abapgit_persist_packages.
+    CLASS-DATA gi_current_user TYPE REF TO zif_abapgit_persist_user.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_PERSIST_FACTORY IMPLEMENTATION.
+CLASS zcl_abapgit_persist_factory IMPLEMENTATION.
+
+
+  METHOD get_background.
+
+    IF gi_background IS INITIAL.
+      CREATE OBJECT gi_background TYPE zcl_abapgit_persist_background.
+    ENDIF.
+
+    ri_background = gi_background.
+
+  ENDMETHOD.
+
+
+  METHOD get_packages.
+
+    IF gi_packages IS INITIAL.
+      CREATE OBJECT gi_packages TYPE zcl_abapgit_persist_packages.
+    ENDIF.
+
+    ri_packages = gi_packages.
+
+  ENDMETHOD.
 
 
   METHOD get_repo.
@@ -56,6 +92,22 @@ CLASS ZCL_ABAPGIT_PERSIST_FACTORY IMPLEMENTATION.
     ENDIF.
 
     ri_settings = gi_settings.
+
+  ENDMETHOD.
+
+
+  METHOD get_user.
+
+    IF iv_user = sy-uname ##USER_OK.
+      IF gi_current_user IS NOT BOUND.
+        CREATE OBJECT gi_current_user TYPE zcl_abapgit_persistence_user.
+      ENDIF.
+      ri_user = gi_current_user.
+    ELSE.
+      CREATE OBJECT ri_user TYPE zcl_abapgit_persistence_user
+        EXPORTING
+          iv_user = iv_user.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/persist/zcl_abapgit_persist_injector.clas.abap
+++ b/src/persist/zcl_abapgit_persist_injector.clas.abap
@@ -17,6 +17,18 @@ CLASS zcl_abapgit_persist_injector DEFINITION
       IMPORTING
         !ii_settings TYPE REF TO zif_abapgit_persist_settings .
 
+    CLASS-METHODS set_background
+      IMPORTING
+        !ii_background TYPE REF TO zif_abapgit_persist_background.
+
+    CLASS-METHODS set_packages
+      IMPORTING
+        !ii_packages TYPE REF TO zif_abapgit_persist_packages.
+
+    CLASS-METHODS set_current_user
+      IMPORTING
+        !ii_current_user TYPE REF TO zif_abapgit_persist_user.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -25,7 +37,28 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_PERSIST_INJECTOR IMPLEMENTATION.
+CLASS zcl_abapgit_persist_injector IMPLEMENTATION.
+
+
+  METHOD set_background.
+
+    zcl_abapgit_persist_factory=>gi_background = ii_background.
+
+  ENDMETHOD.
+
+
+  METHOD set_current_user.
+
+    zcl_abapgit_persist_factory=>gi_current_user = ii_current_user.
+
+  ENDMETHOD.
+
+
+  METHOD set_packages.
+
+    zcl_abapgit_persist_factory=>gi_packages = ii_packages.
+
+  ENDMETHOD.
 
 
   METHOD set_repo.

--- a/src/persist/zcl_abapgit_persist_packages.clas.testclasses.abap
+++ b/src/persist/zcl_abapgit_persist_packages.clas.testclasses.abap
@@ -19,14 +19,14 @@ CLASS ltcl_packages IMPLEMENTATION.
 
   METHOD test_package.
 
-    DATA lo_packages TYPE REF TO zcl_abapgit_persist_packages.
-    DATA ls_package TYPE zcl_abapgit_persist_packages=>ty_package.
+    DATA li_packages TYPE REF TO zif_abapgit_persist_packages.
+    DATA ls_package TYPE zif_abapgit_persist_packages=>ty_package.
     DATA lx_error TYPE REF TO zcx_abapgit_exception.
 
-    lo_packages = zcl_abapgit_persist_packages=>get_instance( ).
+    li_packages = zcl_abapgit_persist_factory=>get_packages( ).
 
     TRY.
-        lo_packages->modify(
+        li_packages->modify(
           iv_package    = c_package
           iv_component  = c_component
           iv_comp_posid = c_comp_posid ).
@@ -35,7 +35,7 @@ CLASS ltcl_packages IMPLEMENTATION.
     ENDTRY.
 
     TRY.
-        ls_package = lo_packages->read( c_package ).
+        ls_package = li_packages->read( c_package ).
 
         cl_abap_unit_assert=>assert_equals(
           act = ls_package-component
@@ -53,13 +53,13 @@ CLASS ltcl_packages IMPLEMENTATION.
 
   METHOD teardown.
 
-    DATA lo_packages TYPE REF TO zcl_abapgit_persist_packages.
+    DATA li_packages TYPE REF TO zif_abapgit_persist_packages.
 
-    lo_packages = zcl_abapgit_persist_packages=>get_instance( ).
+    li_packages = zcl_abapgit_persist_factory=>get_packages( ).
 
     " Remove test data
     TRY.
-        lo_packages->modify( c_package ).
+        li_packages->modify( c_package ).
       CATCH zcx_abapgit_exception.
     ENDTRY.
 

--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -240,10 +240,7 @@ CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
 
   METHOD zif_abapgit_persist_repo~delete.
 
-    DATA: lo_background TYPE REF TO zcl_abapgit_persist_background.
-
-    CREATE OBJECT lo_background.
-    lo_background->delete( iv_key ).
+    zcl_abapgit_persist_factory=>get_background( )->delete( iv_key ).
 
     mo_db->delete( iv_type  = zcl_abapgit_persistence_db=>c_type_repo
                    iv_value = iv_key ).

--- a/src/persist/zcl_abapgit_persistence_user.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_user.clas.abap
@@ -1,6 +1,7 @@
 CLASS zcl_abapgit_persistence_user DEFINITION
   PUBLIC
-  CREATE PRIVATE .
+  CREATE PRIVATE
+  GLOBAL FRIENDS zcl_abapgit_persist_factory.
 
   PUBLIC SECTION.
 
@@ -15,9 +16,7 @@ CLASS zcl_abapgit_persistence_user DEFINITION
         zcx_abapgit_exception .
     METHODS constructor
       IMPORTING
-        !iv_user TYPE sy-uname DEFAULT sy-uname
-      RAISING
-        zcx_abapgit_exception .
+        !iv_user TYPE sy-uname DEFAULT sy-uname.
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -55,12 +54,8 @@ CLASS zcl_abapgit_persistence_user DEFINITION
       IMPORTING
         !iv_xml        TYPE string
       RETURNING
-        VALUE(rs_user) TYPE ty_user
-      RAISING
-        zcx_abapgit_exception .
-    METHODS read
-      RAISING
-        zcx_abapgit_exception .
+        VALUE(rs_user) TYPE ty_user.
+    METHODS read.
     METHODS read_repo_config
       IMPORTING
         !iv_url               TYPE zif_abapgit_persistence=>ty_repo-url

--- a/src/persist/zif_abapgit_persist_background.intf.abap
+++ b/src/persist/zif_abapgit_persist_background.intf.abap
@@ -1,0 +1,54 @@
+INTERFACE zif_abapgit_persist_background PUBLIC.
+
+  TYPES:
+    BEGIN OF ty_xml,
+      method   TYPE string,
+      username TYPE string,
+      password TYPE string,
+      settings TYPE zif_abapgit_background=>ty_settings_tt,
+    END OF ty_xml.
+
+  TYPES:
+    BEGIN OF ty_background,
+      key TYPE zif_abapgit_persistence=>ty_value.
+      INCLUDE TYPE ty_xml.
+  TYPES: END OF ty_background.
+
+  TYPES ty_background_keys TYPE STANDARD TABLE OF ty_background WITH DEFAULT KEY.
+
+  METHODS list
+    RETURNING
+      VALUE(rt_list) TYPE ty_background_keys
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS get_by_key
+    IMPORTING
+      !iv_key        TYPE ty_background-key
+    RETURNING
+      VALUE(rs_data) TYPE ty_background
+    RAISING
+      zcx_abapgit_exception
+      zcx_abapgit_not_found.
+
+  METHODS modify
+    IMPORTING
+      !is_data TYPE ty_background
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS delete
+    IMPORTING
+      !iv_key TYPE ty_background-key
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS exists
+    IMPORTING
+      !iv_key       TYPE ty_background-key
+    RETURNING
+      VALUE(rv_yes) TYPE abap_bool
+    RAISING
+      zcx_abapgit_exception.
+
+ENDINTERFACE.

--- a/src/persist/zif_abapgit_persist_background.intf.xml
+++ b/src/persist/zif_abapgit_persist_background.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_PERSIST_BACKGROUND</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Persistence for Background</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/persist/zif_abapgit_persist_packages.intf.abap
+++ b/src/persist/zif_abapgit_persist_packages.intf.abap
@@ -1,0 +1,25 @@
+INTERFACE zif_abapgit_persist_packages PUBLIC.
+
+  TYPES:
+    BEGIN OF ty_package,
+      devclass   TYPE scompkdtln-devclass,
+      component  TYPE scompkdtln-component,
+      comp_posid TYPE scompkdtln-comp_posid,
+    END OF ty_package,
+    ty_packages TYPE HASHED TABLE OF ty_package WITH UNIQUE KEY devclass.
+
+  METHODS modify
+    IMPORTING
+      !iv_package    TYPE scompkdtln-devclass
+      !iv_component  TYPE scompkdtln-component OPTIONAL
+      !iv_comp_posid TYPE scompkdtln-comp_posid OPTIONAL
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS read
+    IMPORTING
+      !iv_package       TYPE scompkdtln-devclass
+    RETURNING
+      VALUE(rs_package) TYPE ty_package.
+
+ENDINTERFACE.

--- a/src/persist/zif_abapgit_persist_packages.intf.xml
+++ b/src/persist/zif_abapgit_persist_packages.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_PERSIST_PACKAGES</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Persistence for SAP Packages</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -933,13 +933,11 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
   METHOD render_repo_top.
 
     DATA: li_repo_online TYPE REF TO zif_abapgit_repo_online,
-          lo_pback       TYPE REF TO zcl_abapgit_persist_background,
           lx_error       TYPE REF TO zcx_abapgit_exception,
           lv_hint        TYPE string,
           lv_icon        TYPE string.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-    CREATE OBJECT lo_pback.
 
     IF ii_repo->is_offline( ) = abap_true.
       lv_icon = 'plug/darkgrey'.
@@ -1026,7 +1024,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
                                             iv_hint  = 'Toggle Favorite' ) ).
 
     " BG
-    IF lo_pback->exists( ii_repo->get_key( ) ) = abap_true.
+    IF zcl_abapgit_persist_factory=>get_background( )->exists( ii_repo->get_key( ) ) = abap_true.
       ri_html->add( '<span class="bg_marker" title="background">BG</span>' ).
     ENDIF.
 

--- a/src/ui/pages/sett/zcl_abapgit_gui_page_sett_bckg.clas.abap
+++ b/src/ui/pages/sett/zcl_abapgit_gui_page_sett_bckg.clas.abap
@@ -56,7 +56,7 @@ CLASS zcl_abapgit_gui_page_sett_bckg DEFINITION
         zcx_abapgit_exception .
     METHODS read_persist
       RETURNING
-        VALUE(rs_persist) TYPE zcl_abapgit_persist_background=>ty_background
+        VALUE(rs_persist) TYPE zif_abapgit_persist_background=>ty_background
       RAISING
         zcx_abapgit_exception .
     METHODS save_settings
@@ -173,12 +173,8 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
 
   METHOD read_persist.
 
-    DATA lo_per TYPE REF TO zcl_abapgit_persist_background.
-
-    CREATE OBJECT lo_per.
-
     TRY.
-        rs_persist = lo_per->get_by_key( mi_repo->get_key( ) ).
+        zcl_abapgit_persist_factory=>get_background( )->get_by_key( mi_repo->get_key( ) ).
       CATCH zcx_abapgit_not_found.
         CLEAR rs_persist.
     ENDTRY.
@@ -189,7 +185,7 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
   METHOD read_settings.
 
     DATA:
-      ls_per      TYPE zcl_abapgit_persist_background=>ty_background,
+      ls_per      TYPE zif_abapgit_persist_background=>ty_background,
       lv_row      TYPE i,
       lv_val      TYPE string,
       lt_settings LIKE ls_per-settings,
@@ -256,8 +252,7 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
   METHOD save_settings.
 
     DATA:
-      lo_persistence TYPE REF TO zcl_abapgit_persist_background,
-      ls_per         TYPE zcl_abapgit_persist_background=>ty_background,
+      ls_per         TYPE zif_abapgit_persist_background=>ty_background,
       lt_settings    LIKE ls_per-settings.
 
     FIELD-SYMBOLS:
@@ -292,12 +287,10 @@ CLASS zcl_abapgit_gui_page_sett_bckg IMPLEMENTATION.
     ls_per-username = mo_form_data->get( c_id-username ).
     ls_per-password = mo_form_data->get( c_id-password ).
 
-    CREATE OBJECT lo_persistence.
-
     IF ls_per-method IS INITIAL.
-      lo_persistence->delete( ls_per-key ).
+      zcl_abapgit_persist_factory=>get_background( )->delete( ls_per-key ).
     ELSE.
-      lo_persistence->modify( ls_per ).
+      zcl_abapgit_persist_factory=>get_background( )->modify( ls_per ).
     ENDIF.
 
     COMMIT WORK AND WAIT.


### PR DESCRIPTION
This change moves persistence for background, packages, and users to the persistence factory.

Changing `zcl_abapgit_persistence_user=>get_instance( )` to `zcl_abapgit_persist_factory=>get_user( )` will be a separate PR.