### PR TITLE
TABU: Avoid dump if table misses some fields

### DIFF
--- a/src/data/zcl_abapgit_data_deserializer.clas.abap
+++ b/src/data/zcl_abapgit_data_deserializer.clas.abap
@@ -72,6 +72,7 @@ CLASS zcl_abapgit_data_deserializer IMPLEMENTATION.
 
     TRY.
         lo_ajson = zcl_abapgit_ajson=>parse( zcl_abapgit_convert=>xstring_to_string_utf8( is_file-data ) ).
+        lo_ajson->to_abap_corresponding_only( ).
         lo_ajson->zif_abapgit_ajson~to_abap( IMPORTING ev_container = <lg_tab> ).
       CATCH zcx_abapgit_ajson_error INTO lx_ajson.
         zcx_abapgit_exception=>raise( lx_ajson->get_text( ) ).


### PR DESCRIPTION
Use move-corresponding logic for filling the target structure. 

If fields are missing in the target system but are filled in the repo, you will see diffs. 

Closes #7330