### PR TITLE
PO syntax highlighting

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_factory.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_factory.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_syntax_factory IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SYNTAX_FACTORY IMPLEMENTATION.
 
 
   METHOD create.
@@ -35,6 +35,8 @@ CLASS zcl_abapgit_syntax_factory IMPLEMENTATION.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_json.
     ELSEIF iv_filename CP '*.txt' OR iv_filename CP '*.ini'  OR iv_filename CP '*.text'.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_txt.
+    ELSEIF iv_filename CP '*.po'.
+      CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_po.
     ELSE.
       CLEAR ro_instance.
     ENDIF.

--- a/src/syntax/zcl_abapgit_syntax_po.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_po.clas.abap
@@ -1,0 +1,65 @@
+CLASS ZCL_ABAPGIT_SYNTAX_PO DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_syntax_highlighter
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    METHODS constructor.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      BEGIN OF c_style,
+        msgid    TYPE string VALUE 'keyword',
+        msgstr   TYPE string VALUE 'xml_tag',
+        comment  TYPE string VALUE 'comment',
+      END OF c_style.
+    CONSTANTS:
+      BEGIN OF c_token,
+        msgid    TYPE c VALUE 'I',
+        msgstr   TYPE c VALUE 'S',
+        comment  TYPE c VALUE 'C',
+      END OF c_token.
+    CONSTANTS:
+      BEGIN OF c_regex,
+        msgid    TYPE string VALUE '^msgid\b',
+        msgstr   TYPE string VALUE '^msgstr\b',
+        comment  TYPE string VALUE '^#.*',
+      END OF c_regex.
+
+    DATA mv_over_first_line TYPE abap_bool.
+    DATA mv_in_meta_comment TYPE abap_bool.
+    DATA mv_meta_msgid_captured TYPE abap_bool.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_SYNTAX_PO IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( ).
+
+    add_rule(
+      iv_regex = c_regex-msgid
+      iv_token = c_token-msgid
+      iv_style = c_style-msgid ).
+
+    add_rule(
+      iv_regex = c_regex-msgstr
+      iv_token = c_token-msgstr
+      iv_style = c_style-msgstr ).
+
+    add_rule(
+      iv_regex = c_regex-comment
+      iv_token = c_token-comment
+      iv_style = c_style-comment ).
+
+    " TODO maybe add rule to highlight empty msgstr with red
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/syntax/zcl_abapgit_syntax_po.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_po.clas.abap
@@ -1,4 +1,4 @@
-CLASS ZCL_ABAPGIT_SYNTAX_PO DEFINITION
+CLASS zcl_abapgit_syntax_po DEFINITION
   PUBLIC
   INHERITING FROM zcl_abapgit_syntax_highlighter
   CREATE PUBLIC.

--- a/src/syntax/zcl_abapgit_syntax_po.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_po.clas.abap
@@ -29,10 +29,6 @@ CLASS zcl_abapgit_syntax_po DEFINITION
         comment  TYPE string VALUE '^#.*',
       END OF c_regex.
 
-    DATA mv_over_first_line TYPE abap_bool.
-    DATA mv_in_meta_comment TYPE abap_bool.
-    DATA mv_meta_msgid_captured TYPE abap_bool.
-
 ENDCLASS.
 
 

--- a/src/syntax/zcl_abapgit_syntax_po.clas.xml
+++ b/src/syntax/zcl_abapgit_syntax_po.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_SYNTAX_PO</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - PO translation file highlighting</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/pages/diff/zcl_abapgit_gui_page_diff_base.clas.abap
+++ b/src/ui/pages/diff/zcl_abapgit_gui_page_diff_base.clas.abap
@@ -256,7 +256,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_diff_base IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF_BASE IMPLEMENTATION.
 
 
   METHOD add_filter_sub_menu.
@@ -496,7 +496,7 @@ CLASS zcl_abapgit_gui_page_diff_base IMPLEMENTATION.
     FIND FIRST OCCURRENCE OF '.' IN <ls_diff>-type MATCH OFFSET lv_offs.
     <ls_diff>-type = reverse( substring( val = <ls_diff>-type
                                          len = lv_offs ) ).
-    IF <ls_diff>-type <> 'xml' AND <ls_diff>-type <> 'abap'.
+    IF <ls_diff>-type <> 'xml' AND <ls_diff>-type <> 'abap' AND <ls_diff>-type <> 'po'.
       <ls_diff>-type = 'other'.
     ENDIF.
 


### PR DESCRIPTION
Minimalistic, but better than nothing. Also, PO files were treated as binary sometimes because there was no specific condition for them.

<img width="411" height="163" alt="image" src="https://github.com/user-attachments/assets/f3152399-dd4a-4e55-9cf5-cd5e53c160bb" />

P.S. There is a room for improvement in the syntax highlighting cycle. Problem is that it does not process complete file one by one, but rather local line, remote line, local line remote line. So local line N, remote line N, local line N+1, remote line N+1. This is not good because it prevents handling the state inside the highligher. E.g. in PO files I'd like to "grey" the metadata header, but it not possible to capture first string and wait until next blank line, because the next line is from another (remote) file. It needs to be refactored so that highlighter receives same file line N, same file line N+1 ... But not now.