### PR TITLE
PO UTF8 BOM and stage page duplication rule

### DIFF
--- a/src/objects/texts/zcl_abapgit_po_file.clas.abap
+++ b/src/objects/texts/zcl_abapgit_po_file.clas.abap
@@ -356,7 +356,7 @@ CLASS ZCL_ABAPGIT_PO_FILE IMPLEMENTATION.
         && cl_abap_char_utilities=>newline
         && lv_str
         && cl_abap_char_utilities=>newline. " Trailing LF
-      rv_data = zcl_abapgit_convert=>string_to_xstring_utf8_bom( lv_str ).
+      rv_data = zcl_abapgit_convert=>string_to_xstring_utf8( lv_str ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.locals_imp.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.locals_imp.abap
@@ -145,7 +145,7 @@ CLASS lcl_selected IMPLEMENTATION.
       ls_file-filename = to_lower( ls_file-filename ).
 
       " Skip packages since they all have identical filenames
-      IF NOT ( ls_file-filename CP 'package.devc.*' ).
+      IF NOT ls_file-filename CP 'package.devc.*'.
         lv_pattern = '*/' && to_upper( ls_file-filename ).
         REPLACE ALL OCCURRENCES OF '#' IN lv_pattern WITH '##'. " for CP
 

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.locals_imp.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.locals_imp.abap
@@ -145,7 +145,7 @@ CLASS lcl_selected IMPLEMENTATION.
       ls_file-filename = to_lower( ls_file-filename ).
 
       " Skip packages since they all have identical filenames
-      IF ls_file-filename <> 'package.devc.xml'.
+      IF NOT ( ls_file-filename CP 'package.devc.*' ).
         lv_pattern = '*/' && to_upper( ls_file-filename ).
         REPLACE ALL OCCURRENCES OF '#' IN lv_pattern WITH '##'. " for CP
 


### PR DESCRIPTION
Minor fixes to PO related logic:

1) remove UTF8 BOM marker - looks like they are not supported by native gettext tools, and they are unnecessary in general in this case
2) stage page logic that checks duplication excludes package.devc.xml but now also relevant .po files (by the way this is certainly a "business logic" si ideally should be moved to the "model" eventually)