### PR TITLE
DTEL + TABL: fix exists() for identical names

### DIFF
--- a/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
@@ -81,7 +81,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
+CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
 
   METHOD clear_dd03p_fields.

--- a/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/tabl/zcl_abapgit_object_tabl.clas.abap
@@ -81,7 +81,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
 
   METHOD clear_dd03p_fields.
@@ -788,7 +788,11 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
       EXCEPTIONS
         not_found = 1
         OTHERS    = 2.
-    IF sy-subrc <> 0.
+    IF sy-subrc = 0 AND ls_x030l-tabtype = 'E'.
+      " then its a data element
+      rv_bool = abap_false.
+      RETURN.
+    ELSEIF sy-subrc <> 0.
       " Check for new, inactive, or modified versions that might not be in nametab
       SELECT SINGLE tabname FROM dd02l INTO lv_tabname
         WHERE tabname = lv_tabname.                     "#EC CI_NOORDER

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -41,7 +41,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
+CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
 
 
   METHOD deserialize_texts.

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -41,7 +41,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -249,7 +249,8 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
 
   METHOD zif_abapgit_object~exists.
 
-    DATA: lv_rollname TYPE dd04l-rollname.
+    DATA lv_rollname TYPE dd04l-rollname.
+    DATA ls_x030l    TYPE x030l.
 
     lv_rollname = ms_item-obj_name.
 
@@ -257,10 +258,16 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
     CALL FUNCTION 'DD_GET_NAMETAB_HEADER'
       EXPORTING
         tabname   = lv_rollname
+      IMPORTING
+        x030l_wa  = ls_x030l
       EXCEPTIONS
         not_found = 1
         OTHERS    = 2.
-    IF sy-subrc <> 0.
+    IF sy-subrc = 0 AND ls_x030l-tabtype <> 'E'.
+      " then its not a data element
+      rv_bool = abap_false.
+      RETURN.
+    ELSEIF sy-subrc <> 0.
       " Check for inactive or modified versions
       SELECT SINGLE rollname FROM dd04l INTO lv_rollname
         WHERE rollname = lv_rollname.


### PR DESCRIPTION
If a table in remote has the same name as a data element in the system, the exists() method returns true, but it doesnt exist, its a data element


small test program to verify the DTEL:

```abap
DATA ls_x030l TYPE x030l.

SELECT * FROM dd04l INTO TABLE @DATA(tab) UP TO 10000 ROWS.

LOOP AT tab INTO DATA(row).
  CALL FUNCTION 'DD_GET_NAMETAB_HEADER'
    EXPORTING
      tabname   = row-rollname
    IMPORTING
      x030l_wa  = ls_x030l
    EXCEPTIONS
      not_found = 1
      OTHERS    = 2.
  IF ls_x030l-tabtype <> 'E'.
    WRITE / ls_x030l-tabtype.
  ENDIF.
ENDLOOP.

WRITE / 'Done'.
```
