### PR TITLE
Ignore empty translation table

### DIFF
--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
@@ -320,7 +320,8 @@ CLASS ZCL_ABAPGIT_LXE_TEXTS IMPLEMENTATION.
             cv_changed    = lv_changed
             ct_text_pairs = lt_text_pairs_tmp ).
 
-        IF lv_changed = abap_true.
+        IF lv_changed = abap_true AND lines( lt_text_pairs_tmp ) > 0.
+          " If lt_text_pairs_tmp is empty it raises error, while this is a practical case
           write_lxe_object_text_pair(
             iv_s_lang  = lv_main_lang
             iv_t_lang  = lv_target_lang


### PR DESCRIPTION
Subtle bug which raised error if translation block appeared empty.

Looks like no one uses PO files :P Well ... first to blame myself, I also haven't do it productively till this year...