### PR TITLE
suppress modification assistant popup

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -500,7 +500,7 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
 
 * this will update the SEO* database tables
     TRY.
-        lo_update->revert_scan_result( ).
+        lo_update->revert_scan_result( abap_true ).
       CATCH cx_oo_source_save_failure INTO lx_error.
         zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -138,7 +138,7 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
 
 * this will update the SEO* database tables
     TRY.
-        lo_update->revert_scan_result( ).
+        lo_update->revert_scan_result( abap_true ).
       CATCH cx_oo_source_save_failure INTO lx_error.
         zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.


### PR DESCRIPTION
Use case and scenario:

Suppress the modification assistant popup for objects that are in a namespace other than Z or Y. The namespace in question is also only configured with a repair or recipient role.

I believe that this choice should be determined by setting a boolean value via a user exit, but I thought I would get some feedback first before adding an additional user exit method.