### PR TITLE
Page Stage: Fix add filtered and Commit

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -817,8 +817,9 @@ StageHelper.prototype.collectData = function() {
 StageHelper.prototype.markVisiblesAsAdded = function() {
   this.iterateStageTab(false, function(row) {
     // TODO refactor, unify updateRow logic
-    if (row.style.display === "" && row.className === "local") { // visible
-      this.updateRow(row, this.STATUS.add);
+    if (row.style.display === "") { // visible
+      // Local rows are added, remote rows ("to remove or non-code") are removed
+      this.updateRow(row, row.className === "local" ? this.STATUS.add : this.STATUS.remove);
     } else {
       this.updateRow(row, this.STATUS.reset);
     }


### PR DESCRIPTION
 Fix: "Add Filtered and Commit" now stages all filtered files, not just local ones

Problem

  On the Stage page, applying a filter (e.g. developer) showed an accurate count in the action link — "Add Filtered and Commit (13)" — but clicking it only staged the 2 local
  files. The 11 visible rows under "Files to remove or non-code" were silently dropped, so the number of staged files never matched the count shown.

E.g.

<img width="2292" height="1246" alt="image" src="https://github.com/user-attachments/assets/0b5b6033-ca62-45b1-9344-2e6b3c9fb744" />
<img width="1586" height="294" alt="image" src="https://github.com/user-attachments/assets/2207b6b2-0ffd-4e8d-b70f-765c4bbf633b" />

  Cause

  StageHelper.markVisiblesAsAdded only marked visible local rows as add and reset everything else, including the visible remote rows that should be staged for removal.

  Fix

  markVisiblesAsAdded now stages every visible row according to its type:
  - visible local rows → add
  - visible remote rows ("to remove or non-code") → remove
  - non-visible rows → reset

  This mirrors the existing per-row behavior (clicking remove on a single remote row produces the same R status), so the bulk action and the displayed counter are now
  consistent.

E.g.
<img width="1461" height="754" alt="image" src="https://github.com/user-attachments/assets/49875d65-f158-4a8f-87bf-b87eaaff8203" />
