### PR TITLE
COMMON.JS: Small fixes

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -19,8 +19,6 @@
 /* exported setKeyBindings */
 /* exported preparePatch */
 /* exported registerStagePatch */
-/* exported toggleRepoListDetail */
-/* exported onTagTypeChange */
 /* exported getIndocStyleSheet */
 /* exported addMarginBottom */
 /* exported enumerateJumpAllFiles */
@@ -559,15 +557,17 @@ StageHelper.prototype.onFilterMe = function() {
 
 // Hook global click listener on table, load/unload actions
 StageHelper.prototype.setHooks = function() {
-  window.onkeypress                  = this.onCtrlEnter.bind(this);
+  // Use addEventListener for window-level events so we don't clobber handlers
+  // registered by other components (direct window.on* assignment is last-wins)
+  window.addEventListener("keypress", this.onCtrlEnter.bind(this));
   this.dom.stageTab.onclick          = this.onTableClick.bind(this);
   this.dom.commitSelectedBtn.onclick = this.submit.bind(this);
   this.dom.commitFilteredBtn.onclick = this.submitVisible.bind(this);
   this.dom.patchBtn.onclick          = this.submitPatch.bind(this);
   this.dom.objectSearch.oninput      = this.onFilter.bind(this);
   this.dom.objectSearch.onkeypress   = this.onFilter.bind(this);
-  window.onbeforeunload              = this.onPageUnload.bind(this);
-  window.onload                      = this.onPageLoad.bind(this);
+  window.addEventListener("beforeunload", this.onPageUnload.bind(this));
+  window.addEventListener("load", this.onPageLoad.bind(this));
 
   var self = this;
   document.addEventListener("keypress", function(event) {
@@ -726,6 +726,7 @@ StageHelper.prototype.getStatusImpact = function(status) {
     || status.length !== 1
     || this.STATUS.isInvalid(status)) {
     alert("Unknown status");
+    return 0; // avoid NaN propagating into the counters
   } else {
     return (status !== this.STATUS.reset) ? 1: 0;
   }
@@ -1124,6 +1125,7 @@ DiffColumnSelection.prototype.mousedownEventListener = function(e) {
   var splitCodeLeftColumnIdx     = 2;
   var splitLineNumRightColumnIdx = 3;
   var splitCodeRightColumnIdx    = 5;
+  var range;
 
   if (e.button !== 0) return; // function is only valid for left button, not right button
 
@@ -1147,7 +1149,7 @@ DiffColumnSelection.prototype.mousedownEventListener = function(e) {
         // document.getSelection().removeAllRanges() may trigger error
         // so use this code which is equivalent but does not fail
         // (https://stackoverflow.com/questions/22914075/javascript-error-800a025e-using-range-selector)
-        var range = document.body.createTextRange();
+        range = document.body.createTextRange();
         range.collapse();
         range.select();
       } else {
@@ -1216,20 +1218,20 @@ DiffColumnSelection.prototype.getSelectedText = function() {
     var realThis = this;
     var copySide = "";
     [].forEach.call(nodes, function(tr, i) {
-      var cellIdx = (i == 0 ? 0 : realThis.selectedColumnIdx);
+      var cellIdx = (i === 0 ? 0 : realThis.selectedColumnIdx);
       if (tr.cells.length > cellIdx) {
         var tdSelected = tr.cells[cellIdx];
         // decide which side to copy based on first line of selection
-        if (i == 0) {
+        if (i === 0) {
           copySide = (tdSelected.classList.contains("new") ? "new" : "old" );
         }
         // copy is interesting only for one side of code, do not copy lines which exist on other side
-        if (i == 0 || copySide == "new" && !tdSelected.classList.contains("old") || copySide == "old" && !tdSelected.classList.contains("new")) {
+        if (i === 0 || copySide === "new" && !tdSelected.classList.contains("old") || copySide === "old" && !tdSelected.classList.contains("new")) {
           text += newline + tdSelected.textContent;
           // special processing for TD tag which sometimes contains newline
           // (expl: /src/ui/zabapgit_js_common.w3mi.data.js) so do not add newline again in that case.
           var lastChar = tdSelected.textContent[tdSelected.textContent.length - 1];
-          if (lastChar == "\n") newline = "";
+          if (lastChar === "\n") newline = "";
           else newline = "\n";
         }
       }

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2473,8 +2473,8 @@ function restoreScrollPosition() {
 function memorizeScrollPosition(fn) {
   return function() {
     saveScrollPosition();
-    return fn.call(this, fn.args);
-  }.bind(this);
+    return fn.apply(this, arguments);
+  };
 }
 
 /**********************************************************

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2534,7 +2534,7 @@ function displayBrowserControlFooter() {
 // Prevents keyboard navigation to elements outside the modal popup
 // eslint-disable-next-line no-unused-vars
 function trapFocus() {
-  const modal = document.getElementById("modal");
+  var modal = document.getElementById("modal");
   if (!modal) return;
 
   var focusableSelectors = "button, [href], input, select, textarea, [tabindex]";

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -98,10 +98,11 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 
 // Output text to the debug div
 function debugOutput(text, dstID) {
-  var stdout  = document.getElementById(dstID || "debug-output");
-  var wrapped = "<p>" + text + "</p>";
+  var stdout    = document.getElementById(dstID || "debug-output");
+  var paragraph = document.createElement("p");
 
-  stdout.innerHTML = stdout.innerHTML + wrapped;
+  paragraph.textContent = text;
+  stdout.appendChild(paragraph);
 }
 
 // Use a supplied form, a pre-created form or create a hidden form

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -557,8 +557,6 @@ StageHelper.prototype.onFilterMe = function() {
 
 // Hook global click listener on table, load/unload actions
 StageHelper.prototype.setHooks = function() {
-  // Use addEventListener for window-level events so we don't clobber handlers
-  // registered by other components (direct window.on* assignment is last-wins)
   window.addEventListener("keypress", this.onCtrlEnter.bind(this));
   this.dom.stageTab.onclick          = this.onTableClick.bind(this);
   this.dom.commitSelectedBtn.onclick = this.submit.bind(this);


### PR DESCRIPTION
1. Fix implicit global range in DiffColumnSelection.mousedownEventListener
2. Remove stale /* exported */ directives
3. Use strict equality in getSelectedText
4. change `const` to `var`
5. use `window.addEventListener` instead of overwrite
6. Fix memorizeScrollPosition
7. improve debugOuput