### PR TITLE
TRAN: Handle empty transaction attributes

### DIFF
--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -632,6 +632,7 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
 
     READ TABLE lt_tcodes INDEX 1 INTO es_transaction.
     ASSERT sy-subrc = 0.
+    READ TABLE lt_gui_attr INDEX 1 INTO es_gui_attr.
 
   ENDMETHOD.
 


### PR DESCRIPTION
I've encountered older transactions where the additional attributes are empty, causing a dump. Just ignore, this is OK