### PR TITLE
Link hints: redeploy on activation instead of once

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1409,7 +1409,7 @@ function LinkHints(linkHintHotKey) {
   this.linkHintHotKey    = linkHintHotKey;
   this.areHintsDisplayed = false;
   this.pendingPath       = ""; // already typed code prefix
-  this.hintsMap          = this.deployHintContainers();
+  this.hintsMap          = null; // deployed on each activation, the DOM changes after load
   this.activatedDropdown = null;
   this.yankModeActive    = false;
 }
@@ -1489,6 +1489,15 @@ LinkHints.prototype.deployHintContainers = function() {
   return hintsMap;
 };
 
+LinkHints.prototype.removeHintContainers = function() {
+  if (!this.hintsMap) return;
+  for (var i = this.hintsMap.first; i <= this.hintsMap.last; i++) {
+    var container = this.hintsMap[i].container;
+    if (container.parentNode) container.parentNode.removeChild(container);
+  }
+  this.hintsMap = null;
+};
+
 LinkHints.prototype.getHandler = function() {
   return this.handleKey.bind(this);
 };
@@ -1509,6 +1518,12 @@ LinkHints.prototype.handleKey = function(event) {
     if (this.areHintsDisplayed) this.yankModeActive = false;
 
     this.pendingPath = "";
+    if (!this.areHintsDisplayed) {
+      // redeploy on each activation to catch links created or rewritten
+      // after page load (e.g. stage table commands, filtered file names)
+      this.removeHintContainers();
+      this.hintsMap = this.deployHintContainers();
+    }
     this.displayHints(!this.areHintsDisplayed);
 
   } else if (this.areHintsDisplayed) {


### PR DESCRIPTION
Before
<img width="2343" height="1216" alt="image" src="https://github.com/user-attachments/assets/188ccec9-08b4-4b9e-bf3a-cf9e216fac8e" />

After
<img width="2408" height="1197" alt="image" src="https://github.com/user-attachments/assets/09354d1b-e3c4-49e3-9c6c-f569a4374230" />

<details>
<summary>Summary</summary>

Link hints were generated a single time, when the page scripts initialized. Any link created or rewritten after that point never got a hint, so on dynamic pages — most visibly the stage page — large parts of the UI were unreachable via link hints.

Two concrete failure modes on the stage page:

Late-created links never get hints. The per-row add / ignore / remove / reset commands are rendered by StageHelper at window load (updateRowCommand, initial run) — after LinkHints had already scanned the DOM. The whole command column therefore never had hints.
Existing hints get destroyed. Hint badges are injected as <span>s inside the target anchors, and the stage page rewrites those cells via innerHTML on every status click and every filter highlight — silently wiping the hints. The result was gaps in the hint numbering and links that visibly lost their hints during normal use.

</details>


<details>
<summary>Change</summary>

LinkHints no longer deploys hint containers in the constructor. Instead, each time the hint hotkey is pressed to show hints, it:

removes any hint containers still attached from the previous activation (removeHintContainers), and
runs deployHintContainers() against the current DOM.
Hiding hints, prefix filtering, yank mode, and dropdown handling are unchanged — they operate on the freshly built map exactly as they did on the static one.


</details>

<details>
<summary>Behavior notes</summary>

Hints now appear on all links present at the moment of activation, on every page (e.g. stage table commands, links revealed after filtering or toggling sections on the diff page).
Hint codes are renumbered on each activation — consistent with Vimium-style hinting, where codes are ephemeral by design.
Cost is one DOM scan per activation (on demand only); no work is done on pages where hints are never invoked, which previously paid the deployment cost unconditionally at load.

</details>