### PR TITLE
fix(oo): Surface detailed syntax errors from CLAS/INTF check

### DIFF
--- a/src/objects/oo/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_class.clas.abap
@@ -978,26 +978,52 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~syntax_check.
     DATA:
       ls_clskey      TYPE seoclskey,
-      lv_syntaxerror TYPE abap_bool.
+      lv_syntaxerror TYPE abap_bool,
+      lo_checklist   TYPE REF TO cl_wb_checklist,
+      lt_errors      TYPE swbme_error_tab,
+      lo_local_log   TYPE REF TO zif_abapgit_log,
+      ls_item        TYPE zif_abapgit_definitions=>ty_item.
+
+    FIELD-SYMBOLS:
+      <ls_err>  TYPE swbme_error_entry,
+      <lv_line> TYPE string.
 
     ls_clskey-clsname = to_upper( iv_object_name ).
+
+    CREATE OBJECT lo_checklist.
 
     CALL FUNCTION 'SEO_CLASS_CHECK_CLASSPOOL'
       EXPORTING
         clskey                       = ls_clskey
+        wb_checklist                 = lo_checklist
         suppress_error_popup         = abap_true
       IMPORTING
         syntaxerror                  = lv_syntaxerror
       EXCEPTIONS
         _internal_class_not_existing = 1
-        error_message                = 2 " suppress S-message
+        error_message                = 2
         OTHERS                       = 3.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
     IF lv_syntaxerror = abap_true.
-      zcx_abapgit_exception=>raise( |Class { ls_clskey-clsname } has syntax errors | ).
+      CREATE OBJECT lo_local_log TYPE zcl_abapgit_log.
+      ls_item-obj_type = 'CLAS'.
+      ls_item-obj_name = ls_clskey-clsname.
+
+      lo_checklist->get_error_messages( IMPORTING p_error_tab = lt_errors ).
+      LOOP AT lt_errors ASSIGNING <ls_err> WHERE mtype = 'E'.
+        LOOP AT <ls_err>-mtext ASSIGNING <lv_line>.
+          lo_local_log->add_error(
+            iv_msg  = <lv_line>
+            is_item = ls_item ).
+        ENDLOOP.
+      ENDLOOP.
+
+      zcx_abapgit_exception=>raise(
+        iv_text = |Class { ls_clskey-clsname } has syntax errors|
+        ii_log  = lo_local_log ).
     ENDIF.
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/oo/zcl_abapgit_oo_interface.clas.abap
@@ -349,25 +349,51 @@ CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~syntax_check.
     DATA:
       ls_intkey      TYPE seoclskey,
-      lv_syntaxerror TYPE abap_bool.
+      lv_syntaxerror TYPE abap_bool,
+      lo_checklist   TYPE REF TO cl_wb_checklist,
+      lt_errors      TYPE swbme_error_tab,
+      lo_local_log   TYPE REF TO zif_abapgit_log,
+      ls_item        TYPE zif_abapgit_definitions=>ty_item.
+
+    FIELD-SYMBOLS:
+      <ls_err>  TYPE swbme_error_entry,
+      <lv_line> TYPE string.
 
     ls_intkey-clsname = to_upper( iv_object_name ).
+
+    CREATE OBJECT lo_checklist.
 
     CALL FUNCTION 'SEO_INTERFACE_CHECK_POOL'
       EXPORTING
         intkey               = ls_intkey
+        wb_checklist         = lo_checklist
         suppress_error_popup = abap_true
       IMPORTING
         syntaxerror          = lv_syntaxerror
       EXCEPTIONS
-        error_message        = 1 " suppress S-message
+        error_message        = 1
         OTHERS               = 2.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
     IF lv_syntaxerror = abap_true.
-      zcx_abapgit_exception=>raise( |Interface { ls_intkey-clsname } has syntax errors | ).
+      CREATE OBJECT lo_local_log TYPE zcl_abapgit_log.
+      ls_item-obj_type = 'INTF'.
+      ls_item-obj_name = ls_intkey-clsname.
+
+      lo_checklist->get_error_messages( IMPORTING p_error_tab = lt_errors ).
+      LOOP AT lt_errors ASSIGNING <ls_err> WHERE mtype = 'E'.
+        LOOP AT <ls_err>-mtext ASSIGNING <lv_line>.
+          lo_local_log->add_error(
+            iv_msg  = <lv_line>
+            is_item = ls_item ).
+        ENDLOOP.
+      ENDLOOP.
+
+      zcx_abapgit_exception=>raise(
+        iv_text = |Interface { ls_intkey-clsname } has syntax errors|
+        ii_log  = lo_local_log ).
     ENDIF.
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -123,10 +123,36 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
 
   METHOD zif_abapgit_log~add_exception.
 
-    DATA lx_exc TYPE REF TO cx_root.
-    DATA lv_msg TYPE string.
+    DATA lx_exc   TYPE REF TO cx_root.
+    DATA lx_git   TYPE REF TO zcx_abapgit_exception.
+    DATA lt_inner TYPE zif_abapgit_log=>ty_log_outs.
+    DATA lv_msg   TYPE string.
+    DATA ls_inner_item TYPE zif_abapgit_definitions=>ty_item.
+
+    FIELD-SYMBOLS <ls_msg> LIKE LINE OF lt_inner.
+
     lx_exc = ix_exc.
     DO.
+      TRY.
+          lx_git ?= lx_exc.
+          IF lx_git->mi_log IS BOUND.
+            lt_inner = lx_git->mi_log->get_messages( ).
+            LOOP AT lt_inner ASSIGNING <ls_msg>.
+              CLEAR ls_inner_item.
+              ls_inner_item-obj_type = <ls_msg>-obj_type.
+              ls_inner_item-obj_name = <ls_msg>-obj_name.
+              zif_abapgit_log~add(
+                iv_msg    = <ls_msg>-text
+                iv_type   = <ls_msg>-type
+                iv_class  = <ls_msg>-id
+                iv_number = <ls_msg>-number
+                is_item   = ls_inner_item
+                ix_exc    = lx_exc ).
+            ENDLOOP.
+          ENDIF.
+        CATCH cx_sy_move_cast_error ##NO_HANDLER.
+      ENDTRY.
+
       lv_msg = lx_exc->get_text( ).
       zif_abapgit_log~add( iv_msg  = lv_msg
                            iv_type = 'E'


### PR DESCRIPTION
## Problem

When a class or interface fails `syntax_check`, the exception only says:

> Class ZCL_FOO has syntax errors

The FM `SEO_CLASS_CHECK_CLASSPOOL` actually computes detailed errors (e.g. `Method "LV+" is unknown or PROTECTED or PRIVATE.` at line 14) but nobody reads them — the `wb_checklist` parameter is never passed.

Meanwhile, `zcx_abapgit_exception=>raise()` accepts `ii_log` and stores it in `mi_log`, but `add_exception` never drains it. 

## How to reproduce

1. Create a class with a syntax error (e.g. call a non-existent method)
2. Add it to a repo tracked by abapGit
3. Pull/deserialize — the log shows only "has syntax errors", not *what* the error is

## Fix

### Part 1: `zcl_abapgit_log->add_exception`

When the caught exception is `zcx_abapgit_exception` with a bound `mi_log`, drain all inner log messages into the outer log before logging the exception text. Uses `TRY/?=/CATCH` for v702 compat.

### Part 2: `zcl_abapgit_oo_class` / `zcl_abapgit_oo_interface` — `syntax_check`

- Pass a `cl_wb_checklist` to the FM
- Extract detailed errors from the checklist
- Build a local log and raise with `ii_log` attached

## How to test

1. Add https://github.com/YahorNovik/abapgit-test-syntax-error as an online repo in abapGit 
2. Pull — the class `ZCL_TEST_SYNTAX_ERR` has an intentional syntax error (`me->nonexistent_method( )`)
3. After pull, check the log:
   - **Before fix:** log shows `Class ZCL_TEST_SYNTAX_ERR has syntax errors`
   - **After fix:** log also shows `Method "NONEXISTENT_METHOD" is unknown or PROTECTED or PRIVATE.`
4. Alternatively, call `syntax_check` directly:
   ```abap
   DATA lo_fnc TYPE REF TO zif_abapgit_oo_object_fnc.
   lo_fnc = zcl_abapgit_oo_factory=>get_by_name( 'ZCL_TEST_SYNTAX_ERR' ).
   lo_fnc->syntax_check( 'ZCL_TEST_SYNTAX_ERR' ).
   ```
5. Any catch site using `ii_log->add_exception( lx )` now surfaces the detail automatically

