### PR TITLE
Stage page: add hotkey and command palette entry for "Changed by (me)" filter

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -760,6 +760,11 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ls_hotkey_action-hotkey = |f|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
+    ls_hotkey_action-description = |Filter changed by me|.
+    ls_hotkey_action-action      = 'onFilterMe'. " JS function in StageHelper
+    ls_hotkey_action-hotkey      = |m|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
   ENDMETHOD.
 
 

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -547,8 +547,10 @@ StageHelper.prototype.injectFilterMe = function() {
 
   var a = document.createElement("A");
   a.appendChild(document.createTextNode("me"));
-  a.onclick = this.onFilterMe.bind(this);
-  a.href    = "#";
+  a.onclick   = this.onFilterMe.bind(this);
+  a.href      = "#";
+  a.title     = "Filter changed by ";
+  a.className = "command"; // expose to command palette (enumerateUiActions)
   changedByHead.appendChild(a);
   changedByHead.appendChild(document.createTextNode(")"));
 };


### PR DESCRIPTION
The staging page already offers a "Changed by (me)" link in the table header to toggle filtering by the current user, but it was only reachable by mouse. This PR makes it keyboard-accessible:

New hotkey m ("Filter changed by me") registered in ZCL_ABAPGIT_GUI_PAGE_STAGE->ZIF_ABAPGIT_GUI_HOTKEYS~GET_HOTKEY_ACTIONS. It dispatches to the existing onFilterMe function in StageHelper (same mechanism as the p/submitPatch hotkey) and automatically appears in the hotkey help (?). The injected "(me)" link now gets a title and the command CSS class in StageHelper.injectFilterMe, so enumerateUiActions() picks it up and it appears in the command palette (F1) as "Filter changed by me". The class is only a marker for the palette enumerator; the link's appearance is unchanged.

No behavior change for the filter itself — pressing m toggles it on/off exactly like clicking the  link.