### PR TITLE
Downport: fix 702 compatibility

### DIFF
--- a/src/git/zlib/zcl_abapgit_zlib.clas.testclasses.abap
+++ b/src/git/zlib/zcl_abapgit_zlib.clas.testclasses.abap
@@ -280,7 +280,8 @@ CLASS ltcl_zlib IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = ls_data-raw
                                         exp = lc_raw ).
     cl_abap_unit_assert=>assert_not_initial( ls_data-compressed_len ).
-    cl_abap_unit_assert=>assert_true( boolc( ls_data-compressed_len < xstrlen( lv_compressed ) ) ).
+    cl_abap_unit_assert=>assert_equals( act = boolc( ls_data-compressed_len < xstrlen( lv_compressed ) )
+                                        exp = abap_true ).
 
   ENDMETHOD.
 

--- a/src/objects/core/zcl_abapgit_dependencies.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_dependencies.clas.testclasses.abap
@@ -309,8 +309,9 @@ CLASS ltcl_resolve IMPLEMENTATION.
                         WITH KEY object   = iv_object_b
                                  obj_name = iv_obj_name_b.
 
-    cl_abap_unit_assert=>assert_true(
+    cl_abap_unit_assert=>assert_equals(
       act = boolc( ls_tadir_a-korrnum < ls_tadir_b-korrnum )
+      exp = abap_true
       msg = |{ iv_object_a } { iv_obj_name_a } should be deleted before { iv_object_b } { iv_obj_name_b }| ).
 
   ENDMETHOD.

--- a/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_lxe_texts.clas.abap
@@ -477,6 +477,7 @@ CLASS zcl_abapgit_lxe_texts IMPLEMENTATION.
   METHOD get_lxe_object_list.
 
     DATA lv_object_name TYPE trobj_name.
+    DATA lt_e071k TYPE STANDARD TABLE OF e071k WITH DEFAULT KEY ##NEEDED.
 
     lv_object_name = iv_object_name.
 
@@ -486,6 +487,7 @@ CLASS zcl_abapgit_lxe_texts IMPLEMENTATION.
         object          = iv_object_type
         obj_name        = lv_object_name
       TABLES
+        in_e071k        = lt_e071k " not optional in 702
         ex_colob        = rt_obj_list
       EXCEPTIONS
         unknown_object  = 1


### PR DESCRIPTION
- `assert_that` does not exist in 7.02
- missing table parameter in LXE get list