### PR TITLE
LONGTEXTS: Clear DOKIL-DOKSTATE on serialize (#7729)

### DIFF
--- a/src/objects/texts/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_longtexts.clas.abap
@@ -218,7 +218,7 @@ CLASS zcl_abapgit_longtexts IMPLEMENTATION.
 
     LOOP AT lt_longtexts ASSIGNING <ls_longtext>.
 
-      lv_no_main_lang = boolc( iv_main_language <> <ls_longtext>-dokil-langu ).
+      lv_no_main_lang = boolc( <ls_longtext>-dokil-masterlang IS INITIAL ).
 
       CALL FUNCTION 'DOCU_UPDATE'
         EXPORTING

--- a/src/objects/texts/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/texts/zcl_abapgit_longtexts.clas.abap
@@ -121,7 +121,8 @@ CLASS zcl_abapgit_longtexts IMPLEMENTATION.
           line    = ls_longtext-lines.
 
       IF iv_clear_fields = abap_true.
-        CLEAR: ls_longtext-head-tdfuser,
+        CLEAR: ls_longtext-dokil-dokstate,
+               ls_longtext-head-tdfuser,
                ls_longtext-head-tdfreles,
                ls_longtext-head-tdfdate,
                ls_longtext-head-tdftime,


### PR DESCRIPTION
Closes #7729.

### Change
`src/objects/texts/zcl_abapgit_longtexts.clas.abap`, method `read`. Add `dokil-dokstate` to the existing `iv_clear_fields` block:
```abap
IF iv_clear_fields = abap_true.
  CLEAR: ls_longtext-dokil-dokstate,    " added
         ls_longtext-head-tdfuser,
         ...
ENDIF.
```

### Why
`DOKIL-DOKSTATE` is a runtime field that abapGit intentionally does not round-trip — see #2605, which already stripped it for MSAG. The same clearing was missing in the shared longtexts class, so it leaked into XML for FUGR, PROG, and other consumers. The deserializer in this class already ignores the field (hardcoded `state = c_docu_state_active`), so XML carrying a value can never be honored — producing a permanent Diff between repo and target.

See #7729 for full analysis and reproduction.

### Test
Pushed a function group whose function-module longtext had `DOKIL-DOKSTATE = 'R'`. Before: XML carried `<DOKSTATE>R</DOKSTATE>`, target system had `DOKSTATE = 'A'` after pull, Diff stayed dirty. After: XML no longer contains `<DOKSTATE>`, Diff is clean on the target.