### PR TITLE
fix file_to_object to use filename part only

### DIFF
--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -94,19 +94,19 @@ CLASS zcl_abapgit_filename_logic DEFINITION
     CLASS-METHODS map_filename_to_object
       IMPORTING
         !iv_item_part_of_filename TYPE string
-        !iv_path     TYPE string
-        !iv_package  TYPE devclass
-        !io_dot      TYPE REF TO zcl_abapgit_dot_abapgit
+        !iv_path                  TYPE string
+        !iv_package               TYPE devclass
+        !io_dot                   TYPE REF TO zcl_abapgit_dot_abapgit
       CHANGING
-        cs_item      TYPE zif_abapgit_definitions=>ty_item
+        cs_item                   TYPE zif_abapgit_definitions=>ty_item
       RAISING
         zcx_abapgit_exception.
 
     CLASS-METHODS map_object_to_filename
       IMPORTING
-        !is_item    TYPE zif_abapgit_definitions=>ty_item
-        !iv_ext     TYPE string
-        !iv_extra   TYPE clike
+        !is_item                 TYPE zif_abapgit_definitions=>ty_item
+        !iv_ext                  TYPE string
+        !iv_extra                TYPE clike
       CHANGING
         cv_item_part_of_filename TYPE string
       RAISING

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -93,7 +93,7 @@ CLASS zcl_abapgit_filename_logic DEFINITION
 
     CLASS-METHODS map_filename_to_object
       IMPORTING
-        !iv_filename TYPE string
+        !iv_item_part_of_filename TYPE string
         !iv_path     TYPE string
         !iv_package  TYPE devclass
         !io_dot      TYPE REF TO zcl_abapgit_dot_abapgit
@@ -108,7 +108,7 @@ CLASS zcl_abapgit_filename_logic DEFINITION
         !iv_ext     TYPE string
         !iv_extra   TYPE clike
       CHANGING
-        cv_filename TYPE string
+        cv_item_part_of_filename TYPE string
       RAISING
         zcx_abapgit_exception.
 
@@ -173,7 +173,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
     " Get mapping specific to object type
     map_filename_to_object(
       EXPORTING
-        iv_filename = lv_name " original-cased object name part only
+        iv_item_part_of_filename = lv_name " original-cased object name part only
         iv_path     = iv_path
         io_dot      = io_dot
         iv_package  = iv_devclass
@@ -289,7 +289,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
 
         CALL METHOD (lv_class)=>('ZIF_ABAPGIT_OBJECT~MAP_FILENAME_TO_OBJECT')
           EXPORTING
-            iv_filename = iv_filename
+            iv_filename = iv_item_part_of_filename
             iv_path     = iv_path
             io_dot      = io_dot
             iv_package  = iv_package
@@ -327,7 +327,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
             iv_ext      = iv_ext
             iv_extra    = iv_extra
           CHANGING
-            cv_filename = cv_filename.
+            cv_filename = cv_item_part_of_filename.
       CATCH cx_sy_dyn_call_illegal_class ##NO_HANDLER.
     ENDTRY.
 
@@ -377,7 +377,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
             iv_ext      = iv_ext
             iv_extra    = iv_extra
           CHANGING
-            cv_filename = rv_filename ). " just the object name, not the full name with all the prefixes.
+            cv_item_part_of_filename = rv_filename ).
       CATCH zcx_abapgit_exception ##NO_HANDLER.
     ENDTRY.
 

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -144,7 +144,9 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
       lv_ext  TYPE string.
 
     " Guess object type and name
-    SPLIT to_upper( iv_filename ) AT '.' INTO lv_name lv_type lv_ext.
+    SPLIT iv_filename AT '.' INTO lv_name lv_type lv_ext.
+    lv_type = to_upper( lv_type ).
+    lv_ext  = to_upper( lv_ext ).
 
     " Handle namespaces
     REPLACE ALL OCCURRENCES OF '#' IN lv_name WITH '/'.
@@ -166,12 +168,12 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
 
     CLEAR es_item.
     es_item-obj_type = lv_type.
-    es_item-obj_name = lv_name.
+    es_item-obj_name = to_upper( lv_name ).
 
     " Get mapping specific to object type
     map_filename_to_object(
       EXPORTING
-        iv_filename = to_lower( lv_name ) " object name part only
+        iv_filename = lv_name " original-cased object name part only
         iv_path     = iv_path
         io_dot      = io_dot
         iv_package  = iv_devclass

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -171,7 +171,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
     " Get mapping specific to object type
     map_filename_to_object(
       EXPORTING
-        iv_filename = iv_filename
+        iv_filename = to_lower( lv_name ) " object name part only
         iv_path     = iv_path
         io_dot      = io_dot
         iv_package  = iv_devclass

--- a/src/objects/core/zcl_abapgit_filename_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_filename_logic.clas.abap
@@ -289,7 +289,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
 
         CALL METHOD (lv_class)=>('ZIF_ABAPGIT_OBJECT~MAP_FILENAME_TO_OBJECT')
           EXPORTING
-            iv_filename = iv_item_part_of_filename
+            iv_item_part_of_filename = iv_item_part_of_filename
             iv_path     = iv_path
             io_dot      = io_dot
             iv_package  = iv_package
@@ -327,7 +327,7 @@ CLASS ZCL_ABAPGIT_FILENAME_LOGIC IMPLEMENTATION.
             iv_ext      = iv_ext
             iv_extra    = iv_extra
           CHANGING
-            cv_filename = cv_item_part_of_filename.
+            cv_item_part_of_filename = cv_item_part_of_filename.
       CATCH cx_sy_dyn_call_illegal_class ##NO_HANDLER.
     ENDTRY.
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -794,7 +794,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DEVC IMPLEMENTATION.
 
   METHOD zif_abapgit_object~map_filename_to_object.
 
-    IF iv_filename <> zcl_abapgit_filename_logic=>c_package_file.
+    IF to_lower( iv_filename ) <> zcl_abapgit_filename_logic=>c_package_file-obj_name.
       zcx_abapgit_exception=>raise( |Unexpected filename for package { cs_item-obj_name }| ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -794,7 +794,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DEVC IMPLEMENTATION.
 
   METHOD zif_abapgit_object~map_filename_to_object.
 
-    IF iv_filename <> zcl_abapgit_filename_logic=>c_package_file-obj_name.
+    IF iv_item_part_of_filename <> zcl_abapgit_filename_logic=>c_package_file-obj_name.
       zcx_abapgit_exception=>raise( |Unexpected filename for package { cs_item-obj_name }| ).
     ENDIF.
 
@@ -812,7 +812,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DEVC IMPLEMENTATION.
 
     " Packages have a fixed filename so that the repository can be installed to a different
     " package(-hierarchy) on the client and not show up as a different package in the repo.
-    cv_filename = zcl_abapgit_filename_logic=>c_package_file-obj_name.
+    cv_item_part_of_filename = zcl_abapgit_filename_logic=>c_package_file-obj_name.
     " use just obj_name ("package") so that e.g. translation files also have this first part
     " yet be able to modify the extension e.g. package.i18n.de.po
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -794,7 +794,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DEVC IMPLEMENTATION.
 
   METHOD zif_abapgit_object~map_filename_to_object.
 
-    IF to_lower( iv_filename ) <> zcl_abapgit_filename_logic=>c_package_file-obj_name.
+    IF iv_filename <> zcl_abapgit_filename_logic=>c_package_file-obj_name.
       zcx_abapgit_exception=>raise( |Unexpected filename for package { cs_item-obj_name }| ).
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -630,8 +630,8 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_tadir> LIKE LINE OF lt_tadir.
 
-    lv_obj_name = to_upper( iv_filename(15) ) && '%'.
-    lv_hash     = iv_filename+15(25).
+    lv_obj_name = to_upper( iv_item_part_of_filename(15) ) && '%'.
+    lv_hash     = iv_item_part_of_filename+15(25).
 
     SELECT * FROM tadir INTO CORRESPONDING FIELDS OF TABLE lt_tadir
       WHERE pgmid = 'R3TR'
@@ -651,7 +651,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
 
   METHOD zif_abapgit_object~map_object_to_filename.
 
-    cv_filename = |{ cv_filename(15) }{ get_hash_from_object( is_item-obj_name ) }|.
+    cv_item_part_of_filename = |{ cv_item_part_of_filename(15) }{ get_hash_from_object( is_item-obj_name ) }|.
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -631,7 +631,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
     FIELD-SYMBOLS <ls_tadir> LIKE LINE OF lt_tadir.
 
     lv_obj_name = to_upper( iv_filename(15) ) && '%'.
-    lv_hash     = iv_filename+15(25).
+    lv_hash     = to_lower( iv_filename+15(25) ). " get_hash_from_object also returns lowercased
 
     SELECT * FROM tadir INTO CORRESPONDING FIELDS OF TABLE lt_tadir
       WHERE pgmid = 'R3TR'

--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -631,7 +631,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
     FIELD-SYMBOLS <ls_tadir> LIKE LINE OF lt_tadir.
 
     lv_obj_name = to_upper( iv_filename(15) ) && '%'.
-    lv_hash     = to_lower( iv_filename+15(25) ). " get_hash_from_object also returns lowercased
+    lv_hash     = iv_filename+15(25).
 
     SELECT * FROM tadir INTO CORRESPONDING FIELDS OF TABLE lt_tadir
       WHERE pgmid = 'R3TR'

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -88,22 +88,22 @@ INTERFACE zif_abapgit_object PUBLIC.
 
   CLASS-METHODS map_filename_to_object
     IMPORTING
-      !iv_filename TYPE string
-      !iv_path     TYPE string OPTIONAL
-      !io_dot      TYPE REF TO zcl_abapgit_dot_abapgit OPTIONAL
-      !iv_package  TYPE devclass OPTIONAL
+      !iv_item_part_of_filename TYPE string
+      !iv_path                  TYPE string OPTIONAL
+      !io_dot                   TYPE REF TO zcl_abapgit_dot_abapgit OPTIONAL
+      !iv_package               TYPE devclass OPTIONAL
     CHANGING
-      cs_item      TYPE zif_abapgit_definitions=>ty_item
+      cs_item                   TYPE zif_abapgit_definitions=>ty_item
     RAISING
       zcx_abapgit_exception.
 
   CLASS-METHODS map_object_to_filename
     IMPORTING
-      !is_item    TYPE zif_abapgit_definitions=>ty_item
-      !iv_ext     TYPE string
-      !iv_extra   TYPE clike
+      !is_item                  TYPE zif_abapgit_definitions=>ty_item
+      !iv_ext                   TYPE string
+      !iv_extra                 TYPE clike
     CHANGING
-      cv_filename TYPE string
+      !cv_item_part_of_filename TYPE string
     RAISING
       zcx_abapgit_exception.
 


### PR DESCRIPTION
Follows #7259, looks like deserialization (file_to_object) also needed filename logic adjustment to support po deserialization.

Let's keep it wip for a while, I'll be doing some more real tests.

P.S. also architecture-wise ... I don't know, this mapping approach feels somehow very untransparent, feels like some JS spaghetti a bit.