### PR TITLE
FUGS: fix "LXZAGF00 may not have an inactive version"

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -129,6 +129,7 @@ CLASS zcl_abapgit_objects_program DEFINITION
       BEGIN OF c_state,
         active   TYPE r3state VALUE 'A',
         inactive TYPE r3state VALUE 'I',
+        off      TYPE r3state VALUE '',
       END OF c_state.
 
     CONSTANTS c_native_dynpro TYPE c LENGTH 2 VALUE 'IN'.
@@ -164,6 +165,7 @@ CLASS zcl_abapgit_objects_program DEFINITION
         !is_progdir TYPE zif_abapgit_sap_report=>ty_progdir
         !it_source  TYPE abaptxt255_tab
         !iv_title   TYPE repti
+        !iv_state   TYPE progdir-state DEFAULT c_state-inactive
       RAISING
         zcx_abapgit_exception .
     METHODS is_exit_include
@@ -357,7 +359,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 
       " todo: kept for compatibility, remove after grace period #3680
       ls_dynpro-flow_logic = uncondense_flow(
-        it_flow = ls_dynpro-flow_logic
+        it_flow   = ls_dynpro-flow_logic
         it_spaces = ls_dynpro-spaces ).
 
       IF ls_dynpro-flow_logic IS INITIAL.
@@ -493,7 +495,8 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
       update_program(
         is_progdir = is_progdir
         it_source  = it_source
-        iv_title   = lv_title ).
+        iv_title   = lv_title
+        iv_state   = c_state-off ).
     ELSE.
       insert_program(
         is_progdir = is_progdir
@@ -1132,7 +1135,7 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
       EXPORTING
         include_name     = is_progdir-name
         title_string     = iv_title
-        save_inactive    = c_state-inactive
+        save_inactive    = iv_state
       TABLES
         source_extended  = it_source
       EXCEPTIONS


### PR DESCRIPTION
Error "LXZAGF00 may not have an inactive version" when importing exit function groups (`FUGS`). 

Regression #7704

Test: https://github.com/abapGit-tests/FUGS