### PR TITLE
DTSC: Switch to ABAP file format

### DIFF
--- a/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
+++ b/src/objects/aff/zcl_abapgit_aff_registry.clas.abap
@@ -73,6 +73,7 @@ CLASS ZCL_ABAPGIT_AFF_REGISTRY IMPLEMENTATION.
     register( 'UIAD' ).
     register( 'UIPG' ).
     register( 'UIST' ).
+    register( 'DTSC' ).
   ENDMETHOD.
 
 
@@ -103,4 +104,3 @@ CLASS ZCL_ABAPGIT_AFF_REGISTRY IMPLEMENTATION.
     ENDIF.
   ENDMETHOD.
 ENDCLASS.
-

--- a/src/objects/zcl_abapgit_object_dtsc.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtsc.clas.abap
@@ -1,56 +1,15 @@
 CLASS zcl_abapgit_object_dtsc DEFINITION
   PUBLIC
-  INHERITING FROM zcl_abapgit_objects_super
+  INHERITING FROM zcl_abapgit_object_common_aff
   FINAL
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-
-    INTERFACES zif_abapgit_object .
-
-    METHODS constructor
-      IMPORTING
-        !is_item        TYPE zif_abapgit_definitions=>ty_item
-        !iv_language    TYPE spras
-        !io_files       TYPE REF TO zcl_abapgit_objects_files OPTIONAL
-        !io_i18n_params TYPE REF TO zcl_abapgit_i18n_params OPTIONAL
-      RAISING
-        zcx_abapgit_type_not_supported .
+    METHODS zif_abapgit_object~changed_by            REDEFINITION.
+    METHODS zif_abapgit_object~get_deserialize_steps REDEFINITION.
   PROTECTED SECTION.
+    METHODS get_additional_extensions                REDEFINITION.
   PRIVATE SECTION.
-    METHODS:
-      clear_fields
-        CHANGING
-          cs_static_cache TYPE any,
-
-      clear_field
-        IMPORTING
-          iv_fieldname    TYPE csequence
-        CHANGING
-          cs_static_cache TYPE any,
-
-      fill_metadata_from_db
-        CHANGING
-          cs_static_cache TYPE any
-        RAISING
-          zcx_abapgit_exception,
-
-      get_wb_object_operator
-        RETURNING
-          VALUE(ri_wb_object_operator) TYPE REF TO object
-        RAISING
-          zcx_abapgit_exception,
-
-      has_own_wb_data_class
-        RETURNING
-          VALUE(rv_supported) TYPE abap_bool.
-
-    DATA:
-      mr_static_cache          TYPE REF TO data,
-      mv_static_cache_key      TYPE seu_objkey,
-      mv_has_own_wb_data_class TYPE abap_bool,
-      mi_persistence           TYPE REF TO if_wb_object_persist,
-      mi_wb_object_operator    TYPE REF TO object.
 ENDCLASS.
 
 
@@ -58,350 +17,27 @@ ENDCLASS.
 CLASS ZCL_ABAPGIT_OBJECT_DTSC IMPLEMENTATION.
 
 
-  METHOD clear_field.
-
-    FIELD-SYMBOLS: <lv_value> TYPE data.
-
-    ASSIGN COMPONENT iv_fieldname OF STRUCTURE cs_static_cache
-           TO <lv_value>.
-    IF sy-subrc = 0.
-      CLEAR: <lv_value>.
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD clear_fields.
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-CREATED_AT'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-CREATED_BY'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-CHANGED_AT'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-CHANGED_BY'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-MASTER_LANGUAGE'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-MASTER_SYSTEM'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-RESPONSIBLE'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-PACKAGE_REF'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-ABAP_LANGUAGE_VERSION'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'METADATA-ABAP_LANGU_VERSION'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-    clear_field(
-      EXPORTING
-        iv_fieldname     = 'CONTENT-SOURCE'
-      CHANGING
-        cs_static_cache = cs_static_cache ).
-
-  ENDMETHOD.
-
-
-  METHOD constructor.
-
-    super->constructor(
-      is_item        = is_item
-      iv_language    = iv_language
-      io_files       = io_files
-      io_i18n_params = io_i18n_params ).
-
-    mv_static_cache_key = ms_item-obj_name.
-    mv_has_own_wb_data_class = has_own_wb_data_class( ).
-
-    TRY.
-
-        CREATE DATA mr_static_cache TYPE ('CL_BLUE_SOURCE_OBJECT_DATA=>TY_OBJECT_DATA').
-
-        CREATE OBJECT mi_persistence TYPE ('CL_DTSC_OBJECT_PERSIST').
-
-      CATCH cx_sy_create_error.
-        RAISE EXCEPTION TYPE zcx_abapgit_type_not_supported EXPORTING obj_type = is_item-obj_type.
-    ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD fill_metadata_from_db.
-
-    DATA:
-      li_wb_object_operator TYPE REF TO object,
-      lr_static_cache_old   TYPE REF TO data.
-
-    FIELD-SYMBOLS:
-      <ls_static_cache_old> TYPE any,
-      <lv_created_at>       TYPE xsddatetime_z,
-      <lv_created_by>       TYPE syuname,
-      <lv_created_at_old>   TYPE xsddatetime_z,
-      <lv_created_by_old>   TYPE syuname.
-
-    li_wb_object_operator = get_wb_object_operator( ).
-
-    CREATE DATA lr_static_cache_old TYPE ('CL_BLUE_SOURCE_OBJECT_DATA=>TY_OBJECT_DATA').
-
-    ASSIGN lr_static_cache_old->* TO <ls_static_cache_old>.
-    ASSERT sy-subrc = 0.
-
-    CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~READ')
-      IMPORTING
-        data = <ls_static_cache_old>.
-
-    ASSIGN COMPONENT 'METADATA-CREATED_BY' OF STRUCTURE cs_static_cache
-           TO <lv_created_by>.
-    ASSERT sy-subrc = 0.
-
-    ASSIGN COMPONENT 'METADATA-CREATED_AT' OF STRUCTURE cs_static_cache
-           TO <lv_created_at>.
-    ASSERT sy-subrc = 0.
-
-    ASSIGN COMPONENT 'METADATA-CREATED_BY' OF STRUCTURE <ls_static_cache_old>
-           TO <lv_created_by_old>.
-    ASSERT sy-subrc = 0.
-
-    ASSIGN COMPONENT 'METADATA-CREATED_AT' OF STRUCTURE <ls_static_cache_old>
-           TO <lv_created_at_old>.
-    ASSERT sy-subrc = 0.
-
-    <lv_created_at> = <lv_created_at_old>.
-    <lv_created_by> = <lv_created_by_old>.
-
-  ENDMETHOD.
-
-
-  METHOD get_wb_object_operator.
-
-    DATA:
-      ls_object_type TYPE wbobjtype,
-      lx_error       TYPE REF TO cx_root.
-
-    IF mi_wb_object_operator IS BOUND.
-      ri_wb_object_operator = mi_wb_object_operator.
-    ENDIF.
-
-    ls_object_type-objtype_tr = 'DTSC'.
-    ls_object_type-subtype_wb = 'DF'.
-
-    TRY.
-        CALL METHOD ('CL_WB_OBJECT_OPERATOR')=>('CREATE_INSTANCE')
-          EXPORTING
-            object_type = ls_object_type
-            object_key  = mv_static_cache_key
-          RECEIVING
-            result      = mi_wb_object_operator.
-
-      CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise_with_text( lx_error ).
-    ENDTRY.
-
-    ri_wb_object_operator = mi_wb_object_operator.
-
-  ENDMETHOD.
-
-
-  METHOD has_own_wb_data_class.
-
-    rv_supported = abap_false.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_object~changed_by.
 
-    DATA:
-      li_object_data_model  TYPE REF TO if_wb_object_data_model,
-      lx_error              TYPE REF TO cx_root,
-      li_wb_object_operator TYPE REF TO object.
+    DATA: lo_dtsc_handler TYPE REF TO object,
+          lv_object_key   TYPE seu_objkey,
+          lx_error        TYPE REF TO cx_root.
 
     TRY.
-        li_wb_object_operator = get_wb_object_operator( ).
-
-        CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~READ')
-          IMPORTING
-            eo_object_data = li_object_data_model.
-
-        rv_user = li_object_data_model->get_changed_by( ).
-
-      CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise_with_text( lx_error ).
-    ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~delete.
-
-    DATA:
-      lx_error              TYPE REF TO cx_root,
-      li_wb_object_operator TYPE REF TO object.
-
-    TRY.
-        li_wb_object_operator = get_wb_object_operator( ).
-
-        CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~DELETE')
+        lv_object_key = ms_item-obj_name.
+        CALL METHOD ('CL_DTSC_AFF_OBJECT_HANDLER')=>('GET_DDIC_HANDLER')
           EXPORTING
-            transport_request = iv_transport.
+            object_key = lv_object_key
+          RECEIVING
+            handler    = lo_dtsc_handler.
+
+        CALL METHOD lo_dtsc_handler->('IF_DD_DT_HANDLER~GET_CHANGED_BY')
+          RECEIVING
+            rv_changed_by = rv_user.
 
       CATCH cx_root INTO lx_error.
         zcx_abapgit_exception=>raise_with_text( lx_error ).
     ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~deserialize.
-
-    DATA:
-      li_object_data_model  TYPE REF TO if_wb_object_data_model,
-      li_wb_object_operator TYPE REF TO object,
-      lx_error              TYPE REF TO cx_root.
-
-    FIELD-SYMBOLS:
-      <lv_abap_language_version> TYPE uccheck,
-      <ls_static_cache>          TYPE any,
-      <lv_source>                TYPE data.
-
-    ASSIGN mr_static_cache->* TO <ls_static_cache>.
-    ASSERT sy-subrc = 0.
-
-    io_xml->read(
-      EXPORTING
-        iv_name = 'DTSC'
-      CHANGING
-        cg_data = <ls_static_cache> ).
-
-    li_wb_object_operator = get_wb_object_operator( ).
-
-    TRY.
-
-        CREATE OBJECT li_object_data_model TYPE ('CL_BLUE_SOURCE_OBJECT_DATA').
-
-        ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <ls_static_cache>
-               TO <lv_source>.
-        ASSERT sy-subrc = 0.
-
-        <lv_source> = mo_files->read_string( 'acds' ).
-
-        tadir_insert( iv_package ).
-
-        IF zif_abapgit_object~exists( ) = abap_true.
-
-          " We need to populate created_at, created_by, because otherwise update  is not possible
-          fill_metadata_from_db( CHANGING cs_static_cache = <ls_static_cache> ).
-          li_object_data_model->set_data( <ls_static_cache> ).
-
-          CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~UPDATE')
-            EXPORTING
-              io_object_data    = li_object_data_model
-              transport_request = iv_transport.
-
-        ELSE.
-
-          li_object_data_model->set_data( <ls_static_cache> ).
-
-          CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~CREATE')
-            EXPORTING
-              io_object_data    = li_object_data_model
-              data_selection    = 'P' " if_wb_object_data_selection_co=>c_properties
-              package           = iv_package
-              transport_request = iv_transport.
-
-          CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~UPDATE')
-            EXPORTING
-              io_object_data    = li_object_data_model
-              data_selection    = 'D' " if_wb_object_data_selection_co=>c_data_content
-              transport_request = iv_transport.
-
-        ENDIF.
-
-        CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~ACTIVATE').
-
-        ASSIGN COMPONENT 'METADATA-ABAP_LANGUAGE_VERSION' OF STRUCTURE <ls_static_cache>
-          TO <lv_abap_language_version>.
-        IF sy-subrc = 0.
-          set_abap_language_version( CHANGING cv_abap_language_version = <lv_abap_language_version> ).
-
-          TRY.
-              UPDATE ('DDDTSC_SOURCE') SET abap_language_version = <lv_abap_language_version>
-                WHERE dtsc_name = ms_item-obj_name.
-            CATCH cx_sy_dynamic_osql_semantics ##NO_HANDLER.
-          ENDTRY.
-        ENDIF.
-
-        corr_insert( iv_package ).
-
-      CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise_with_text( lx_error ).
-    ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~exists.
-
-    TRY.
-        mi_persistence->get(
-          p_object_key           = mv_static_cache_key
-          p_version              = 'A'
-          p_existence_check_only = abap_true ).
-        rv_bool = abap_true.
-
-      CATCH cx_swb_exception.
-        rv_bool = abap_false.
-    ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~get_comparator.
-    RETURN.
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~get_deserialize_order.
-    RETURN.
   ENDMETHOD.
 
 
@@ -410,89 +46,12 @@ CLASS ZCL_ABAPGIT_OBJECT_DTSC IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_object~get_metadata.
-    rs_metadata = get_metadata( ).
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~is_active.
-    rv_active = is_active( ).
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~is_locked.
-
-    rv_is_locked = exists_a_lock_entry_for( iv_lock_object = 'ESWB_EO'
-                                            iv_argument    = |{ ms_item-obj_type }{ ms_item-obj_name }| ).
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~jump.
-    " Covered by ZCL_ABAPGIT_OBJECTS=>JUMP
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~map_filename_to_object.
-    RETURN.
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~map_object_to_filename.
-    RETURN.
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_object~serialize.
-
-    DATA:
-      li_wb_object_operator TYPE REF TO object,
-      li_object_data_model  TYPE REF TO if_wb_object_data_model,
-      lx_error              TYPE REF TO cx_root,
-      lv_source             TYPE string.
-
-    FIELD-SYMBOLS:
-      <lv_abap_language_version> TYPE uccheck,
-      <ls_static_cache>          TYPE any,
-      <lv_source>                TYPE string.
-
-    ASSIGN mr_static_cache->* TO <ls_static_cache>.
-    ASSERT sy-subrc = 0.
-
-    TRY.
-        li_wb_object_operator = get_wb_object_operator( ).
-
-        CALL METHOD li_wb_object_operator->('IF_WB_OBJECT_OPERATOR~READ')
-          EXPORTING
-            version        = 'A'
-          IMPORTING
-            data           = <ls_static_cache>
-            eo_object_data = li_object_data_model.
-
-        ASSIGN COMPONENT 'CONTENT-SOURCE' OF STRUCTURE <ls_static_cache>
-               TO <lv_source>.
-        ASSERT sy-subrc = 0.
-
-        lv_source = <lv_source>.
-
-        clear_fields( CHANGING cs_static_cache = <ls_static_cache> ).
-
-      CATCH cx_root INTO lx_error.
-        zcx_abapgit_exception=>raise_with_text( lx_error ).
-    ENDTRY.
-
-    ASSIGN COMPONENT 'METADATA-ABAP_LANGUAGE_VERSION' OF STRUCTURE <ls_static_cache> TO <lv_abap_language_version>.
-    IF sy-subrc = 0.
-      <lv_abap_language_version> = get_abap_language_version( ).
-    ENDIF.
-
-    io_xml->add(
-      iv_name = 'DTSC'
-      ig_data = <ls_static_cache> ).
-
-    mo_files->add_string(
-      iv_ext    = 'acds'
-      iv_string = lv_source ).
-
+  METHOD get_additional_extensions.
+    DATA ls_additional_extension LIKE LINE OF rv_additional_extensions.
+    ls_additional_extension-extension = 'acds'.
+    CALL METHOD ('CL_CDS_AFF_FILE_NAME_MAPPER')=>for_cds
+      RECEIVING
+        result = ls_additional_extension-file_name_mapper.
+    APPEND ls_additional_extension TO rv_additional_extensions.
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
Now for up-to-date branch

in order to support the migration scenario from PrivateCloud to PublicCloud (PUSH to Repo via ZABAGIT and PULL into ABAP Steampunk system), we decided to adopt the DTSC properties file and changed it from .xml to .json. The relevant implementation has been adopted and DTSC has been added in ZCL_ABAPGIT_AFF_REGISTRY. The ZABAPGIT is now also coherent with https://github.com/SAP/abap-file-formats
The repository with the test objects has been updated as well.

Best,
Krzysztof