### PR TITLE
PDTS: Fix dump when task has no container

### DIFF
--- a/src/objects/zcl_abapgit_object_pdts.clas.abap
+++ b/src/objects/zcl_abapgit_object_pdts.clas.abap
@@ -193,15 +193,19 @@ CLASS zcl_abapgit_object_pdts IMPLEMENTATION.
 
   METHOD zif_abapgit_object~serialize.
 
-    DATA li_task TYPE REF TO lif_task_definition.
+    DATA li_task          TYPE REF TO lif_task_definition.
+    DATA li_container_xml TYPE REF TO if_ixml_element.
 
     li_task = lcl_task_definition=>load( mv_objid ).
     li_task->clear_origin_data( ).
     io_xml->add( iv_name = 'PDTS'
                  ig_data = li_task->get_definition( ) ).
 
-    io_xml->add_xml( iv_name = 'CONTAINER'
-                     ii_xml  = get_container_xml( li_task ) ).
+    li_container_xml = get_container_xml( li_task ).
+    IF li_container_xml IS BOUND.
+      io_xml->add_xml( iv_name = 'CONTAINER'
+                       ii_xml  = li_container_xml ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_pdts.clas.locals_imp.abap
+++ b/src/objects/zcl_abapgit_object_pdts.clas.locals_imp.abap
@@ -203,6 +203,10 @@ CLASS lcl_task_definition IMPLEMENTATION.
     DATA lt_exception_list TYPE swf_cx_tab.
     DATA lx_exception TYPE REF TO cx_swf_ifs_exception.
 
+    IF iv_xml_string IS INITIAL OR mo_taskdef->container IS NOT BOUND.
+      RETURN.
+    ENDIF.
+
     mo_taskdef->container->import_from_xml(
             EXPORTING xml_stream     = iv_xml_string
             IMPORTING exception_list = lt_exception_list ).


### PR DESCRIPTION
## Summary
- Standard Tasks (TS) without a container cause `CX_SY_REF_IS_INITIAL` dump during serialization
- `mo_taskdef->container` can be NULL when a task doesn't pass data
- Added bound-check guards in `get_user_container` and `get_container_xml` to handle this gracefully

## Test plan
- [ ] Serialize a PDTS object that has no container defined — should no longer dump
- [ ] Serialize a PDTS object that has a container — should behave as before
- [ ] Deserialize path already handles missing container (`extract_container` checks `IS BOUND`)