### PR TITLE
Fix "Activate Objects" for classes and interfaces

### DIFF
--- a/src/objects/core/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/core/zcl_abapgit_objects_activation.clas.abap
@@ -6,9 +6,10 @@ CLASS zcl_abapgit_objects_activation DEFINITION
 
     CLASS-METHODS add
       IMPORTING
-        !iv_type   TYPE trobjtype
-        !iv_name   TYPE clike
-        !iv_delete TYPE abap_bool DEFAULT abap_false
+        !iv_type       TYPE trobjtype
+        !iv_name       TYPE clike
+        !iv_delete     TYPE abap_bool DEFAULT abap_false
+        !iv_force_clif TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS add_item
@@ -356,7 +357,7 @@ CLASS zcl_abapgit_objects_activation IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_object>  TYPE dwinactiv,
                    <ls_classes> LIKE LINE OF gt_classes.
 
-    IF iv_type = 'CLAS' OR iv_type = 'INTF'.
+    IF ( iv_type = 'CLAS' OR iv_type = 'INTF' ) AND iv_force_clif = abap_false.
       APPEND INITIAL LINE TO gt_classes ASSIGNING <ls_classes>.
       <ls_classes>-object  = iv_type.
       <ls_classes>-clsname = iv_name.

--- a/src/ui/routing/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/routing/zcl_abapgit_services_repo.clas.abap
@@ -165,8 +165,9 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
     LOOP AT lt_repo_items ASSIGNING <ls_item> WHERE inactive = abap_true.
       zcl_abapgit_objects_activation=>add(
-        iv_type = <ls_item>-obj_type
-        iv_name = <ls_item>-obj_name ).
+        iv_type       = <ls_item>-obj_type
+        iv_name       = <ls_item>-obj_name
+        iv_force_clif = abap_true ).
       lv_count = lv_count + 1.
     ENDLOOP.
 


### PR DESCRIPTION
Fixes `Advanced > Activate Objects` for classes and interfaces which were previously ignored.