### PR TITLE
Feature: Create GitHub repository from abapGit

### DIFF
--- a/src/git_platform/zcl_abapgit_pr_enum_gitea.clas.abap
+++ b/src/git_platform/zcl_abapgit_pr_enum_gitea.clas.abap
@@ -129,6 +129,11 @@ CLASS zcl_abapgit_pr_enum_gitea IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_pr_enum_provider~create_repository.
+    zcx_abapgit_exception=>raise( 'Not implemented for Gitea' ).
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_pr_enum_provider~list_pull_requests.
 
     DATA lv_upstream_url TYPE string.

--- a/src/git_platform/zcl_abapgit_pr_enumerator.clas.abap
+++ b/src/git_platform/zcl_abapgit_pr_enumerator.clas.abap
@@ -17,6 +17,14 @@ CLASS zcl_abapgit_pr_enumerator DEFINITION
       RAISING
         zcx_abapgit_exception.
 
+    METHODS create_repository
+      IMPORTING
+        iv_description TYPE string OPTIONAL
+        iv_private     TYPE abap_bool DEFAULT abap_true
+        iv_auto_init   TYPE abap_bool DEFAULT abap_true
+      RAISING
+        zcx_abapgit_exception.
+
     METHODS create_initial_branch
       IMPORTING
         iv_readme             TYPE string OPTIONAL
@@ -116,6 +124,20 @@ CLASS zcl_abapgit_pr_enumerator IMPLEMENTATION.
     IF ri_provider IS NOT BOUND.
       zcx_abapgit_exception=>raise( |PR enumeration is not supported for { iv_repo_url }| ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD create_repository.
+
+    IF mi_enum_provider IS NOT BOUND.
+      RETURN.
+    ENDIF.
+
+    mi_enum_provider->create_repository(
+      iv_description = iv_description
+      iv_private     = iv_private
+      iv_auto_init   = iv_auto_init ).
 
   ENDMETHOD.
 

--- a/src/git_platform/zif_abapgit_pr_enum_provider.intf.abap
+++ b/src/git_platform/zif_abapgit_pr_enum_provider.intf.abap
@@ -23,6 +23,14 @@ INTERFACE zif_abapgit_pr_enum_provider
     RAISING
       zcx_abapgit_exception.
 
+  METHODS create_repository
+    IMPORTING
+      iv_description TYPE string OPTIONAL
+      iv_private     TYPE abap_bool DEFAULT abap_true
+      iv_auto_init   TYPE abap_bool DEFAULT abap_true
+    RAISING
+      zcx_abapgit_exception.
+
   METHODS create_initial_branch
     IMPORTING
       iv_readme             TYPE string OPTIONAL

--- a/src/http/zcl_abapgit_login_manager.clas.abap
+++ b/src/http/zcl_abapgit_login_manager.clas.abap
@@ -28,6 +28,14 @@ CLASS zcl_abapgit_login_manager DEFINITION
         VALUE(rv_auth) TYPE string
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS set_token
+      IMPORTING
+        !iv_uri        TYPE string
+        !iv_token      TYPE string
+      RETURNING
+        VALUE(rv_auth) TYPE string
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS get
       IMPORTING
         !iv_uri        TYPE string
@@ -57,7 +65,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_LOGIN_MANAGER IMPLEMENTATION.
+CLASS zcl_abapgit_login_manager IMPLEMENTATION.
 
 
   METHOD append.
@@ -132,6 +140,16 @@ CLASS ZCL_ABAPGIT_LOGIN_MANAGER IMPLEMENTATION.
 
     CONCATENATE 'Basic' rv_auth INTO rv_auth
       SEPARATED BY space.
+
+    append( iv_uri  = iv_uri
+            iv_auth = rv_auth ).
+
+  ENDMETHOD.
+
+
+  METHOD set_token.
+
+    CONCATENATE 'Bearer' iv_token INTO rv_auth SEPARATED BY space.
 
     append( iv_uri  = iv_uri
             iv_auth = rv_auth ).

--- a/src/ui/pages/dlg/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/pages/dlg/zcl_abapgit_gui_page_addonline.clas.abap
@@ -42,6 +42,7 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
         choose_branch   TYPE string VALUE 'choose-branch',
         choose_labels   TYPE string VALUE 'choose-labels',
         add_online_repo TYPE string VALUE 'add-repo-online',
+        create_repo     TYPE string VALUE 'create-repository',
       END OF c_event.
 
     DATA mo_form TYPE REF TO zcl_abapgit_html_form .
@@ -202,6 +203,9 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
       iv_label       = 'Create Package'
       iv_action      = c_event-create_package
     )->command(
+      iv_label       = 'GitHub Repository'
+      iv_action      = c_event-create_repo
+    )->command(
       iv_label       = 'Back'
       iv_action      = zif_abapgit_definitions=>c_action-go_back ).
 
@@ -280,6 +284,11 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
           zcx_abapgit_exception=>raise( |Package { lv_package } already exists| ).
         ENDIF.
         rs_handled-page  = zcl_abapgit_gui_page_cpackage=>create( lv_package ).
+        rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
+
+      WHEN c_event-create_repo.
+
+        rs_handled-page  = zcl_abapgit_gui_page_cr_repo=>create( mo_form_data->get( c_id-url ) ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN c_event-choose_package.

--- a/src/ui/pages/dlg/zcl_abapgit_gui_page_cr_repo.clas.abap
+++ b/src/ui/pages/dlg/zcl_abapgit_gui_page_cr_repo.clas.abap
@@ -1,0 +1,211 @@
+CLASS zcl_abapgit_gui_page_cr_repo DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_component
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_gui_event_handler.
+    INTERFACES zif_abapgit_gui_renderable.
+
+    CLASS-METHODS create
+      IMPORTING
+        !iv_url        TYPE string
+      RETURNING
+        VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS constructor
+      IMPORTING
+        !iv_url TYPE string
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+
+  PRIVATE SECTION.
+
+    DATA mo_form           TYPE REF TO zcl_abapgit_html_form.
+    DATA mo_form_data      TYPE REF TO zcl_abapgit_string_map.
+    DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map.
+    DATA mo_form_util      TYPE REF TO zcl_abapgit_html_form_utils.
+    DATA mv_url TYPE string.
+
+    CONSTANTS:
+      BEGIN OF c_id,
+        org         TYPE string VALUE 'org',
+        name        TYPE string VALUE 'name',
+        description TYPE string VALUE 'description',
+        private     TYPE string VALUE 'private',
+        token       TYPE string VALUE 'token',
+      END OF c_id.
+
+    CONSTANTS:
+      BEGIN OF c_event,
+        create TYPE string VALUE 'create',
+      END OF c_event.
+
+    METHODS get_form_schema
+      RETURNING
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form.
+
+    METHODS set_defaults
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_gui_page_cr_repo IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( ).
+
+    CREATE OBJECT mo_validation_log.
+    CREATE OBJECT mo_form_data.
+
+    mo_form = get_form_schema( ).
+    mo_form_util = zcl_abapgit_html_form_utils=>create( mo_form ).
+
+    mv_url = iv_url.
+
+    set_defaults( ).
+
+  ENDMETHOD.
+
+
+  METHOD create.
+
+    DATA lo_component TYPE REF TO zcl_abapgit_gui_page_cr_repo.
+
+    CREATE OBJECT lo_component
+      EXPORTING
+        iv_url = iv_url.
+
+    ri_page = zcl_abapgit_gui_page_hoc=>create(
+      iv_page_title         = 'Create GitHub Repository'
+      ii_child_component    = lo_component ).
+
+  ENDMETHOD.
+
+
+  METHOD get_form_schema.
+
+    ro_form = zcl_abapgit_html_form=>create( iv_form_id = 'create-repository' ).
+
+    ro_form->text(
+      iv_label       = 'Organization'
+      iv_name        = c_id-org
+      iv_required    = abap_true ).
+
+    ro_form->text(
+      iv_label       = 'Repository Name'
+      iv_name        = c_id-name
+      iv_required    = abap_true ).
+
+    ro_form->text(
+      iv_label       = 'Description'
+      iv_name        = c_id-description ).
+
+    ro_form->checkbox(
+      iv_label       = 'Private'
+      iv_name        = c_id-private
+      iv_hint        = 'Set visibility to private (organization) or public' ).
+
+    ro_form->text(
+      iv_label       = 'GitHub Token'
+      iv_name        = c_id-token ).
+
+    ro_form->command(
+      iv_label       = 'Create'
+      iv_cmd_type    = zif_abapgit_html_form=>c_cmd_type-input_main
+      iv_action      = c_event-create ).
+
+    ro_form->command(
+      iv_label       = 'Back'
+      iv_action      = zif_abapgit_definitions=>c_action-go_back ).
+
+  ENDMETHOD.
+
+
+  METHOD set_defaults.
+
+    DATA lv_rest TYPE string ##NEEDED.
+    DATA lv_org TYPE string.
+    DATA lv_name TYPE string.
+
+    FIND ALL OCCURRENCES OF REGEX 'github\.com\/([^\/]+)\/([^\/]+)'
+      IN mv_url
+      SUBMATCHES lv_org lv_name.
+    IF sy-subrc = 0.
+      mo_form_data->set(
+        iv_key = c_id-org
+        iv_val = lv_org ).
+
+      mo_form_data->set(
+        iv_key = c_id-name
+        iv_val = lv_name ).
+    ENDIF.
+
+    mo_form_data->set(
+      iv_key = c_id-private
+      iv_val = abap_true ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_event_handler~on_event.
+
+    DATA lv_url TYPE string.
+
+    mo_form_data = mo_form_util->normalize( ii_event->form_data( ) ).
+
+    CASE ii_event->mv_action.
+      WHEN c_event-create.
+        mo_validation_log = mo_form_util->validate( mo_form_data ).
+
+        IF mo_validation_log->is_empty( ) = abap_true.
+
+          zcl_abapgit_login_manager=>set_token(
+            iv_uri   = 'https://api.github.com/'
+            iv_token = mo_form_data->get( c_id-token ) ).
+
+          " So far, this is only implemented for GitHub
+          lv_url = |https://github.com/{ mo_form_data->get( c_id-org ) }/{ mo_form_data->get( c_id-name ) }|.
+
+          zcl_abapgit_pr_enumerator=>new( lv_url )->create_repository(
+            iv_description = mo_form_data->get( c_id-description )
+            iv_private     = |{ mo_form_data->get( c_id-private ) }| ).
+
+          MESSAGE 'Repository created' TYPE 'S'.
+
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
+        ELSE.
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.
+        ENDIF.
+      WHEN OTHERS.
+        " do nothing
+    ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_renderable~render.
+
+    register_handlers( ).
+
+    ri_html = zcl_abapgit_html=>create( ).
+
+    ri_html->add( '<div class="form-container">' ).
+    ri_html->add( mo_form->render(
+      io_values         = mo_form_data
+      io_validation_log = mo_validation_log ) ).
+    ri_html->add( '</div>' ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/pages/dlg/zcl_abapgit_gui_page_cr_repo.clas.xml
+++ b/src/ui/pages/dlg/zcl_abapgit_gui_page_cr_repo.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_CR_REPO</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI Create Package</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
From the "New Online Repo" dialog, you can jump to a new dialog for creating a GitHub repository from abapGit - without having to visit github.com. :-)

### New Online Repo

<img width="564" height="88" alt="image" src="https://github.com/user-attachments/assets/6988edd5-0b53-4225-a63e-bc29bc3166f1" />

### Create GitHub Repository

<img width="1296" height="529" alt="image" src="https://github.com/user-attachments/assets/e97f6b92-378f-47a7-9fac-e0aa80c7146a" />

### Help Requested

Well, it's supposed to work but something is off. I'm always getting a "404 - Not found" error. This is usually related to [authentication issues](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#failed-login-limit). I added a "token" input field to set a "Bearer" authentication header but no luck.

The API call is in `zcl_abapgit_pr_enum_github->zif_abapgit_pr_enum_provider~create_repository`.

I'm tired and need a different set of eyes on this. Please give it a try. Maybe you can find out what's missing.