### PR TITLE
Exclude objects from i18n

### DIFF
--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -274,7 +274,8 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
 
     IF io_dot_abapgit IS BOUND.
       ms_i18n_params = io_dot_abapgit->determine_i18n_parameters( is_local_settings-main_language_only ).
-      mt_wo_translation_patterns = zcl_abapgit_i18n_params=>normalize_obj_patterns( io_dot_abapgit->get_objs_without_translation( ) ).
+      mt_wo_translation_patterns =
+        zcl_abapgit_i18n_params=>normalize_obj_patterns( io_dot_abapgit->get_objs_without_translation( ) ).
     ELSE.
       ms_i18n_params-main_language      = sy-langu.
       ms_i18n_params-main_language_only = is_local_settings-main_language_only.

--- a/src/objects/core/zcl_abapgit_serialize.clas.abap
+++ b/src/objects/core/zcl_abapgit_serialize.clas.abap
@@ -55,6 +55,7 @@ CLASS zcl_abapgit_serialize DEFINITION
     DATA ms_local_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings.
     DATA ms_i18n_params TYPE zif_abapgit_definitions=>ty_i18n_params.
     DATA mo_abap_language_version TYPE REF TO zcl_abapgit_abap_language_vers.
+    DATA mt_wo_translation_patterns TYPE string_table.
 
     METHODS add_apack
       IMPORTING
@@ -273,6 +274,7 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
 
     IF io_dot_abapgit IS BOUND.
       ms_i18n_params = io_dot_abapgit->determine_i18n_parameters( is_local_settings-main_language_only ).
+      mt_wo_translation_patterns = zcl_abapgit_i18n_params=>normalize_obj_patterns( io_dot_abapgit->get_objs_without_translation( ) ).
     ELSE.
       ms_i18n_params-main_language      = sy-langu.
       ms_i18n_params-main_language_only = is_local_settings-main_language_only.
@@ -598,10 +600,18 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
           lv_task TYPE c LENGTH 32,
           lv_free LIKE mv_free.
     DATA lv_abap_language_version TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version.
+    DATA lv_main_language_only TYPE abap_bool.
 
     ASSERT mv_free > 0.
 
     lv_abap_language_version = mo_abap_language_version->get_repo_abap_language_version( ).
+
+    lv_main_language_only = ms_i18n_params-main_language_only.
+    IF lv_main_language_only = abap_false AND mt_wo_translation_patterns IS NOT INITIAL.
+      lv_main_language_only = zcl_abapgit_i18n_params=>match_obj_patterns(
+        is_tadir                   = is_tadir
+        it_wo_translation_patterns = mt_wo_translation_patterns ).
+    ENDIF.
 
     DO.
       lv_task = |{ iv_task }-{ sy-index }|.
@@ -618,7 +628,7 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
           iv_srcsystem          = is_tadir-srcsystem
           iv_abap_language_vers = lv_abap_language_version
           iv_language           = ms_i18n_params-main_language
-          iv_main_language_only = ms_i18n_params-main_language_only
+          iv_main_language_only = lv_main_language_only
           iv_suppress_po_comments = ms_i18n_params-suppress_po_comments
           it_translation_langs  = ms_i18n_params-translation_languages
           iv_use_lxe            = ms_i18n_params-use_lxe
@@ -645,6 +655,7 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
   METHOD run_sequential.
 
     DATA: lx_error     TYPE REF TO zcx_abapgit_exception,
+          ls_i18n_params LIKE ms_i18n_params,
           ls_file_item TYPE zif_abapgit_objects=>ty_serialization.
 
     ls_file_item-item-obj_type  = is_tadir-object.
@@ -653,10 +664,17 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
     ls_file_item-item-srcsystem = is_tadir-srcsystem.
     ls_file_item-item-abap_language_version = mo_abap_language_version->get_repo_abap_language_version( ).
 
+    ls_i18n_params = ms_i18n_params.
+    IF ls_i18n_params-main_language_only = abap_false AND mt_wo_translation_patterns IS NOT INITIAL.
+      ls_i18n_params-main_language_only = zcl_abapgit_i18n_params=>match_obj_patterns(
+        is_tadir                   = is_tadir
+        it_wo_translation_patterns = mt_wo_translation_patterns ).
+    ENDIF.
+
     TRY.
         ls_file_item = zcl_abapgit_objects=>serialize(
           is_item        = ls_file_item-item
-          io_i18n_params = zcl_abapgit_i18n_params=>new( is_params = ms_i18n_params ) ).
+          io_i18n_params = zcl_abapgit_i18n_params=>new( is_params = ls_i18n_params ) ).
 
         add_to_return( is_file_item = ls_file_item
                        iv_path      = is_tadir-path ).

--- a/src/objects/texts/zcl_abapgit_i18n_params.clas.abap
+++ b/src/objects/texts/zcl_abapgit_i18n_params.clas.abap
@@ -46,7 +46,7 @@ CLASS zcl_abapgit_i18n_params DEFINITION
 
     CLASS-METHODS normalize_obj_patterns
       IMPORTING
-        it_wo_translation_patterns TYPE string_table
+        it_wo_translation_patterns     TYPE string_table
       RETURNING
         VALUE(rt_wo_translation_clean) TYPE string_table
       RAISING
@@ -55,9 +55,9 @@ CLASS zcl_abapgit_i18n_params DEFINITION
     CLASS-METHODS match_obj_patterns
       IMPORTING
         it_wo_translation_patterns TYPE string_table
-        is_tadir TYPE zif_abapgit_definitions=>ty_tadir
+        is_tadir                   TYPE zif_abapgit_definitions=>ty_tadir
       RETURNING
-        VALUE(rv_yes) TYPE abap_bool
+        VALUE(rv_yes)              TYPE abap_bool
       RAISING
         zcx_abapgit_exception.
 

--- a/src/objects/texts/zcl_abapgit_i18n_params.clas.testclasses.abap
+++ b/src/objects/texts/zcl_abapgit_i18n_params.clas.testclasses.abap
@@ -8,6 +8,7 @@ CLASS ltcl_i18n_params_test DEFINITION FINAL
     METHODS iso_langs_to_lang_filter FOR TESTING.
     METHODS filter_sap_langs FOR TESTING RAISING zcx_abapgit_exception.
     METHODS filter_sap_langs_tab FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS normalize_obj_patterns FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -168,6 +169,61 @@ CLASS ltcl_i18n_params_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals(
       act = lt_act
       exp = lt_exp ).
+
+  ENDMETHOD.
+
+  METHOD normalize_obj_patterns.
+
+    DATA lt_patterns TYPE string_table.
+    DATA lv_pattern TYPE string.
+
+    APPEND '  zcl_XY.clas' TO lt_patterns.
+    lt_patterns = zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+    READ TABLE lt_patterns INDEX 1 INTO lv_pattern.
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_pattern
+      exp = 'zcl_xy.clas' ).
+
+    APPEND '*.devc' TO lt_patterns.
+    zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+
+    APPEND 'pkg/*' TO lt_patterns.
+    zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+
+    APPEND 'pkg/sub/*' TO lt_patterns.
+    zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+
+    TRY.
+        CLEAR lt_patterns.
+        APPEND 'pkg/sub/ooo' TO lt_patterns.
+        zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception.
+    ENDTRY.
+
+    TRY.
+        CLEAR lt_patterns.
+        APPEND 'obj.badtype' TO lt_patterns.
+        zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception.
+    ENDTRY.
+
+    TRY.
+        CLEAR lt_patterns.
+        APPEND '/stuff' TO lt_patterns.
+        zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception.
+    ENDTRY.
+
+    TRY.
+        CLEAR lt_patterns.
+        APPEND '*.*' TO lt_patterns.
+        zcl_abapgit_i18n_params=>normalize_obj_patterns( lt_patterns ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH zcx_abapgit_exception.
+    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/repo/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/repo/zcl_abapgit_dot_abapgit.clas.abap
@@ -116,12 +116,12 @@ CLASS zcl_abapgit_dot_abapgit DEFINITION
     METHODS set_original_system
       IMPORTING
         !iv_original_system TYPE csequence .
-    METHODS get_master_lang_only_objects
+    METHODS get_objs_without_translation
       RETURNING
-        VALUE(rt_list) TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit-master_lang_only_objs.
-    METHODS set_master_lang_only_objects
+        VALUE(rt_list) TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit-without_translation.
+    METHODS set_objs_without_translation
       IMPORTING
-        !it_list TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit-master_lang_only_objs.
+        !it_list TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit-without_translation.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -264,13 +264,13 @@ CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_master_lang_only_objects.
-    rt_list = ms_data-master_lang_only_objs.
+  METHOD get_name.
+    rv_name = ms_data-name.
   ENDMETHOD.
 
 
-  METHOD get_name.
-    rv_name = ms_data-name.
+  METHOD get_objs_without_translation.
+    rt_list = ms_data-without_translation.
   ENDMETHOD.
 
 
@@ -383,13 +383,13 @@ CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD set_master_lang_only_objects.
-    ms_data-master_lang_only_objs = it_list.
+  METHOD set_name.
+    ms_data-name = iv_name.
   ENDMETHOD.
 
 
-  METHOD set_name.
-    ms_data-name = iv_name.
+  METHOD set_objs_without_translation.
+    ms_data-without_translation = it_list.
   ENDMETHOD.
 
 

--- a/src/repo/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/repo/zcl_abapgit_dot_abapgit.clas.abap
@@ -116,6 +116,12 @@ CLASS zcl_abapgit_dot_abapgit DEFINITION
     METHODS set_original_system
       IMPORTING
         !iv_original_system TYPE csequence .
+    METHODS get_master_lang_only_objects
+      RETURNING
+        VALUE(rt_list) TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit-master_lang_only_objs.
+    METHODS set_master_lang_only_objects
+      IMPORTING
+        !it_list TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit-master_lang_only_objs.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -138,7 +144,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
 
 
   METHOD add_ignore.
@@ -258,6 +264,11 @@ CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_master_lang_only_objects.
+    rt_list = ms_data-master_lang_only_objs.
+  ENDMETHOD.
+
+
   METHOD get_name.
     rv_name = ms_data-name.
   ENDMETHOD.
@@ -369,6 +380,11 @@ CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
 
   METHOD set_i18n_languages.
     ms_data-i18n_languages = it_languages.
+  ENDMETHOD.
+
+
+  METHOD set_master_lang_only_objects.
+    ms_data-master_lang_only_objs = it_list.
   ENDMETHOD.
 
 

--- a/src/repo/zif_abapgit_dot_abapgit.intf.abap
+++ b/src/repo/zif_abapgit_dot_abapgit.intf.abap
@@ -15,7 +15,7 @@ INTERFACE zif_abapgit_dot_abapgit PUBLIC.
       master_language       TYPE spras,
       i18n_languages        TYPE zif_abapgit_definitions=>ty_languages,
       use_lxe               TYPE abap_bool,
-      master_lang_only_objs TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+      without_translation   TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
       starting_folder       TYPE string,
       folder_logic          TYPE string,
       ignore                TYPE STANDARD TABLE OF string WITH DEFAULT KEY,

--- a/src/repo/zif_abapgit_dot_abapgit.intf.abap
+++ b/src/repo/zif_abapgit_dot_abapgit.intf.abap
@@ -15,6 +15,7 @@ INTERFACE zif_abapgit_dot_abapgit PUBLIC.
       master_language       TYPE spras,
       i18n_languages        TYPE zif_abapgit_definitions=>ty_languages,
       use_lxe               TYPE abap_bool,
+      master_lang_only_objs TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
       starting_folder       TYPE string,
       folder_logic          TYPE string,
       ignore                TYPE STANDARD TABLE OF string WITH DEFAULT KEY,

--- a/src/ui/pages/sett/zcl_abapgit_gui_page_sett_repo.clas.abap
+++ b/src/ui/pages/sett/zcl_abapgit_gui_page_sett_repo.clas.abap
@@ -163,7 +163,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETT_REPO IMPLEMENTATION.
       iv_hint        = 'It''s mandatory to specify the list of languages above in addition to this setting'
     )->textarea(
       iv_name        = c_id-wo_transaltion
-      iv_label       = 'Objects (wildcard) to keep in master language only (without translation)'
+      iv_label       = 'Objects (wildcard) to keep in main language only (without translation)'
       iv_hint        = |List of patterns to exclude from translation. The check builds a simplified path to object:|
                     && | like `/src/pkg/subpkg/obj.type` which is then checked versus patterns with CP.|
                     && | So to exclude specific object use `*/zcl_xy.clas`, object of the specific type - `*.clas`,|

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -389,6 +389,7 @@ INTERFACE zif_abapgit_definitions
     BEGIN OF ty_i18n_params,
       main_language         TYPE sy-langu,
       main_language_only    TYPE abap_bool,
+      main_lang_only_objs   TYPE string_table,
       translation_languages TYPE ty_languages,
       use_lxe               TYPE abap_bool,
       suppress_po_comments  TYPE abap_bool,

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -389,7 +389,6 @@ INTERFACE zif_abapgit_definitions
     BEGIN OF ty_i18n_params,
       main_language         TYPE sy-langu,
       main_language_only    TYPE abap_bool,
-      main_lang_only_objs   TYPE string_table,
       translation_languages TYPE ty_languages,
       use_lxe               TYPE abap_bool,
       suppress_po_comments  TYPE abap_bool,


### PR DESCRIPTION
closes #7293

![image](https://github.com/user-attachments/assets/fae64c9b-dd9a-4d24-8a71-d24d23a18f9a)

![image](https://github.com/user-attachments/assets/03c83439-02f3-4b20-aeab-ff34ca87f895)

**Final solution**:
- build a simplified path, from tadir item (from serialization - it has package path!): `/src/pkg/subpkg/obj.type`, so not xmls, the type is kind of file extension
- check this path versus list of patterns
- the pattern without `/` or `*` at start are prepended with `*/` (kind of relative path - though I'm not 100% as it becomes implicit... yet convenient)
