### PR TITLE
Change version constant type to simple

### DIFF
--- a/src/repo/utils/zcl_abapgit_version.clas.abap
+++ b/src/repo/utils/zcl_abapgit_version.clas.abap
@@ -203,7 +203,7 @@ CLASS zcl_abapgit_version IMPLEMENTATION.
   METHOD get_version_constant_value.
     DATA: lv_version_class     TYPE seoclsname,
           lv_version_component TYPE string.
-    FIELD-SYMBOLS: <lv_version> TYPE string.
+    FIELD-SYMBOLS: <lv_version> TYPE simple.
 
     IF iv_version_constant NP '*=>*'.
       zcx_abapgit_exception=>raise( 'Version constant needs to use the format CLASS/INTERFACE=>CONSTANT' ).


### PR DESCRIPTION
This is for fixing a dump when trying to place a non-string constant there:
![image](https://github.com/user-attachments/assets/dcafd4a3-3de5-4ebb-afc6-392ec8f663b1)

![image](https://github.com/user-attachments/assets/4fdacf3c-50d2-49dd-8912-6be351dd90b4)

I believe version variables can also be typed as integers, floats, numeric, char and others.