### PR TITLE
Add ADS check to SFPF Object Class

### DIFF
--- a/src/objects/zcl_abapgit_object_sfpf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpf.clas.abap
@@ -15,7 +15,7 @@ CLASS zcl_abapgit_object_sfpf DEFINITION
         !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
         !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_type_not_supported.
 
     CLASS-METHODS fix_oref
       IMPORTING
@@ -59,11 +59,11 @@ CLASS zcl_abapgit_object_sfpf IMPLEMENTATION.
             )->get_version_info( ).
 
         IF lv_version IS INITIAL.
-          zcx_abapgit_exception=>raise( 'Object SFPF not supported, Adobe Document Service(ADS) is not configured.' ).
+          RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
         ENDIF.
 
       CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'Object SFPF not supported, Adobe Document Service(ADS) is not configured.' ).
+        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
     ENDTRY.
 
   ENDMETHOD.


### PR DESCRIPTION
SFPF Objects depend on the ADS service (Adobe Document Service).
If this service is not available or configured,  SFPF objects should not be considered when importing an offline repository.

The check implemented in the constructor follows the same approach as the SAP standard test program `FP_PDF_TEST_00`.