### PR TITLE
Fix "Uninstall error: Object directory entry cannot be deleted"

### DIFF
--- a/src/objects/core/zcl_abapgit_tadir.clas.abap
+++ b/src/objects/core/zcl_abapgit_tadir.clas.abap
@@ -368,7 +368,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
         change_of_class_not_allowed    = 23
         no_change_from_sap_to_tmp      = 24
         OTHERS                         = 25.
-    IF sy-subrc > 1.
+    IF sy-subrc > 1 AND iv_no_throw = abap_false.
       " No error if entry does not exist
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.

--- a/src/objects/core/zif_abapgit_tadir.intf.abap
+++ b/src/objects/core/zif_abapgit_tadir.intf.abap
@@ -53,6 +53,7 @@ INTERFACE zif_abapgit_tadir
       !iv_pgmid    TYPE csequence DEFAULT 'R3TR'
       !iv_object   TYPE csequence
       !iv_obj_name TYPE csequence
+      !iv_no_throw TYPE abap_bool DEFAULT abap_false
     RAISING
       zcx_abapgit_exception.
 

--- a/src/objects/texts/zcl_abapgit_sotr_handler.clas.abap
+++ b/src/objects/texts/zcl_abapgit_sotr_handler.clas.abap
@@ -305,9 +305,11 @@ CLASS zcl_abapgit_sotr_handler IMPLEMENTATION.
       SELECT SINGLE obj_name FROM tadir INTO lv_obj_name
         WHERE pgmid = 'R3TR' AND object = 'SOTR' AND obj_name = iv_package.
       IF sy-subrc = 0.
+        " Ignore errors since objects might be locked in unreleased transport (TR022)
         zcl_abapgit_factory=>get_tadir( )->delete_single(
           iv_object   = 'SOTR'
-          iv_obj_name = lv_obj_name ).
+          iv_obj_name = lv_obj_name
+          iv_no_throw = abap_true ).
 
         IF zcl_abapgit_factory=>get_sap_package( iv_package )->are_changes_recorded_in_tr_req( ) = abap_true.
 

--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -216,9 +216,11 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
       ls_item-obj_name = ls_tadir-obj_name.
 
       IF zcl_abapgit_objects=>exists( ls_item ) = abap_false.
+        " Ignore errors since objects might be locked in unreleased transport (TR022)
         zcl_abapgit_factory=>get_tadir( )->delete_single(
-          iv_object    = ls_tadir-object
-          iv_obj_name  = ls_tadir-obj_name ).
+          iv_object   = ls_tadir-object
+          iv_obj_name = ls_tadir-obj_name
+          iv_no_throw = abap_true ).
       ENDIF.
     ENDLOOP.
 


### PR DESCRIPTION
"Uninstall error: Object directory entry cannot be deleted, since the object is locked" (TR022) can occur when trying to uninstall a transportable package. 

Fix is to ignore subrc when calling `TR_TADIR_INTERFACE` (as it was previously).

Test: https://github.com/abapGit-tests/CLAS_exc_with_SOTR with Z-package

Regression #7309