### PR TITLE
Fix binary file detection

### DIFF
--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -55,11 +55,11 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
       lc_binary_threshold TYPE i VALUE 10,
       lc_bytes_to_check   TYPE i VALUE 1000.
 
-    DATA: lv_string_data           TYPE string,
-          lv_non_printable_chars   TYPE i,
-          lv_percentage            TYPE i,
-          lv_data                  TYPE xstring,
-          lv_xlen                  TYPE i.
+    DATA: lv_string_data         TYPE string,
+          lv_non_printable_chars TYPE i,
+          lv_percentage          TYPE i,
+          lv_data                TYPE xstring,
+          lv_xlen                TYPE i.
 
     lv_xlen = xstrlen( iv_data ).
     IF lv_xlen = 0.
@@ -67,10 +67,12 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
     ENDIF.
 
     lv_xlen = nmin(
-                val1 = lv_xlen
-                val2 = lc_bytes_to_check ).
+      val1 = lv_xlen
+      val2 = lc_bytes_to_check ).
 
     lv_data = iv_data(lv_xlen).
+
+    lv_data = lcl_utf8_utils=>strip_incomplete_utf8_tail( lv_data ).
 
     TRY.
         lv_string_data = zcl_abapgit_convert=>xstring_to_string_utf8( lv_data ).
@@ -84,7 +86,7 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
     REPLACE ALL OCCURRENCES OF cl_abap_char_utilities=>newline IN lv_string_data WITH space.
 
     FIND ALL OCCURRENCES OF REGEX '[^[:print:]]' IN lv_string_data MATCH COUNT lv_non_printable_chars  ##REGEX_POSIX.
-    lv_percentage = lv_non_printable_chars  * 100 / strlen( lv_string_data ).
+    lv_percentage = lv_non_printable_chars * 100 / strlen( lv_string_data ).
     rv_is_binary = boolc( lv_percentage > lc_binary_threshold ).
 
   ENDMETHOD.

--- a/src/utils/zcl_abapgit_utils.clas.locals_imp.abap
+++ b/src/utils/zcl_abapgit_utils.clas.locals_imp.abap
@@ -1,0 +1,102 @@
+CLASS lcl_utf8_utils DEFINITION.
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS strip_incomplete_utf8_tail
+      IMPORTING
+        iv_bytes        TYPE xstring
+      RETURNING
+        VALUE(rv_bytes) TYPE xstring.
+
+ENDCLASS.
+
+CLASS lcl_utf8_utils IMPLEMENTATION.
+
+  METHOD strip_incomplete_utf8_tail.
+
+    CONSTANTS:
+      lc_mask_80 TYPE x LENGTH 1 VALUE '80',
+      lc_mask_c0 TYPE x LENGTH 1 VALUE 'C0',
+      lc_mask_e0 TYPE x LENGTH 1 VALUE 'E0',
+      lc_mask_f0 TYPE x LENGTH 1 VALUE 'F0',
+      lc_mask_f8 TYPE x LENGTH 1 VALUE 'F8',
+      lc_val_00  TYPE x LENGTH 1 VALUE '00',
+      lc_val_c0  TYPE x LENGTH 1 VALUE 'C0',
+      lc_val_e0  TYPE x LENGTH 1 VALUE 'E0',
+      lc_val_f0  TYPE x LENGTH 1 VALUE 'F0'.
+
+    DATA lv_len      TYPE i.
+    DATA lv_i        TYPE i.
+    DATA lv_b        TYPE x LENGTH 1.
+    DATA lv_and      TYPE x LENGTH 1.
+    DATA lv_expected TYPE i.
+    DATA lv_actual   TYPE i.
+    DATA lv_cut      TYPE i.
+
+    rv_bytes = iv_bytes.
+
+    lv_len = xstrlen( rv_bytes ).
+    IF lv_len = 0.
+      RETURN.
+    ENDIF.
+
+    lv_i = lv_len - 1.
+
+    WHILE lv_i >= 0.
+      lv_b = rv_bytes+lv_i(1).
+      lv_and = lv_b BIT-AND lc_mask_c0.
+      IF lv_and <> lc_mask_80.
+        EXIT.
+      ENDIF.
+      lv_i = lv_i - 1.
+    ENDWHILE.
+
+    IF lv_i < 0.
+      CLEAR rv_bytes.
+      RETURN.
+    ENDIF.
+
+    lv_b = rv_bytes+lv_i(1).
+
+    lv_and = lv_b BIT-AND lc_mask_80.
+    IF lv_and = lc_val_00.
+      lv_expected = 1.
+    ELSE.
+      lv_and = lv_b BIT-AND lc_mask_e0.
+      IF lv_and = lc_val_c0.
+        lv_expected = 2.
+      ELSE.
+        lv_and = lv_b BIT-AND lc_mask_f0.
+        IF lv_and = lc_val_e0.
+          lv_expected = 3.
+        ELSE.
+          lv_and = lv_b BIT-AND lc_mask_f8.
+          IF lv_and = lc_val_f0.
+            lv_expected = 4.
+          ELSE.
+            lv_cut = lv_i.
+            IF lv_cut > 0.
+              rv_bytes = rv_bytes(lv_cut).
+            ELSE.
+              CLEAR rv_bytes.
+            ENDIF.
+            RETURN.
+          ENDIF.
+        ENDIF.
+      ENDIF.
+    ENDIF.
+
+    lv_actual = lv_len - lv_i.
+
+    IF lv_actual < lv_expected.
+      lv_cut = lv_i.
+      IF lv_cut > 0.
+        rv_bytes = rv_bytes(lv_cut).
+      ELSE.
+        CLEAR rv_bytes.
+      ENDIF.
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/utils/zcl_abapgit_utils.clas.testclasses.abap
+++ b/src/utils/zcl_abapgit_utils.clas.testclasses.abap
@@ -17,6 +17,7 @@ CLASS ltcl_is_binary DEFINITION FINAL FOR TESTING
       cds_with_umlaut_is_text FOR TESTING RAISING cx_static_check,
       image_is_binary FOR TESTING RAISING cx_static_check,
       text_is_not_binary FOR TESTING RAISING cx_static_check,
+      text_is_not_binary_tail FOR TESTING RAISING cx_static_check,
 
       given_file
         IMPORTING
@@ -28,6 +29,8 @@ CLASS ltcl_is_binary DEFINITION FINAL FOR TESTING
       given_cds_view_with_umlaut
         RAISING zcx_abapgit_exception,
       given_text
+        RAISING zcx_abapgit_exception,
+      given_text_incomplete_tail
         RAISING zcx_abapgit_exception,
 
       when_is_binary_determined
@@ -56,7 +59,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   ENDMETHOD.
 
-
   METHOD cds_with_umlaut_is_text.
 
     given_cds_view_with_umlaut( ).
@@ -64,7 +66,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
     then_is_not_binary( ).
 
   ENDMETHOD.
-
 
   METHOD image_is_binary.
 
@@ -82,9 +83,23 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD text_is_not_binary_tail.
+
+    given_text_incomplete_tail( ).
+    when_is_binary_determined( ).
+    then_is_not_binary( ).
+
+  ENDMETHOD.
+
   METHOD given_text.
 
     mv_given_file = zcl_abapgit_convert=>string_to_xstring_utf8( 'Test' && cl_abap_char_utilities=>cr_lf ).
+
+  ENDMETHOD.
+
+  METHOD given_text_incomplete_tail.
+
+    mv_given_file = zcl_abapgit_convert=>string_to_xstring_utf8( 'Test' && cl_abap_char_utilities=>cr_lf ) && 'E2'.
 
   ENDMETHOD.
 
@@ -93,7 +108,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
     mv_given_file = zcl_abapgit_convert=>string_to_xstring_utf8( iv_file ).
 
   ENDMETHOD.
-
 
   METHOD given_image.
 
@@ -136,7 +150,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   ENDMETHOD.
 
-
   METHOD given_cds_metadata.
 
     given_file( `{`
@@ -157,7 +170,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
       && gv_nl && `}` ).
 
   ENDMETHOD.
-
 
   METHOD given_cds_view_with_umlaut.
 
@@ -188,7 +200,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   ENDMETHOD.
 
-
   METHOD then_is_not_binary.
 
     cl_abap_unit_assert=>assert_equals(
@@ -197,7 +208,6 @@ CLASS ltcl_is_binary IMPLEMENTATION.
 
   ENDMETHOD.
 
-
   METHOD then_is_binary.
 
     cl_abap_unit_assert=>assert_equals(
@@ -205,5 +215,4 @@ CLASS ltcl_is_binary IMPLEMENTATION.
       exp = abap_true ).
 
   ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
If a file is longer than 1000 bytes, it can happen that the tail of the bytes has an incomplete utf8 character. The result was a failing utf8 conversion and detection as binary. The fix strips any imcomplete tail before the conversion.