### PR TITLE
FUGR: bugfix serialization inactive function module

### DIFF
--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -593,7 +593,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     ENDIF.
 
     " FM RS_FUNCTION_POOL_CONTENTS is not reliable if Function Group is inconsistent, so cross-check results (#7147)
-    " Don't check active flag, or the includes become wrong (#1234)
+    " Don't check active flag, or the includes become wrong (#7702)
     SELECT * FROM enlfdir
       INTO TABLE lt_enlfdir
       WHERE area = ms_item-obj_name

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -593,7 +593,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     ENDIF.
 
     " FM RS_FUNCTION_POOL_CONTENTS is not reliable if Function Group is inconsistent, so cross-check results (#7147)
-    " dont check active flag, or the includes become wrong (#1234)
+    " Don't check active flag, or the includes become wrong (#1234)
     SELECT * FROM enlfdir
       INTO TABLE lt_enlfdir
       WHERE area = ms_item-obj_name

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -592,11 +592,11 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    "FM is not reliable if Function Group is inconsistent, so cross-check results (#7147)
+    " FM RS_FUNCTION_POOL_CONTENTS is not reliable if Function Group is inconsistent, so cross-check results (#7147)
+    " dont check active flag, or the includes become wrong (#1234)
     SELECT * FROM enlfdir
       INTO TABLE lt_enlfdir
       WHERE area = ms_item-obj_name
-        AND active = abap_true
       ORDER BY funcname.                                  "#EC CI_SUBRC
 
     LOOP AT lt_enlfdir ASSIGNING <ls_enlfdir>.


### PR DESCRIPTION
closes #7701 <- see this for how to reproduce

regression from https://github.com/abapGit/abapGit/pull/7147


after the fix, which is the same behavior as PROG, the active version is serialized, and the object is marked as inactive,

<img width="1557" height="1137" alt="image" src="https://github.com/user-attachments/assets/6c040221-5aac-4dd3-a31d-379735ed5705" />
