### PR TITLE
Make Pull/Stage buttons visible if there are no changes

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -201,7 +201,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_VIEW IMPLEMENTATION.
 
 
   METHOD apply_order_by.
@@ -431,14 +431,15 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
     IF mi_repo->is_offline( ) = abap_false.
       " online repo
 
+      ro_toolbar->add( iv_txt = 'Pull'
+                       iv_act = |{ zif_abapgit_definitions=>c_action-git_pull }?key={ mv_key }|
+                       iv_opt = get_crossout( iv_protected = abap_true
+                                              iv_strong    = abap_true ) ).
+      ro_toolbar->add( iv_txt = 'Stage'
+                       iv_act = |{ zif_abapgit_definitions=>c_action-go_stage }?key={ mv_key }|
+                       iv_opt = zif_abapgit_html=>c_html_opt-strong ).
+
       IF mo_repo_aggregated_state->is_unchanged( ) = abap_false. " Any changes
-        ro_toolbar->add( iv_txt = 'Pull'
-                         iv_act = |{ zif_abapgit_definitions=>c_action-git_pull }?key={ mv_key }|
-                         iv_opt = get_crossout( iv_protected = abap_true
-                                                iv_strong    = abap_true ) ).
-        ro_toolbar->add( iv_txt = 'Stage'
-                         iv_act = |{ zif_abapgit_definitions=>c_action-go_stage }?key={ mv_key }|
-                         iv_opt = zif_abapgit_html=>c_html_opt-strong ).
         ro_toolbar->add( iv_txt = 'Patch'
                          iv_act = |{ zif_abapgit_definitions=>c_action-go_patch }?key={ mv_key }|
                          iv_opt = zif_abapgit_html=>c_html_opt-strong ).


### PR DESCRIPTION
<img width="454" alt="image" src="https://github.com/user-attachments/assets/6e3033b0-9caa-4db2-8562-5c25d313f77d" />

Get those 2 buttons visible all the time. The problem is that if the repo is opened in AG and there is active work on the code and the user knows there were changes and he wants to commit, he has to Refresh first and than stage. The state triggers refresh the repo again, which is annoying for larger repos. Actually this was the original behavior and then it changed at some point to show only when changes are detected but it ended up being inconvenient. It was actually tolerable when there was caching, but without caching it is really annoying and wasteful. So let's fix things back.

For both commands there is a guard check - to do nothing if there are no real changes detected after the command, so this change is safe.