### PR TITLE
Repo Overview/Repo View: Enhanced repo settings

### DIFF
--- a/src/ui/lib/zcl_abapgit_html_toolbar_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_toolbar_lib.clas.abap
@@ -68,8 +68,7 @@ CLASS zcl_abapgit_html_toolbar_lib IMPLEMENTATION.
       iv_txt   = 'Stats'
       iv_act   = |{ zif_abapgit_definitions=>c_action-repo_infos }?key={ iv_key }|
       iv_class = iv_class
-      iv_title = `Statistics`
-    ).
+      iv_title = `Statistics` ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_html_toolbar_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_toolbar_lib.clas.abap
@@ -1,0 +1,76 @@
+CLASS zcl_abapgit_html_toolbar_lib DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    CLASS-METHODS render_repo_settings_dropdown
+      IMPORTING
+        io_toolbar  TYPE REF TO zcl_abapgit_html_toolbar
+        iv_key      TYPE zif_abapgit_persistence=>ty_value
+        iv_opt      TYPE c OPTIONAL
+        iv_class    TYPE string OPTIONAL
+        iv_li_class TYPE string OPTIONAL.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CLASS-METHODS build_repo_settings_dropdown
+      IMPORTING
+        iv_key            TYPE zif_abapgit_persistence=>ty_value
+        iv_class          TYPE string OPTIONAL
+      RETURNING
+        VALUE(ro_toolbar) TYPE REF TO zcl_abapgit_html_toolbar.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_html_toolbar_lib IMPLEMENTATION.
+
+  METHOD render_repo_settings_dropdown.
+
+    ASSERT io_toolbar IS BOUND.
+
+    io_toolbar->add( iv_txt      = 'Repo Settings'
+                     io_sub      = build_repo_settings_dropdown( iv_key   = iv_key
+                                                                 iv_class = iv_class )
+                     iv_opt      = iv_opt
+                     iv_title    = `Repository Settings`
+                     iv_class    = iv_class
+                     iv_li_class = iv_li_class ).
+
+  ENDMETHOD.
+
+
+  METHOD build_repo_settings_dropdown.
+
+    CREATE OBJECT ro_toolbar.
+
+    ro_toolbar->add(
+      iv_txt   = 'Repository'
+      iv_act   = |{ zif_abapgit_definitions=>c_action-repo_settings }?key={ iv_key }|
+      iv_class = iv_class
+      iv_title = `Repository Settings`
+    )->add(
+      iv_txt   = 'Local'
+      iv_act   = |{ zif_abapgit_definitions=>c_action-repo_local_settings }?key={ iv_key }|
+      iv_class = iv_class
+      iv_title = `Local Settings`
+    )->add(
+      iv_txt   = 'Remote'
+      iv_act   = |{ zif_abapgit_definitions=>c_action-repo_remote_settings }?key={ iv_key }|
+      iv_class = iv_class
+      iv_title = `Remote Settings`
+    )->add(
+      iv_txt   = 'Background'
+      iv_act   = |{ zif_abapgit_definitions=>c_action-repo_background }?key={ iv_key }|
+      iv_class = iv_class
+      iv_title = `Background Settings`
+    )->add(
+      iv_txt   = 'Stats'
+      iv_act   = |{ zif_abapgit_definitions=>c_action-repo_infos }?key={ iv_key }|
+      iv_class = iv_class
+      iv_title = `Statistics`
+    ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_html_toolbar_lib.clas.xml
+++ b/src/ui/lib/zcl_abapgit_html_toolbar_lib.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_HTML_TOOLBAR_LIB</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - GUI HTML Toolbar Library</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -439,6 +439,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
   METHOD render_action_toolbar.
 
     CONSTANTS:
+      " dummy key is replaced in RepoOverViewHelper.prototype.updateActionLinks with actual key
       lc_dummy_key     TYPE zif_abapgit_persistence=>ty_value VALUE `#`,
       lc_offline_class TYPE string VALUE `action_offline_repo`,
       lc_online_class  TYPE string VALUE `action_online_repo`,
@@ -448,7 +449,6 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
     DATA lo_toolbar_more_sub TYPE REF TO zcl_abapgit_html_toolbar.
     DATA lv_dummy_key_param TYPE string.
 
-    " dummy key is replaced in RepoOverViewHelper.prototype.updateActionLinks with actual key
     lv_dummy_key_param = |?key={ lc_dummy_key }|.
 
     lo_toolbar = zcl_abapgit_html_toolbar=>create( 'actionbar-repo-list' ).
@@ -496,10 +496,10 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_li_class = |{ lc_action_class }| ).
 
     zcl_abapgit_html_toolbar_lib=>render_repo_settings_dropdown(
-        io_toolbar  = lo_toolbar
-        iv_key      = lc_dummy_key
-        iv_class    = |{ lc_action_class }|
-        iv_li_class = |{ lc_action_class }| ).
+      io_toolbar  = lo_toolbar
+      iv_key      = lc_dummy_key
+      iv_class    = |{ lc_action_class }|
+      iv_li_class = |{ lc_action_class }| ).
 
     CREATE OBJECT lo_toolbar_more_sub EXPORTING iv_id = 'toolbar-ovp-more_sub'.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -439,81 +439,85 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
   METHOD render_action_toolbar.
 
     CONSTANTS:
-      lc_dummy_key     TYPE string VALUE `?key=#`,
+      lc_dummy_key     TYPE zif_abapgit_persistence=>ty_value VALUE `#`,
       lc_offline_class TYPE string VALUE `action_offline_repo`,
       lc_online_class  TYPE string VALUE `action_online_repo`,
       lc_action_class  TYPE string VALUE `action_link`.
 
     DATA lo_toolbar TYPE REF TO zcl_abapgit_html_toolbar.
     DATA lo_toolbar_more_sub TYPE REF TO zcl_abapgit_html_toolbar.
+    DATA lv_dummy_key_param TYPE string.
+
+    " dummy key is replaced in RepoOverViewHelper.prototype.updateActionLinks with actual key
+    lv_dummy_key_param = |?key={ lc_dummy_key }|.
 
     lo_toolbar = zcl_abapgit_html_toolbar=>create( 'actionbar-repo-list' ).
 
     lo_toolbar->add(
       iv_txt      = |Pull|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-git_pull }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-git_pull }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar->add(
       iv_txt      = |Stage|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-go_stage }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-go_stage }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar->add(
       iv_txt      = |Patch|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-go_patch }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-go_patch }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar->add(
       iv_txt      = |Diff|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-go_repo_diff }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-go_repo_diff }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar->add(
       iv_txt      = |Check|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_code_inspector }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_code_inspector }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar->add(
       iv_txt      = |Import|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-zip_import }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-zip_import }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_offline_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar->add(
       iv_txt      = |Export|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-zip_export }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-zip_export }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_offline_class }|
       iv_li_class = |{ lc_action_class }| ).
 
-    lo_toolbar->add(
-      iv_txt      = |Repo Settings|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_settings }{ lc_dummy_key }|
-      iv_class    = |{ lc_action_class }|
-      iv_li_class = |{ lc_action_class }| ).
+    zcl_abapgit_html_toolbar_lib=>render_repo_settings_dropdown(
+        io_toolbar  = lo_toolbar
+        iv_key      = lc_dummy_key
+        iv_class    = |{ lc_action_class }|
+        iv_li_class = |{ lc_action_class }| ).
 
     CREATE OBJECT lo_toolbar_more_sub EXPORTING iv_id = 'toolbar-ovp-more_sub'.
 
     lo_toolbar_more_sub->add(
       iv_txt      = |Stage by Transport|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-go_stage_transport }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-go_stage_transport }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar_more_sub->add(
       iv_txt      = |Export by Transport|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-zip_export_transport }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-zip_export_transport }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_offline_class }|
       iv_li_class = |{ lc_action_class }| ).
 
     lo_toolbar_more_sub->add(
       iv_txt      = |Change Repository Package|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_change_package }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_change_package }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class } { lc_online_class }|
       iv_li_class = |{ lc_action_class }| ).
 
@@ -525,7 +529,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_txt      = |Remove Repository|
       iv_title    = |Remove abapGit's records of the repository (the system's |
                     && |development objects will remain unaffected)|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_remove }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_remove }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class }|
       iv_li_class = |{ lc_action_class }| ).
 
@@ -533,7 +537,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_txt      = |Remove Objects|
       iv_title    = |Delete all development objects belonging to this package |
                     && |(and subpackages) from the system, but keep repository in abapGit|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_delete_objects }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_delete_objects }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class }|
       iv_li_class = |{ lc_action_class }| ).
 
@@ -541,7 +545,7 @@ CLASS zcl_abapgit_gui_page_repo_over IMPLEMENTATION.
       iv_txt      = |Uninstall|
       iv_title    = |Delete all development objects belonging to this package |
                     && |(and subpackages) from the system, and remove the repository from abapGit|
-      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_purge }{ lc_dummy_key }|
+      iv_act      = |{ zif_abapgit_definitions=>c_action-repo_purge }{ lv_dummy_key_param }|
       iv_class    = |{ lc_action_class }|
       iv_li_class = |{ lc_action_class }| ).
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -510,9 +510,9 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                      iv_opt = zif_abapgit_html=>c_html_opt-strong ).
 
     zcl_abapgit_html_toolbar_lib=>render_repo_settings_dropdown(
-        io_toolbar = ro_toolbar
-        iv_key     = mv_key
-        iv_opt     = zif_abapgit_html=>c_html_opt-strong ).
+      io_toolbar = ro_toolbar
+      iv_key     = mv_key
+      iv_opt     = zif_abapgit_html=>c_html_opt-strong ).
 
   ENDMETHOD.
 

--- a/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_repo_view.clas.abap
@@ -509,10 +509,10 @@ CLASS zcl_abapgit_gui_page_repo_view IMPLEMENTATION.
                      iv_act = |{ zif_abapgit_definitions=>c_action-repo_refresh }?key={ mv_key }|
                      iv_opt = zif_abapgit_html=>c_html_opt-strong ).
 
-    ro_toolbar->add( iv_txt   = 'Repo Settings'
-                     iv_act   = |{ zif_abapgit_definitions=>c_action-repo_settings }?key={ mv_key }|
-                     iv_opt   = zif_abapgit_html=>c_html_opt-strong
-                     iv_title = `Repository Settings` ).
+    zcl_abapgit_html_toolbar_lib=>render_repo_settings_dropdown(
+        io_toolbar = ro_toolbar
+        iv_key     = mv_key
+        iv_opt     = zif_abapgit_html=>c_html_opt-strong ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
With this change all repo settings pages are directly accessible in repo overview and repo view. 

:white_check_mark: Allows faster navigation to Local/Remote etc., especially with the command palette.

:warning: Navigation to repository settings with mouse may slow down a bit, as one first needs to hoover and then click

Imho a tradeoff worthwhile.

Repo overview:
<img width="1332" height="297" alt="image" src="https://github.com/user-attachments/assets/fe280511-bd0f-4400-9fe0-bcf2f819cf78" />

Repo view:
<img width="1368" height="321" alt="image" src="https://github.com/user-attachments/assets/0ea0b669-fda0-465a-87d1-b1c6401318e1" />
