### PR TITLE
fix when table is initial and nothing was selected

### DIFF
--- a/src/data/zcl_abapgit_data_serializer.clas.abap
+++ b/src/data/zcl_abapgit_data_serializer.clas.abap
@@ -124,6 +124,9 @@ CLASS zcl_abapgit_data_serializer IMPLEMENTATION.
         ls_file-data = convert_itab_to_json(
           ir_data         = lr_data
           iv_skip_initial = ls_config-skip_initial ).
+        IF ls_file-data IS INITIAL.
+          ls_file-data = zcl_abapgit_convert=>string_to_xstring_utf8( '[]' ).
+        ENDIF.
       ELSE.
         ls_file-data = zcl_abapgit_convert=>string_to_xstring_utf8( '[]' ).
       ENDIF.


### PR DESCRIPTION
Scenario:
The config provided for a valid table results in no table entries being selected (Entries might have been deleted from the table since the config was configured). When this is converted to json it results in an initial data xstring. This does not cause any problems during serialization, but does cause a shortdump during deserialization. 