### PR TITLE
Fix staging error when link hints are combined with the stage filter.

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -607,7 +607,7 @@ StageHelper.prototype.onPageLoad = function() {
   var data = window.sessionStorage && JSON.parse(window.sessionStorage.getItem(this.pageSeed));
 
   this.iterateStageTab(true, function(row) {
-    var status = data && data[row.cells[this.colIndex["name"]].innerText];
+    var status = data && data[this.getPlainText(row.cells[this.colIndex["name"]])];
     this.updateRow(row, status || this.STATUS.reset);
   });
 
@@ -680,6 +680,19 @@ StageHelper.prototype.applyFilterValue = function(sFilterValue) {
   this.updateMenu();
 };
 
+// Get plain text of a cell, ignoring injected link-hint spans.
+// innerText is not reliable for this: while the stage table is hidden
+// (iterateStageTab change mode), it includes display:none descendants,
+// so the link-hint codes would leak into the file names
+StageHelper.prototype.getPlainText = function(elem) {
+  var clone = elem.cloneNode(true);
+  var hints = clone.querySelectorAll("span.link-hint");
+  for (var i = hints.length - 1; i >= 0; i--) {
+    hints[i].parentNode.removeChild(hints[i]);
+  }
+  return clone.textContent;
+};
+
 // Apply filter to a single stage line - hide or show
 StageHelper.prototype.applyFilterToRow = function(row, filter) {
   // Collect data cells
@@ -693,7 +706,7 @@ StageHelper.prototype.applyFilterToRow = function(row, filter) {
     if (elemA) elem = elemA;
     return {
       elem     : elem,
-      plainText: elem.innerText.replace(/ /g, "\u00a0"), // without tags, with encoded spaces
+      plainText: this.getPlainText(elem).replace(/ /g, "\u00a0"), // without tags, with encoded spaces
       curHtml  : elem.innerHTML
     };
   }, this);
@@ -811,7 +824,7 @@ StageHelper.prototype.submitPatch = function() {
 StageHelper.prototype.collectData = function() {
   var data = {};
   this.iterateStageTab(false, function(row) {
-    data[row.cells[this.colIndex["name"]].innerText] = row.cells[this.colIndex["status"]].innerText;
+    data[this.getPlainText(row.cells[this.colIndex["name"]])] = row.cells[this.colIndex["status"]].innerText;
   });
   return data;
 };


### PR DESCRIPTION
Staging or patching after typing a filter on the Stage page fails with:
`Unable to stage ZCL_ABAPGIT_GUI_PAGE_STAGE.CLAS.ABAP30. If the filename contains spaces, this is a known issue. Consider ignoring or staging the file at a later time.`

How to reproduce (before this fix)
1. Enable link hints (set a link hint key in the settings)
2. Open the Stage page of a repo with changes
3. Activate Link Hints
4. Type something into the filter box and press Enter
5. Commit or Patch (toolbar or command palette) => error 


<img width="2348" height="1617" alt="image" src="https://github.com/user-attachments/assets/017f8e68-ffc7-49e5-9b82-166588fbe7b8" />

Note the trailing 30 — it is the link hint code of the file's anchor leaking into the filename that gets posted to the backend.