### PR TITLE
Require CLAS and INTF for HTTP in deserialization

### DIFF
--- a/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_deserialize.clas.abap
@@ -203,6 +203,9 @@ CLASS zcl_abapgit_file_deserialize IMPLEMENTATION.
           lt_requires = lt_items.
           DELETE lt_requires WHERE obj_type <> 'SPRX'
             AND obj_type <> 'XSLT'.
+        WHEN 'HTTP'.
+          lt_requires = lt_items.
+          DELETE lt_requires WHERE obj_type <> 'CLAS' AND obj_type <> 'INTF'.
         WHEN 'TABL'.
           lt_requires = lt_items.
           DELETE lt_requires WHERE obj_type <> 'SPRX'.


### PR DESCRIPTION
Fixes #7249