### PR TITLE
PROG: Ignore invalid TADIR entries for ENHO includes

### DIFF
--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -340,9 +340,6 @@ CLASS zcl_abapgit_object_prog IMPLEMENTATION.
 
   METHOD zif_abapgit_object~serialize.
 
-* see SAP note 1025291, run report DELETE_TADIR_FOR_EIMP_INCLUDE to clean bad TADIR entries
-    ASSERT NOT ms_item-obj_name CP '*=E'.
-
     serialize_program( io_xml   = io_xml
                        is_item  = ms_item
                        io_files = mo_files ).


### PR DESCRIPTION
Enhancement object includes sometimes end in TADIR (note 1025291).
 #1813 partly resolves one scenario but wil fail for progs with 30 char name and also dumps when this is encountered. 
The SAP  note's report only cleans one variant, and user action should not be necessary because these includes are already serialized as part of the ENHO. This PR will validate ENHO as extra precaution.