### PR TITLE
ignore conversion errors on non-unicode systems

### DIFF
--- a/src/utils/zcl_abapgit_convert.clas.locals_imp.abap
+++ b/src/utils/zcl_abapgit_convert.clas.locals_imp.abap
@@ -18,6 +18,10 @@ CLASS lcl_in IMPLEMENTATION.
 
     DATA lv_class TYPE string.
     DATA lx_error TYPE REF TO cx_root.
+    DATA lv_ignore_cerr TYPE abap_bool.
+
+* ignore conversion errors on non-unicode systems
+    lv_ignore_cerr = boolc( cl_abap_char_utilities=>charsize = 1 ).
 
     IF go_conv_new IS INITIAL AND go_conv_old IS INITIAL.
       TRY.
@@ -28,9 +32,10 @@ CLASS lcl_in IMPLEMENTATION.
           lv_class = 'CL_ABAP_CONV_IN_CE'.
           CALL METHOD (lv_class)=>create
             EXPORTING
-              encoding = 'UTF-8'
+              encoding    = 'UTF-8'
+              ignore_cerr = lv_ignore_cerr
             RECEIVING
-              conv     = go_conv_old.
+              conv        = go_conv_old.
       ENDTRY.
     ENDIF.
 


### PR DESCRIPTION
this can happen if eg. the commit message contains emojis