### PR TITLE
SRVD: handle CX_WB_OBJECT_ALREADY_EXISTS on CREATE by falling back to UPDATE

### DIFF
--- a/src/objects/zcl_abapgit_object_srvd.clas.abap
+++ b/src/objects/zcl_abapgit_object_srvd.clas.abap
@@ -393,6 +393,9 @@ CLASS zcl_abapgit_object_srvd IMPLEMENTATION.
 
         tadir_insert( iv_package ).
 
+        " exists() can return false even when a ghost WB entry remains
+        " (e.g. after incomplete delete/activation). In that case CREATE
+        " throws CX_WB_OBJECT_ALREADY_EXISTS and we fall through to UPDATE.
         TRY.
             IF zif_abapgit_object~exists( ) = abap_false.
               CASE <lv_category>.


### PR DESCRIPTION
When a SRVD object is deserialized and `exists()` returns false (TADIR entry
missing or WB READ fails), the CREATE call may still throw
`CX_WB_OBJECT_ALREADY_EXISTS` because the WB persistence layer has a ghost
entry from a prior incomplete delete or activation failure.

This happens because the WB operator's internal existence check uses a
different lookup than the READ API used by `exists()`. The result is that
the object can't be created (already exists) nor updated (doesn't exist
according to `exists()`), making deserialization fail permanently.

**Fix:** wrap the CREATE/UPDATE decision in TRY/CATCH for
`CX_WB_OBJECT_ALREADY_EXISTS`. If CREATE throws it, fall through to the
UPDATE path. If `exists()` returns true, raise the same exception to go
directly to UPDATE.