### PR TITLE
DDLS: Add protocol for deletions

### DIFF
--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -125,6 +125,23 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_log_uuid.
+
+    DATA lv_tstmpl       TYPE timestampl.
+    DATA lv_tstmp_string TYPE string.
+
+    TRY.
+        cl_system_uuid=>convert_uuid_x16_static( EXPORTING uuid     = cl_system_uuid=>create_uuid_x16_static( )
+                                                 IMPORTING uuid_c32 = rv_log_uuid ).
+      CATCH cx_uuid_error.
+        GET TIME STAMP FIELD lv_tstmpl.
+        lv_tstmp_string = lv_tstmpl.
+        rv_log_uuid = |{ sy-uname }{ lv_tstmp_string }|.
+    ENDTRY.
+
+  ENDMETHOD.
+
+
   METHOD is_baseinfo_supported.
 
     DATA:
@@ -291,6 +308,7 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
         p_operation   = 'DELETE'
       EXCEPTIONS
         OTHERS        = 0.
+
   ENDMETHOD.
 
 
@@ -551,21 +569,4 @@ CLASS zcl_abapgit_object_ddls IMPLEMENTATION.
                  ig_data = <lg_data> ).
 
   ENDMETHOD.
-
-  METHOD get_log_uuid.
-
-    DATA lv_tstmpl       TYPE timestampl.
-    DATA lv_tstmp_string TYPE string.
-
-    TRY.
-        cl_system_uuid=>convert_uuid_x16_static( EXPORTING uuid     = cl_system_uuid=>create_uuid_x16_static( )
-                                                 IMPORTING uuid_c32 = rv_log_uuid ).
-      CATCH cx_uuid_error.
-        GET TIME STAMP FIELD lv_tstmpl.
-        lv_tstmp_string = lv_tstmpl.
-        rv_log_uuid = |{ sy-uname }{ lv_tstmp_string }|.
-    ENDTRY.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_enho.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho.clas.abap
@@ -162,7 +162,8 @@ CLASS zcl_abapgit_object_enho IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     io_xml->read( EXPORTING iv_name = 'TOOL'

--- a/src/objects/zcl_abapgit_object_enhs.clas.abap
+++ b/src/objects/zcl_abapgit_object_enhs.clas.abap
@@ -17,7 +17,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_ENHS IMPLEMENTATION.
+CLASS zcl_abapgit_object_enhs IMPLEMENTATION.
 
 
   METHOD factory.
@@ -101,7 +101,8 @@ CLASS ZCL_ABAPGIT_OBJECT_ENHS IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     io_xml->read( EXPORTING iv_name = 'TOOL'

--- a/src/objects/zcl_abapgit_object_ensc.clas.abap
+++ b/src/objects/zcl_abapgit_object_ensc.clas.abap
@@ -7,7 +7,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_ENSC IMPLEMENTATION.
+CLASS zcl_abapgit_object_ensc IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~changed_by.
@@ -88,7 +88,8 @@ CLASS ZCL_ABAPGIT_OBJECT_ENSC IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     lv_package = iv_package.

--- a/src/objects/zcl_abapgit_object_iaxu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iaxu.clas.abap
@@ -241,7 +241,8 @@ CLASS zcl_abapgit_object_iaxu IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     save( ls_attr ).

--- a/src/objects/zcl_abapgit_object_saxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_object_saxx_super.clas.abap
@@ -61,6 +61,7 @@ ENDCLASS.
 
 CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
 
+
   METHOD constructor.
 
     super->constructor(
@@ -72,6 +73,7 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
     mv_object_key = ms_item-obj_name.
 
   ENDMETHOD.
+
 
   METHOD create_channel_objects.
 
@@ -223,7 +225,8 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     TRY.
@@ -367,5 +370,4 @@ CLASS zcl_abapgit_object_saxx_super IMPLEMENTATION.
                  ig_data = <lg_data> ).
 
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_sfpi.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpi.clas.abap
@@ -103,7 +103,8 @@ CLASS zcl_abapgit_object_sfpi IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     TRY.

--- a/src/objects/zcl_abapgit_object_sqsc.clas.abap
+++ b/src/objects/zcl_abapgit_object_sqsc.clas.abap
@@ -106,6 +106,7 @@ CLASS zcl_abapgit_object_sqsc DEFINITION
           iv_package   TYPE devclass
           iv_transport TYPE trkorr
           iv_interface TYPE ty_abap_name
+          ii_log       TYPE REF TO zif_abapgit_log
         RAISING
           zcx_abapgit_exception.
 ENDCLASS.
@@ -164,7 +165,8 @@ CLASS zcl_abapgit_object_sqsc IMPLEMENTATION.
           io_i18n_params = mo_i18n_params.
 
       lo_interface->zif_abapgit_object~delete( iv_package   = iv_package
-                                               iv_transport = iv_transport ).
+                                               iv_transport = iv_transport
+                                               ii_log       = ii_log ).
 
     ENDIF.
 
@@ -219,9 +221,10 @@ CLASS zcl_abapgit_object_sqsc IMPLEMENTATION.
     IF zif_abapgit_object~exists( ) = abap_false.
 
       delete_interface_if_it_exists(
-          iv_package   = iv_package
-          iv_transport = iv_transport
-          iv_interface = ls_proxy-header-interface_pool ).
+        iv_package   = iv_package
+        iv_transport = iv_transport
+        iv_interface = ls_proxy-header-interface_pool
+        ii_log       = ii_log ).
 
       CALL METHOD mo_proxy->('IF_DBPROC_PROXY_UI~CREATE')
         EXPORTING

--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -705,7 +705,8 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     io_xml->read( EXPORTING iv_name = 'TSTC'

--- a/src/objects/zcl_abapgit_object_xslt.clas.abap
+++ b/src/objects/zcl_abapgit_object_xslt.clas.abap
@@ -116,7 +116,8 @@ CLASS zcl_abapgit_object_xslt IMPLEMENTATION.
 
     IF zif_abapgit_object~exists( ) = abap_true.
       zif_abapgit_object~delete( iv_package   = iv_package
-                                 iv_transport = iv_transport ).
+                                 iv_transport = iv_transport
+                                 ii_log       = ii_log ).
     ENDIF.
 
     io_xml->read( EXPORTING iv_name = 'ATTRIBUTES'

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -118,7 +118,7 @@ CLASS zcl_abapgit_objects DEFINITION
         !iv_package   TYPE devclass
         !is_item      TYPE zif_abapgit_definitions=>ty_item
         !iv_transport TYPE trkorr
-        !ii_log       TYPE REF TO zif_abapgit_log OPTIONAL
+        !ii_log       TYPE REF TO zif_abapgit_log
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS deserialize_steps
@@ -492,7 +492,8 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
             delete_object(
               iv_package   = <ls_tadir>-devclass
               is_item      = ls_item
-              iv_transport = is_checks-transport-transport ).
+              iv_transport = is_checks-transport-transport
+              ii_log       = ii_log ).
 
             INSERT <ls_tadir> INTO TABLE lt_deleted.
             DELETE lt_tadir.
@@ -1015,6 +1016,37 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD is_prog_enho_include.
+
+    DATA lv_enho_name TYPE enhname.
+
+    " ENHO includes ending in 'E' or 'EIMP' at position 31 shouldn't be in TADIR
+    " but appear due to bug (SAP note 1025291). Skip them, sources are in ENHO.
+
+    " Format: <enho_name><padding_with_=><E/EIMP>
+    " Example: ZMM_SOME_ENHANCEMENT==========E
+
+    IF NOT ( iv_obj_name+30(4) = 'EIMP' OR
+             iv_obj_name+30(4) = 'E   ' ).
+      RETURN.
+    ENDIF.
+
+    " Extract enhancement name: first 30 chars, strip trailing '='
+    lv_enho_name = iv_obj_name(30).
+    SHIFT lv_enho_name RIGHT DELETING TRAILING '='.
+    SHIFT lv_enho_name LEFT DELETING LEADING space.
+
+    " Check if corresponding ENHO exists
+    SELECT SINGLE obj_name FROM tadir INTO lv_enho_name
+      WHERE pgmid = 'R3TR'
+      AND object = 'ENHO'
+      AND obj_name = lv_enho_name.
+
+    rv_bool = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.
+
+
   METHOD is_supported.
 
     TRY.
@@ -1358,36 +1390,4 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     ENDLOOP.
 
   ENDMETHOD.
-
-
-  METHOD is_prog_enho_include.
-
-    DATA lv_enho_name TYPE enhname.
-
-    " ENHO includes ending in 'E' or 'EIMP' at position 31 shouldn't be in TADIR
-    " but appear due to bug (SAP note 1025291). Skip them, sources are in ENHO.
-
-    " Format: <enho_name><padding_with_=><E/EIMP>
-    " Example: ZMM_SOME_ENHANCEMENT==========E
-
-    IF NOT ( iv_obj_name+30(4) = 'EIMP' OR
-             iv_obj_name+30(4) = 'E   ' ).
-      RETURN.
-    ENDIF.
-
-    " Extract enhancement name: first 30 chars, strip trailing '='
-    lv_enho_name = iv_obj_name(30).
-    SHIFT lv_enho_name RIGHT DELETING TRAILING '='.
-    SHIFT lv_enho_name LEFT DELETING LEADING space.
-
-    " Check if corresponding ENHO exists
-    SELECT SINGLE obj_name FROM tadir INTO lv_enho_name
-      WHERE pgmid = 'R3TR'
-      AND object = 'ENHO'
-      AND obj_name = lv_enho_name.
-
-    rv_bool = boolc( sy-subrc = 0 ).
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -29,7 +29,7 @@ INTERFACE zif_abapgit_object PUBLIC.
     IMPORTING
       !iv_package   TYPE devclass
       !iv_transport TYPE trkorr
-      !ii_log       TYPE REF TO zif_abapgit_log OPTIONAL
+      !ii_log       TYPE REF TO zif_abapgit_log
     RAISING
       zcx_abapgit_exception .
 


### PR DESCRIPTION
Any deletions of objects with type DDLS get an empty ABAP Dictionary protocol due to explicit specification of "prid = -1". This is now fixed and allows better analysis of deletions using common ABAP Dictionary support tools (e.g. PROG RADPROTA or TRAN SDDLAR).