### PR TITLE
ENHO: Add check for identical enhancements in hook class

### DIFF
--- a/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/enh/zcl_abapgit_object_enho_hook.clas.abap
@@ -84,7 +84,8 @@ CLASS ZCL_ABAPGIT_OBJECT_ENHO_HOOK IMPLEMENTATION.
 * some ENHO might be inconsistent, resulting in identical filenames added to mo_files, so do a check
       IF mo_files->contains_file( iv_extra = ls_file-file
                                   iv_ext = 'abap' ) = abap_true.
-        zcx_abapgit_exception=>raise( |ENHO { ms_item-obj_name } contains enhancements with duplicate filenames (hash collision)| ).
+        zcx_abapgit_exception=>raise( |ENHO { ms_item-obj_name
+          } contains enhancements with duplicate filenames (hash collision)| ).
       ENDIF.
 
       mo_files->add_abap( iv_extra = ls_file-file


### PR DESCRIPTION
some ENHO can be inconsistent, resulting in a crash when adding identical filenames to `mo_files`, this adds a guard and a proper error message