### PR TITLE
FUGR: Restore longtext master language on deserialize

### DIFF
--- a/src/objects/texts/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_longtexts.clas.abap
@@ -218,7 +218,7 @@ CLASS zcl_abapgit_longtexts IMPLEMENTATION.
 
     LOOP AT lt_longtexts ASSIGNING <ls_longtext>.
 
-      lv_no_main_lang = boolc( iv_main_language <> <ls_longtext>-dokil-langu ).
+      lv_no_main_lang = boolc( <ls_longtext>-dokil-masterlang IS INITIAL ).
 
       CALL FUNCTION 'DOCU_UPDATE'
         EXPORTING


### PR DESCRIPTION
  Closes #7722.

  ### Change
  `src/objects/texts/zcl_abapgit_longtexts.clas.abap`, method
  `zif_abapgit_longtexts~deserialize`:

  ```abap
  " before
  lv_no_main_lang = boolc( iv_main_language <> <ls_longtext>-dokil-langu ).

  " after
  lv_no_main_lang = boolc( <ls_longtext>-dokil-masterlang IS INITIAL ).
  ```

  ### Why
  `no_masterlang` was recomputed from a heuristic (repo main language ≠ longtext
  language) instead of using the `dokil-masterlang` value that `ii_xml->read`
  already populated from the XML. The heuristic drops the master flag whenever
  the object's documentation master language differs from the repo's main
  language.
  See #7722 for full analysis, reproduction, and debug evidence.

  ### Test
  Pulled a function module whose longtext has `DOKIL-MASTERLANG = 'X'` in
  language D into a repo with main language E. Before: `MASTERLANG` blank on
  target, Diff stays dirty. After: `MASTERLANG` restored to `X`, Diff clean.