### PR TITLE
SUSH: fix error when using transportable package

### DIFF
--- a/src/objects/zcl_abapgit_object_sush.clas.abap
+++ b/src/objects/zcl_abapgit_object_sush.clas.abap
@@ -175,9 +175,9 @@ CLASS zcl_abapgit_object_sush IMPLEMENTATION.
                 ls_usobhash-object   = 'TRAN'.
                 ls_usobhash-obj_name = <lv_display_name>.
               WHEN 'RF'.
+                " No object name for function groups since hash is for function module
                 ls_usobhash-pgmid    = 'R3TR'.
                 ls_usobhash-object   = 'FUGR'.
-                ls_usobhash-obj_name = <lv_display_name>.
               WHEN 'HT'.
                 IF <lv_display_name> CP 'R3TR*'.
                   SPLIT <lv_display_name> AT space INTO ls_usobhash-pgmid ls_usobhash-object ls_usobhash-obj_name.
@@ -198,6 +198,7 @@ CLASS zcl_abapgit_object_sush IMPLEMENTATION.
             CALL METHOD lo_su22->('IF_SU22_ADT_OBJECT~CREATE')
               EXPORTING
                 iv_new_key = ls_usobhash
+                iv_task    = iv_transport
               RECEIVING
                 rs_key     = ls_key.
           ENDIF.


### PR DESCRIPTION
Error: "You cannot use request <space>" when trying to import SUSH object to transportable package

Fixed by passing transport request

Test: https://github.com/abapGit-tests/FUGR_rfc_with_scope with Z-package

