### PR TITLE
Stage page: unify Commit and Patch in the toolbar

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -788,11 +788,11 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
         iv_txt = ``
         iv_typ = zif_abapgit_html=>c_action_type-separator
       )->add(
-        iv_txt = 'Refresh'
-        iv_act = |{ c_action-stage_refresh }|
-      )->add(
         iv_txt = |Diff|
         iv_act = |{ zif_abapgit_definitions=>c_action-go_repo_diff }?key={ mi_repo->get_key( ) }|
+      )->add(
+        iv_txt = 'Refresh'
+        iv_act = |{ c_action-stage_refresh }|
       )->add(
         iv_txt = |Back|
         iv_act = zif_abapgit_definitions=>c_action-go_back ).

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -322,6 +322,13 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     DELETE lt_files WHERE method <> zif_abapgit_definitions=>c_method-add
                       AND method <> zif_abapgit_definitions=>c_method-rm.
 
+    IF lt_files IS INITIAL.
+      " No selection: patch the same file set as the default commit (stage_all)
+      lt_files = stage_all( )->get_all( ).
+      DELETE lt_files WHERE method <> zif_abapgit_definitions=>c_method-add
+                        AND method <> zif_abapgit_definitions=>c_method-rm.
+    ENDIF.
+
     ri_page  = zcl_abapgit_gui_page_patch=>create(
       iv_key        = lv_key
       it_files      = lt_files
@@ -343,37 +350,12 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
   METHOD render_actions.
 
-    DATA: lv_local_count TYPE i,
-          lv_add_all_txt TYPE string.
-
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-    lv_local_count = count_default_files_to_commit( ).
-    IF lv_local_count > 0.
-      lv_add_all_txt = |Add All and Commit ({ lv_local_count })|.
-      " Otherwise empty, but the element (id) is preserved for JS
-    ENDIF.
+
+    " Commit and Patch actions live in the page toolbar (commitBtn / patchBtn,
+    " labels managed by StageHelper.updateMenu)
 
     ri_html->add( '<table class="w100 margin-v5"><tr>' ).
-
-    " Action buttons
-    ri_html->add( '<td class="indent5em">' ).
-    ri_html->add_a( iv_act   = 'errorStub(event)' " Will be reinit by JS
-                    iv_typ   = zif_abapgit_html=>c_action_type-onclick
-                    iv_id    = 'commitSelectedButton'
-                    iv_style = 'display: none'
-                    iv_txt   = 'Commit Selected (<span class="counter"></span>)'
-                    iv_opt   = zif_abapgit_html=>c_html_opt-strong ).
-    ri_html->add_a( iv_act   = 'errorStub(event)' " Will be reinit by JS
-                    iv_typ   = zif_abapgit_html=>c_action_type-onclick
-                    iv_id    = 'commitFilteredButton'
-                    iv_style = 'display: none'
-                    iv_txt   = 'Add <b>Filtered</b> and Commit (<span class="counter"></span>)' ).
-    ri_html->add_a( iv_act = |{ c_action-stage_all }|
-                    iv_id  = 'commitAllButton'
-                    iv_txt = lv_add_all_txt ).
-
-
-    ri_html->add( '</td>' ).
 
     " Filter bar
     ri_html->add( '<td class="right">' ).
@@ -612,13 +594,12 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     ri_html->add( |  user:            "{ to_lower( sy-uname ) }",| ).
     ri_html->add( |  formAction:      "{ c_action-stage_commit }",| ).
     ri_html->add( |  patchAction:     "{ zif_abapgit_definitions=>c_action-go_patch }",| ).
+    ri_html->add( |  stageAllAction:  "{ c_action-stage_all }",| ).
     ri_html->add( '  focusFilterKey:  "f",' ).
 
     ri_html->add( '  ids: {' ).
     ri_html->add( '    stageTab:          "stageTab",' ).
-    ri_html->add( '    commitAllBtn:      "commitAllButton",' ).
-    ri_html->add( '    commitSelectedBtn: "commitSelectedButton",' ).
-    ri_html->add( '    commitFilteredBtn: "commitFilteredButton",' ).
+    ri_html->add( '    commitBtn:         "commitBtn",' ).
     ri_html->add( '    patchBtn:          "patchBtn",' ).
     ri_html->add( '    objectSearch:      "objectSearch",' ).
     ri_html->add( '  }' ).
@@ -739,6 +720,11 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
     DATA ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
 
     ls_hotkey_action-ui_component = 'Stage'.
+    ls_hotkey_action-description  = |Commit|.
+    ls_hotkey_action-action       = 'submitCommit'. " JS function in StageHelper
+    ls_hotkey_action-hotkey       = |c|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
     ls_hotkey_action-description  = |Patch|.
     ls_hotkey_action-action       = 'submitPatch'. " JS function in StageHelper
     ls_hotkey_action-hotkey       = |p|.
@@ -770,20 +756,43 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_menu_provider~get_menu.
 
+    DATA: lv_local_count    TYPE i,
+          lv_commit_all_txt TYPE string,
+          lv_patch_all_txt  TYPE string.
+
     ro_toolbar = zcl_abapgit_html_toolbar=>create( 'toolbar-staging' ).
 
     IF lines( ms_files-local ) > 0 OR lines( ms_files-remote ) > 0.
+      lv_local_count = count_default_files_to_commit( ).
+      lv_patch_all_txt = |Patch|.
+      IF lv_local_count > 0.
+        lv_commit_all_txt = |Add All and Commit ({ lv_local_count })|.
+        lv_patch_all_txt  = |Patch All ({ lv_local_count })|.
+        " Otherwise commit is empty, but the element (id) is preserved for JS
+      ENDIF.
+
       ro_toolbar->add(
+        iv_txt = lv_commit_all_txt
+        iv_typ = zif_abapgit_html=>c_action_type-onclick
+        iv_id  = |commitBtn|
+        iv_opt = zif_abapgit_html=>c_html_opt-strong
+      )->add(
+        iv_txt = ``
+        iv_typ = zif_abapgit_html=>c_action_type-separator
+      )->add(
+        iv_txt = lv_patch_all_txt
+        iv_typ = zif_abapgit_html=>c_action_type-onclick
+        iv_id  = |patchBtn|
+        iv_opt = zif_abapgit_html=>c_html_opt-strong
+      )->add(
+        iv_txt = ``
+        iv_typ = zif_abapgit_html=>c_action_type-separator
+      )->add(
         iv_txt = 'Refresh'
         iv_act = |{ c_action-stage_refresh }|
-        iv_opt = zif_abapgit_html=>c_html_opt-strong
       )->add(
         iv_txt = |Diff|
         iv_act = |{ zif_abapgit_definitions=>c_action-go_repo_diff }?key={ mi_repo->get_key( ) }|
-      )->add(
-        iv_txt = |Patch|
-        iv_typ = zif_abapgit_html=>c_action_type-onclick
-        iv_id  = |patchBtn|
       )->add(
         iv_txt = |Back|
         iv_act = zif_abapgit_definitions=>c_action-go_back ).

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -773,6 +773,16 @@ div.tutorial h2 { font-size: 14pt;}
 }
 .nav-container ul ul li.separator:first-child { border-top: none; }
 
+/* Top-level toolbar separator - vertical divider between item groups */
+.nav-container > ul > li.separator {
+  width: 0;
+  height: 18px;
+  padding: 0;
+  margin: 6px 0.6em;
+  border-left: 1px solid;
+  opacity: 0.25;
+}
+
 /* NEWS ANNOUNCEMENT */
 
 div.info-panel {

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -486,6 +486,7 @@ function StageHelper(params) {
   this.pageSeed        = params.seed;
   this.formAction      = params.formAction;
   this.patchAction     = params.patchAction;
+  this.stageAllAction  = params.stageAllAction;
   this.user            = params.user;
   this.ids             = params.ids;
   this.selectedCount   = 0;
@@ -495,16 +496,16 @@ function StageHelper(params) {
 
   // DOM nodes
   this.dom = {
-    stageTab         : document.getElementById(params.ids.stageTab),
-    commitAllBtn     : document.getElementById(params.ids.commitAllBtn),
-    commitSelectedBtn: document.getElementById(params.ids.commitSelectedBtn),
-    commitFilteredBtn: document.getElementById(params.ids.commitFilteredBtn),
-    patchBtn         : document.getElementById(params.ids.patchBtn),
-    objectSearch     : document.getElementById(params.ids.objectSearch),
-    selectedCounter  : null,
-    filteredCounter  : null,
+    stageTab    : document.getElementById(params.ids.stageTab),
+    commitBtn   : document.getElementById(params.ids.commitBtn),
+    patchBtn    : document.getElementById(params.ids.patchBtn),
+    objectSearch: document.getElementById(params.ids.objectSearch),
   };
-  this.findCounters();
+
+  // Server-rendered "Add All and Commit (n)" / "Patch All (n)" labels
+  // (commit label is empty if nothing to commit by default)
+  this.commitAllLabel = this.dom.commitBtn.innerHTML;
+  this.patchAllLabel  = this.dom.patchBtn.innerHTML;
 
   // Table columns (autodetection)
   this.colIndex      = this.detectColumns();
@@ -530,11 +531,6 @@ function StageHelper(params) {
   if (this.user) this.injectFilterMe();
   Hotkeys.addHotkeyToHelpSheet("^Enter", "Commit");
 }
-
-StageHelper.prototype.findCounters = function() {
-  this.dom.selectedCounter = this.dom.commitSelectedBtn.querySelector("span.counter");
-  this.dom.filteredCounter = this.dom.commitFilteredBtn.querySelector("span.counter");
-};
 
 StageHelper.prototype.injectFilterMe = function() {
   var tabFirstHead = this.dom.stageTab.tHead.rows[0];
@@ -563,12 +559,11 @@ StageHelper.prototype.onFilterMe = function() {
 // Hook global click listener on table, load/unload actions
 StageHelper.prototype.setHooks = function() {
   window.addEventListener("keypress", this.onCtrlEnter.bind(this));
-  this.dom.stageTab.onclick          = this.onTableClick.bind(this);
-  this.dom.commitSelectedBtn.onclick = this.submit.bind(this);
-  this.dom.commitFilteredBtn.onclick = this.submitVisible.bind(this);
-  this.dom.patchBtn.onclick          = this.submitPatch.bind(this);
-  this.dom.objectSearch.oninput      = this.onFilter.bind(this);
-  this.dom.objectSearch.onkeypress   = this.onFilter.bind(this);
+  this.dom.stageTab.onclick        = this.onTableClick.bind(this);
+  this.dom.commitBtn.onclick       = this.submitCommit.bind(this);
+  this.dom.patchBtn.onclick        = this.submitPatch.bind(this);
+  this.dom.objectSearch.oninput    = this.onFilter.bind(this);
+  this.dom.objectSearch.onkeypress = this.onFilter.bind(this);
   window.addEventListener("beforeunload", this.onPageUnload.bind(this));
   window.addEventListener("load", this.onPageLoad.bind(this));
 
@@ -656,12 +651,7 @@ StageHelper.prototype.onTableClick = function(event) {
 
 StageHelper.prototype.onCtrlEnter = function(e) {
   if (e.ctrlKey && (e.which === 10 || e.key === "Enter")) {
-    var clickMap = {
-      "default" : this.dom.commitAllBtn,
-      "selected": this.dom.commitSelectedBtn,
-      "filtered": this.dom.commitFilteredBtn
-    };
-    clickMap[this.calculateActiveCommitCommand()].click();
+    this.submitCommit();
   }
 };
 
@@ -796,19 +786,19 @@ StageHelper.prototype.calculateActiveCommitCommand = function() {
   return active;
 };
 
-// Update menu items visibility
+// Update commit/patch toolbar button labels according to the active command
 StageHelper.prototype.updateMenu = function() {
   var display = this.calculateActiveCommitCommand();
 
-  if (display === "selected") this.dom.selectedCounter.innerText = this.selectedCount.toString();
-  if (display === "filtered") this.dom.filteredCounter.innerText = this.filteredCount.toString();
-
-  this.dom.commitAllBtn.style.display      = display === "default" ? "" : "none";
-  this.dom.commitSelectedBtn.style.display = display === "selected" ? "" : "none";
-  this.dom.commitFilteredBtn.style.display = display === "filtered" ? "" : "none";
+  var commitLabels = {
+    "default" : this.commitAllLabel,
+    "selected": "Commit <b>Selected</b> (" + this.selectedCount + ")",
+    "filtered": "Add <b>Filtered</b> and Commit (" + this.filteredCount + ")"
+  };
+  this.dom.commitBtn.innerHTML = commitLabels[display];
 
   var patchLabels = {
-    "default" : "Patch",
+    "default" : this.patchAllLabel,
     "selected": "Patch <b>Selected</b> (" + this.selectedCount + ")",
     "filtered": "Patch <b>Filtered</b> (" + this.filteredCount + ")"
   };
@@ -823,6 +813,15 @@ StageHelper.prototype.submit = function() {
 StageHelper.prototype.submitVisible = function() {
   this.markVisiblesAsAdded();
   submitSapeventForm(this.collectData(), this.formAction);
+};
+
+// Submit the active commit command (commit button in the page toolbar)
+StageHelper.prototype.submitCommit = function() {
+  switch (this.calculateActiveCommitCommand()) {
+  case "selected": this.submit(); break;
+  case "filtered": this.submitVisible(); break;
+  default: submitSapeventForm({}, this.stageAllAction);
+  }
 };
 
 StageHelper.prototype.submitPatch = function() {
@@ -2304,6 +2303,9 @@ CommandPalette.prototype.toggleDisplay = function(forceState) {
 
   this.elements.palette.style.display = tobeDisplayed ? "" : "none";
   if (tobeDisplayed) {
+    this.commands.forEach(function(cmd) {
+      if (cmd.getTitle) cmd.title = cmd.getTitle();
+    });
     this.elements.input.value = "";
     this.elements.input.focus();
     this.applyFilter();
@@ -2400,9 +2402,15 @@ function enumerateUiActions() {
       action = anchor.href.replace("sapevent:", "");
     }
     var prefix = item[1];
+    // title is re-read on each palette open, some labels change dynamically
+    // (e.g. commit/patch buttons on the stage page)
+    var getTitle = function() {
+      return (prefix ? prefix + ": " : "") + anchor.innerText.trim();
+    };
     return {
-      action: action,
-      title : (prefix ? prefix + ": " : "") + anchor.innerText.trim()
+      action  : action,
+      getTitle: getTitle,
+      title   : getTitle()
     };
   });
 


### PR DESCRIPTION
<details>
<summary>Summary</summary>

The stage page previously offered Commit via three separate buttons below the
file list (`Commit All`, `Commit Selected`, `Commit Filtered`) while Patch
lived in the top toolbar — even though both act on the same staging selection.
This PR moves Commit up next to Patch and makes the two behave symmetrically.

**Toolbar before:** `Refresh | Diff | Patch | Back` + separate commit button row
**Toolbar after:** `Add All and Commit (n) | Patch All (n) ‖ Diff | Refresh | Back`


</details>

<details>
<summary>Changes</summary>

**Single dynamic Commit button.** The three commit anchors are replaced by one
toolbar button (`commitBtn`) whose label and action follow the current mode,
same as Patch already did:

| Mode | Commit | Patch |
|---|---|---|
| nothing selected | Add All and Commit (n) | Patch All (n) |
| files selected | Commit **Selected** (n) | Patch **Selected** (n) |
| filter active | Add **Filtered** and Commit (n) | Patch **Filtered** (n) |

**Patch default now matches Commit default.** Previously, Patch with no
selection opened the patch page for the *entire* repo diff — including
remote-only files that "Add All and Commit" would never touch — so the two
buttons silently operated on different file sets (e.g. 6 vs. 14). With no
selection, `get_page_patch` now falls back to the `stage_all` file set (all
local changes plus purely local deletions), and the button label shows that
count. When there is nothing to add or remove (n = 0), the label stays "Patch"
and the previous full-diff behavior is preserved.

**Visual grouping.** Toolbar separator items now also render at the top level
(previously only styled inside dropdowns) as a thin vertical divider, setting
the Commit/Patch pair apart from navigation actions.

**Command palette stays in sync.** Palette entries built from toolbar anchors
snapshotted their labels at page load and went stale once the buttons were
rewritten. Entries now re-read the anchor text each time the palette opens.

**Hotkeys:** new `c` → Commit, mirroring the existing `p` → Patch. Ctrl+Enter
continues to trigger Commit.


</details>

<details>
<summary>Implementation notes</summary>

- `ZCL_ABAPGIT_GUI_PAGE_STAGE`: `render_actions` reduced to the filter row;
  toolbar built in `get_menu` (separator items, server-rendered default labels
  with count from `count_default_files_to_commit`); `get_page_patch` falls
  back to `stage_all` when the selection yields no add/rm files;
  `render_scripts` passes `commitBtn` id and `stageAllAction`.
- `common.js` (`StageHelper`): new `submitCommit()` dispatches per mode
  (selected → `submit()`, filtered → `submitVisible()`, default → `stage_all`
  sapevent); `updateMenu` rewrites both button labels; default labels are
  captured from the server-rendered buttons at init. `CommandPalette` toolbar
  entries carry a `getTitle` closure refreshed in `toggleDisplay`.
- `common.css`: new top-level `.nav-container > ul > li.separator` rule
  (1px vertical divider, inherits text color, theme-safe).

</details>

<details>
<summary>Screenshots</summary>

All
<img width="2387" height="526" alt="image" src="https://github.com/user-attachments/assets/c90157b9-5eb7-49f1-ac1b-b78ed20a2896" />

Filtered
<img width="2324" height="723" alt="image" src="https://github.com/user-attachments/assets/e1575e33-1394-4cc1-a641-bef0209c7d45" />

Selected
<img width="2352" height="1268" alt="image" src="https://github.com/user-attachments/assets/fd22b9a7-bcf5-443b-abeb-bbb0988fa632" />

</details>

