### PR TITLE
INTF: Fix attribute, methods, events docu deserialization

### DIFF
--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -184,23 +184,22 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
         iv_id          = c_longtext_id-interface
         iv_object_name = lv_object
         iv_language    = mv_language ).
-      RETURN.
-    ENDIF.
-
-    mi_object_oriented_object_fct->create_documentation(
-      it_lines       = is_docu-lines
-      iv_id          = c_longtext_id-interface
-      iv_object_name = lv_object
-      iv_language    = mv_language ).
-
-    LOOP AT is_docu-i18n_lines INTO ls_i18n_lines.
+    ELSE.
       mi_object_oriented_object_fct->create_documentation(
-        it_lines         = ls_i18n_lines-lines
-        iv_id            = c_longtext_id-interface
-        iv_object_name   = lv_object
-        iv_language      = ls_i18n_lines-language
-        iv_no_masterlang = abap_true ).
-    ENDLOOP.
+        it_lines       = is_docu-lines
+        iv_id          = c_longtext_id-interface
+        iv_object_name = lv_object
+        iv_language    = mv_language ).
+
+      LOOP AT is_docu-i18n_lines INTO ls_i18n_lines.
+        mi_object_oriented_object_fct->create_documentation(
+          it_lines         = ls_i18n_lines-lines
+          iv_id            = c_longtext_id-interface
+          iv_object_name   = lv_object
+          iv_language      = ls_i18n_lines-language
+          iv_no_masterlang = abap_true ).
+      ENDLOOP.
+    ENDIF.
 
     deserialize_longtexts(
       ii_xml           = ii_xml


### PR DESCRIPTION
Closes #7731.
Method `zcl_abapgit_object_intf->deserialize_docu( )` returned early when the interface had no own documentation, skipping `deserialize_longtexts` for attributes, methods and events. 

Replaced early RETURN with IF/ELSE so that IA/IO/IE longtexts are still deserialized when the interface itself has no description, matching the existing CLAS pattern.