### PR TITLE
Stage page: morph Patch button into "Patch Selected/Filtered (n)" like the commit button

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -791,6 +791,13 @@ StageHelper.prototype.updateMenu = function() {
   this.dom.commitAllBtn.style.display      = display === "default" ? "" : "none";
   this.dom.commitSelectedBtn.style.display = display === "selected" ? "" : "none";
   this.dom.commitFilteredBtn.style.display = display === "filtered" ? "" : "none";
+
+  var patchLabels = {
+    "default" : "Patch",
+    "selected": "Patch <b>Selected</b> (" + this.selectedCount + ")",
+    "filtered": "Patch <b>Filtered</b> (" + this.filteredCount + ")"
+  };
+  this.dom.patchBtn.innerHTML = patchLabels[display];
 };
 
 // Submit stage state to the server
@@ -804,6 +811,9 @@ StageHelper.prototype.submitVisible = function() {
 };
 
 StageHelper.prototype.submitPatch = function() {
+  if (this.calculateActiveCommitCommand() === "filtered") {
+    this.markVisiblesAsAdded();
+  }
   submitSapeventForm(this.collectData(), this.patchAction);
 };
 


### PR DESCRIPTION
The commit action on the stage page already adapts to the current context — "Add All and Commit", "Commit Selected (n)", or "Add Filtered and Commit (n)". The Patch button in the toolbar stayed a static "Patch" regardless. This change makes Patch behave the same way. Note that the sematic of the change buttons changed if something is filtered. Previously it was ignored, now it's considered.

| Context | Button label | Action on click / hotkey `p` |
|---|---|---|
| Rows manually selected | Patch **Selected** (n) | Patch the selected rows (unchanged) |
| Filter active, nothing selected | Patch **Filtered** (n) | Mark visible rows as added/removed, then patch them — same semantics as "Add Filtered and Commit" |
| Default | Patch | Unchanged |

<img width="2364" height="460" alt="image" src="https://github.com/user-attachments/assets/c86a1678-51d9-4917-9331-239c967b6749" />
<img width="2292" height="550" alt="image" src="https://github.com/user-attachments/assets/3a52b37f-0f4e-46a5-b086-44ce48836d7f" />
