### PR TITLE
Patch: Shift SCI integration left

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -45,7 +45,8 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         !iv_interactive_branch   TYPE abap_bool DEFAULT abap_false
         !iv_interactive_favorite TYPE abap_bool DEFAULT abap_true
         !io_news                 TYPE REF TO zcl_abapgit_repo_news OPTIONAL
-        !iv_sci_result           TYPE zif_abapgit_definitions=>ty_sci_result DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
+        !iv_sci_result           TYPE zif_abapgit_definitions=>ty_sci_result
+          DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
       RETURNING
         VALUE(ri_html)           TYPE REF TO zif_abapgit_html
       RAISING

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -45,6 +45,7 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         !iv_interactive_branch   TYPE abap_bool DEFAULT abap_false
         !iv_interactive_favorite TYPE abap_bool DEFAULT abap_true
         !io_news                 TYPE REF TO zcl_abapgit_repo_news OPTIONAL
+        !iv_sci_result           TYPE zif_abapgit_definitions=>ty_sci_result DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
       RETURNING
         VALUE(ri_html)           TYPE REF TO zif_abapgit_html
       RAISING
@@ -1027,6 +1028,11 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     ri_html->add( '</td>' ).
 
     ri_html->add( '<td class="repo_attr right">' ).
+
+    " SCI result
+    render_sci_result(
+      ii_html       = ri_html
+      iv_sci_result = iv_sci_result ).
 
     " Fav
     IF abap_true = zcl_abapgit_persist_factory=>get_user( )->is_favorite_repo( ii_repo->get_key( ) ).

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -265,10 +265,11 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
     ls_hotkey_action-action = mv_followup_action.
     IF ls_hotkey_action-action = c_actions-patch.
       ls_hotkey_action-description = |Patch|.
+      ls_hotkey_action-hotkey = |p|.
     ELSE.
       ls_hotkey_action-description = |Stage|.
+      ls_hotkey_action-hotkey = |s|.
     ENDIF.
-    ls_hotkey_action-hotkey = |s|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
     ls_hotkey_action-description = |Re-Run|.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -265,7 +265,7 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
     ls_hotkey_action-action = mv_followup_action.
     IF ls_hotkey_action-action = c_actions-patch.
       ls_hotkey_action-description = |Patch|.
-      ls_hotkey_action-hotkey = |p|.
+      ls_hotkey_action-hotkey = |a|.
     ELSE.
       ls_hotkey_action-description = |Stage|.
       ls_hotkey_action-hotkey = |s|.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -19,6 +19,7 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION
         io_stage                 TYPE REF TO zcl_abapgit_stage OPTIONAL
         iv_check_variant         TYPE sci_chkv OPTIONAL
         iv_raise_when_no_results TYPE abap_bool DEFAULT abap_false
+        iv_followup_action       TYPE string DEFAULT c_actions-stage
       RETURNING
         VALUE(ri_page)           TYPE REF TO zif_abapgit_gui_renderable
       RAISING
@@ -30,6 +31,7 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION
         io_stage                 TYPE REF TO zcl_abapgit_stage OPTIONAL
         iv_check_variant         TYPE sci_chkv OPTIONAL
         iv_raise_when_no_results TYPE abap_bool DEFAULT abap_false
+        iv_followup_action       TYPE string DEFAULT c_actions-stage
       RAISING
         zcx_abapgit_exception.
 
@@ -37,7 +39,8 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION
   PRIVATE SECTION.
 
     DATA mo_stage         TYPE REF TO zcl_abapgit_stage.
-    DATA mv_check_variant TYPE sci_chkv.
+    DATA mv_check_variant    TYPE sci_chkv.
+    DATA mv_followup_action  TYPE string.
 
     METHODS:
       run_code_inspector
@@ -90,6 +93,7 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
     mi_repo = ii_repo.
     mo_stage = io_stage.
     mv_check_variant = iv_check_variant.
+    mv_followup_action = iv_followup_action.
     determine_check_variant( ).
     run_code_inspector( ).
 
@@ -109,7 +113,8 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
         ii_repo                  = ii_repo
         io_stage                 = io_stage
         iv_check_variant         = iv_check_variant
-        iv_raise_when_no_results = iv_raise_when_no_results.
+        iv_raise_when_no_results = iv_raise_when_no_results
+        iv_followup_action       = iv_followup_action.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create( lo_component ).
 
@@ -205,6 +210,22 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
 
         ENDIF.
 
+      WHEN c_actions-patch.
+
+        IF is_stage_allowed( ) = abap_true.
+
+          rs_handled-page = zcl_abapgit_gui_page_patch=>create(
+            iv_key        = mi_repo->get_key( )
+            iv_sci_result = status( ) ).
+
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
+
+        ELSE.
+
+          rs_handled-state = zcl_abapgit_gui=>c_event_state-no_more_act.
+
+        ENDIF.
+
       WHEN c_actions-commit.
 
         li_repo_online ?= mi_repo.
@@ -241,8 +262,12 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
 
     ls_hotkey_action-ui_component = 'Code Inspector'.
 
-    ls_hotkey_action-description = |Stage|.
-    ls_hotkey_action-action = c_actions-stage.
+    ls_hotkey_action-action = mv_followup_action.
+    IF ls_hotkey_action-action = c_actions-patch.
+      ls_hotkey_action-description = |Patch|.
+    ELSE.
+      ls_hotkey_action-description = |Stage|.
+    ENDIF.
     ls_hotkey_action-hotkey = |s|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
@@ -276,6 +301,13 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
       ro_toolbar->add(
         iv_txt = 'Commit'
         iv_act = c_actions-commit
+        iv_opt = lv_opt ).
+
+    ELSEIF mv_followup_action = c_actions-patch.
+
+      ro_toolbar->add(
+        iv_txt = 'Patch'
+        iv_act = c_actions-patch
         iv_opt = lv_opt ).
 
     ELSE.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -5,8 +5,6 @@ CLASS zcl_abapgit_gui_page_codi_base DEFINITION
   PUBLIC SECTION.
     INTERFACES zif_abapgit_html_table.
 
-  PROTECTED SECTION.
-
     CONSTANTS:
       BEGIN OF c_actions,
         rerun        TYPE string VALUE 'rerun',
@@ -16,6 +14,8 @@ CLASS zcl_abapgit_gui_page_codi_base DEFINITION
         filter_kind  TYPE string VALUE 'filter_kind',
         apply_filter TYPE string VALUE 'apply_filter',
       END OF c_actions .
+
+  PROTECTED SECTION.
 
     DATA mi_repo TYPE REF TO zif_abapgit_repo.
     DATA mt_result TYPE zif_abapgit_code_inspector=>ty_results.

--- a/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/pages/codi/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -11,6 +11,7 @@ CLASS zcl_abapgit_gui_page_codi_base DEFINITION
       BEGIN OF c_actions,
         rerun        TYPE string VALUE 'rerun',
         stage        TYPE string VALUE 'stage',
+        patch        TYPE string VALUE 'patch',
         commit       TYPE string VALUE 'commit',
         filter_kind  TYPE string VALUE 'filter_kind',
         apply_filter TYPE string VALUE 'apply_filter',

--- a/src/ui/pages/diff/zcl_abapgit_gui_page_diff_base.clas.abap
+++ b/src/ui/pages/diff/zcl_abapgit_gui_page_diff_base.clas.abap
@@ -102,6 +102,9 @@ CLASS zcl_abapgit_gui_page_diff_base DEFINITION
         iv_action TYPE clike
       RAISING
         zcx_abapgit_exception .
+    METHODS get_sci_result
+      RETURNING
+        VALUE(rv_sci_result) TYPE zif_abapgit_definitions=>ty_sci_result .
     METHODS refresh_full
       RAISING
         zcx_abapgit_exception .
@@ -685,6 +688,13 @@ CLASS zcl_abapgit_gui_page_diff_base IMPLEMENTATION.
       CATCH zcx_abapgit_exception.
         rv_page_layout = zcl_abapgit_gui_page=>c_page_layout-full_width.
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD get_sci_result.
+
+    rv_sci_result = zif_abapgit_definitions=>c_sci_result-no_run.
 
   ENDMETHOD.
 
@@ -1454,7 +1464,9 @@ CLASS zcl_abapgit_gui_page_diff_base IMPLEMENTATION.
 
     IF mi_repo IS NOT INITIAL.
       ri_html->add( `<div class="repo">` ).
-      ri_html->add( zcl_abapgit_gui_chunk_lib=>render_repo_top( mi_repo ) ).
+      ri_html->add( zcl_abapgit_gui_chunk_lib=>render_repo_top(
+        ii_repo        = mi_repo
+        iv_sci_result  = get_sci_result( ) ) ).
       ri_html->add( `</div>` ).
     ENDIF.
 

--- a/src/ui/pages/diff/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/pages/diff/zcl_abapgit_gui_page_patch.clas.abap
@@ -13,6 +13,7 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
         !is_file       TYPE zif_abapgit_git_definitions=>ty_file OPTIONAL
         !is_object     TYPE zif_abapgit_definitions=>ty_item OPTIONAL
         !it_files      TYPE zif_abapgit_definitions=>ty_stage_tt OPTIONAL
+        !iv_sci_result TYPE zif_abapgit_definitions=>ty_sci_result DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
       RETURNING
         VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
       RAISING
@@ -20,10 +21,11 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
 
     METHODS constructor
       IMPORTING
-        !iv_key    TYPE zif_abapgit_persistence=>ty_repo-key
-        !is_file   TYPE zif_abapgit_git_definitions=>ty_file OPTIONAL
-        !is_object TYPE zif_abapgit_definitions=>ty_item OPTIONAL
-        !it_files  TYPE zif_abapgit_definitions=>ty_stage_tt OPTIONAL
+        !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
+        !is_file       TYPE zif_abapgit_git_definitions=>ty_file OPTIONAL
+        !is_object     TYPE zif_abapgit_definitions=>ty_item OPTIONAL
+        !it_files      TYPE zif_abapgit_definitions=>ty_stage_tt OPTIONAL
+        !iv_sci_result TYPE zif_abapgit_definitions=>ty_sci_result DEFAULT zif_abapgit_definitions=>c_sci_result-no_run
       RAISING
         zcx_abapgit_exception.
 
@@ -46,6 +48,7 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
     METHODS:
       add_menu_begin REDEFINITION,
       add_menu_end REDEFINITION,
+      get_sci_result REDEFINITION,
       refresh REDEFINITION.
 
   PRIVATE SECTION.
@@ -65,6 +68,7 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
     DATA mv_section_count TYPE i .
     DATA mv_pushed TYPE abap_bool .
     DATA mi_repo_online TYPE REF TO zif_abapgit_repo_online .
+    DATA mv_sci_result TYPE zif_abapgit_definitions=>ty_sci_result .
 
     METHODS render_patch
       IMPORTING
@@ -355,6 +359,7 @@ CLASS zcl_abapgit_gui_page_patch IMPLEMENTATION.
     mi_extra = me.
 
     mi_repo_online ?= mi_repo.
+    mv_sci_result = iv_sci_result.
 
     " While patching we always want to be in split mode
     CLEAR mv_unified.
@@ -369,16 +374,24 @@ CLASS zcl_abapgit_gui_page_patch IMPLEMENTATION.
 
     CREATE OBJECT lo_component
       EXPORTING
-        iv_key    = iv_key
-        is_file   = is_file
-        is_object = is_object
-        it_files  = it_files.
+        iv_key        = iv_key
+        is_file       = is_file
+        is_object     = is_object
+        it_files      = it_files
+        iv_sci_result = iv_sci_result.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title         = 'Patch'
       iv_page_layout        = zcl_abapgit_gui_page=>c_page_layout-full_width
       ii_page_menu_provider = lo_component
       ii_child_component    = lo_component ).
+
+  ENDMETHOD.
+
+
+  METHOD get_sci_result.
+
+    rv_sci_result = mv_sci_result.
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -323,8 +323,9 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
                       AND method <> zif_abapgit_definitions=>c_method-rm.
 
     ri_page  = zcl_abapgit_gui_page_patch=>create(
-      iv_key   = lv_key
-      it_files = lt_files ).
+      iv_key        = lv_key
+      it_files      = lt_files
+      iv_sci_result = mv_sci_result ).
 
   ENDMETHOD.
 
@@ -379,9 +380,6 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ri_html->add( '<input class="stage-filter" id="objectSearch"' &&
                   ' type="search" placeholder="Filter Objects"' &&
                   | value="{ mv_filter_value }">| ).
-    zcl_abapgit_gui_chunk_lib=>render_sci_result(
-      ii_html       = ri_html
-      iv_sci_result = mv_sci_result ).
     ri_html->add( '</td>' ).
 
     ri_html->add( '</tr>' ).
@@ -799,7 +797,8 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ri_html->add( zcl_abapgit_gui_chunk_lib=>render_repo_top(
       ii_repo               = mi_repo
       iv_show_commit        = abap_false
-      iv_interactive_branch = abap_true ) ).
+      iv_interactive_branch = abap_true
+      iv_sci_result         = mv_sci_result ) ).
     ri_html->add( zcl_abapgit_gui_chunk_lib=>render_js_error_banner( ) ).
     ri_html->add( render_main_language_warning( ) ).
 

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -348,9 +348,11 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
   METHOD get_page_patch.
 
-    DATA: ls_file   TYPE zif_abapgit_git_definitions=>ty_file,
-          ls_object TYPE zif_abapgit_definitions=>ty_item,
-          lv_key    TYPE zif_abapgit_persistence=>ty_repo-key.
+    DATA: ls_file       TYPE zif_abapgit_git_definitions=>ty_file,
+          ls_object     TYPE zif_abapgit_definitions=>ty_item,
+          lv_key        TYPE zif_abapgit_persistence=>ty_repo-key,
+          li_repo       TYPE REF TO zif_abapgit_repo,
+          lv_sci_result TYPE zif_abapgit_definitions=>ty_sci_result.
 
     lv_key             = ii_event->query( )->get( 'KEY' ).
     ls_file-path       = ii_event->query( )->get( 'PATH' ).
@@ -358,10 +360,31 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
     ls_object-obj_type = ii_event->query( )->get( 'OBJ_TYPE' ).
     ls_object-obj_name = ii_event->query( )->get( 'OBJ_NAME' ). " unescape ?
 
-    ri_page = zcl_abapgit_gui_page_patch=>create(
-      iv_key    = lv_key
-      is_file   = ls_file
-      is_object = ls_object ).
+    lv_sci_result = zif_abapgit_definitions=>c_sci_result-no_run.
+
+    li_repo = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
+
+    IF li_repo->get_local_settings( )-code_inspector_check_variant IS NOT INITIAL.
+
+      TRY.
+          ri_page = zcl_abapgit_gui_page_code_insp=>create(
+            ii_repo                  = li_repo
+            iv_raise_when_no_results = abap_true
+            iv_followup_action       = 'patch' ).
+
+        CATCH zcx_abapgit_exception.
+          lv_sci_result = zif_abapgit_definitions=>c_sci_result-passed.
+      ENDTRY.
+
+    ENDIF.
+
+    IF ri_page IS INITIAL.
+      ri_page = zcl_abapgit_gui_page_patch=>create(
+        iv_key        = lv_key
+        is_file       = ls_file
+        is_object     = ls_object
+        iv_sci_result = lv_sci_result ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -366,10 +366,15 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
     IF li_repo->get_local_settings( )-code_inspector_check_variant IS NOT INITIAL.
 
-      ri_page = zcl_abapgit_gui_page_code_insp=>create(
-        ii_repo                  = li_repo
-        iv_raise_when_no_results = abap_true
-        iv_followup_action       = zcl_abapgit_gui_page_codi_base=>c_actions-patch ).
+      TRY.
+          ri_page = zcl_abapgit_gui_page_code_insp=>create(
+            ii_repo                  = li_repo
+            iv_raise_when_no_results = abap_true
+            iv_followup_action       = zcl_abapgit_gui_page_codi_base=>c_actions-patch ).
+
+        CATCH zcx_abapgit_exception.
+          lv_sci_result = zif_abapgit_definitions=>c_sci_result-passed.
+      ENDTRY.
 
     ENDIF.
 

--- a/src/ui/routing/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/routing/zcl_abapgit_gui_router.clas.abap
@@ -366,15 +366,10 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
     IF li_repo->get_local_settings( )-code_inspector_check_variant IS NOT INITIAL.
 
-      TRY.
-          ri_page = zcl_abapgit_gui_page_code_insp=>create(
-            ii_repo                  = li_repo
-            iv_raise_when_no_results = abap_true
-            iv_followup_action       = 'patch' ).
-
-        CATCH zcx_abapgit_exception.
-          lv_sci_result = zif_abapgit_definitions=>c_sci_result-passed.
-      ENDTRY.
+      ri_page = zcl_abapgit_gui_page_code_insp=>create(
+        ii_repo                  = li_repo
+        iv_raise_when_no_results = abap_true
+        iv_followup_action       = zcl_abapgit_gui_page_codi_base=>c_actions-patch ).
 
     ENDIF.
 


### PR DESCRIPTION
Fix: Run ATC check before patch page and show correct followup action

Problem: When a repository has a mandatory ATC check configured (code_inspector_check_variant + block_commit), the check could be bypassed by using the Patch action from the repo view instead of the Stage action. Finally the commit page blocks with
<img width="411" height="50" alt="image" src="https://github.com/user-attachments/assets/9a336bb6-95aa-43b3-b3ad-4ac4fa71d8b3" />

The goal of this PR is to move SCI feedback left for this scenario.

Changes:

	1. ATC check gate for Patch (ZCL_ABAPGIT_GUI_ROUTER): get_page_patch now runs the code inspector before rendering the patch page, matching the existing behavior in get_page_stage. If findings exist, the code inspector results page is shown first.
	2. SCI result badge in repo header (ZCL_ABAPGIT_GUI_CHUNK_LIB): Added iv_sci_result parameter to render_repo_top. The PASSED/FAILED/WARN badge is now rendered centrally in the repo header, replacing the separate inline rendering that was in the stage page's render_actions. Removed redundant render_sci_result call from ZCL_ABAPGIT_GUI_PAGE_STAGE.
	3. SCI result propagation through diff pages (ZCL_ABAPGIT_GUI_PAGE_DIFF_BASE / ZCL_ABAPGIT_GUI_PAGE_PATCH): Added a protected template method get_sci_result in diff_base (returns no_run by default), overridden in the patch page to return its stored result. This keeps the SCI concern out of the base class data while allowing the parent's render to pass it to render_repo_top. The stage page also forwards its SCI result when navigating to patch.
	4. Context-aware code inspector page (ZCL_ABAPGIT_GUI_PAGE_CODE_INSP / ZCL_ABAPGIT_GUI_PAGE_CODI_BASE): Added iv_followup_action parameter (defaults to c_actions-stage). When the code inspector page is shown as a gate before the patch page, the router passes 'patch' as followup action. The code inspector page then shows a "Patch" button (instead of "Stage"), and navigates to the patch page on click. Hotkeys are adjusted accordingly. Added patch constant to c_actions in the base class.

Flow: Repo > Patch

- passed
<img width="1700" height="567" alt="image" src="https://github.com/user-attachments/assets/f0301862-be08-45fa-8f0c-76a3bcd77705" />

- warning
<img width="1313" height="332" alt="image" src="https://github.com/user-attachments/assets/07b6b7d7-074a-4ec5-9b3f-944d96e5b2be" />
 
<img width="1711" height="343" alt="image" src="https://github.com/user-attachments/assets/d49c5473-0072-4604-b695-bc0c7ea4d0fd" />


- failed without block
 
<img width="1307" height="218" alt="image" src="https://github.com/user-attachments/assets/8ede3a7a-4c0a-4423-8627-bfbe25b82e66" />
<img width="1705" height="232" alt="image" src="https://github.com/user-attachments/assets/6c89124b-cb2c-4b7e-9faf-3335992261ee" />

- failed with block
<img width="1373" height="168" alt="image" src="https://github.com/user-attachments/assets/ee740bfc-ffb6-4f92-a978-ad3a91edf761" />

Flow: Repo > Stage > ... is not changed except the SCI banner was moved.

Disclaimer: This change was created with the help of AI.