### PR TITLE
WAPA: descriptive error when CREATE_NEW_PAGE fails

### DIFF
--- a/src/objects/zcl_abapgit_object_wapa.clas.abap
+++ b/src/objects/zcl_abapgit_object_wapa.clas.abap
@@ -102,6 +102,8 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
   METHOD create_new_page.
 
+    DATA lv_exc TYPE string.
+
     cl_o2_api_pages=>create_new_page(
       EXPORTING
         p_pageattrs           = is_page_attributes
@@ -113,8 +115,24 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
         error_occured         = 3
         o2appl_not_existing   = 4
         OTHERS                = 5 ).
+
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error { sy-subrc } from CL_O2_API_PAGES=>CREATE_NEW_PAGE| ).
+      CASE sy-subrc.
+        WHEN 1.
+          lv_exc = 'object_already_exists'.
+        WHEN 2.
+          lv_exc = 'invalid_name'.
+        WHEN 3.
+          lv_exc = 'error_occured'.
+        WHEN 4.
+          lv_exc = 'o2appl_not_existing'.
+        WHEN OTHERS.
+          lv_exc = 'unknown_error'.
+      ENDCASE.
+      zcx_abapgit_exception=>raise(
+        |CL_O2_API_PAGES=>CREATE_NEW_PAGE sy-subrc={ sy-subrc } ({ lv_exc })|
+        && | page='{ is_page_attributes-pagename }' pagekey='{ is_page_attributes-pagekey }'|
+        && | applname='{ is_page_attributes-applname }'| ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
### Problem
When `CL_O2_API_PAGES=>CREATE_NEW_PAGE` fails during WAPA deserialization, abapGit raises `Error 2 from CL_O2_API_PAGES=>CREATE_NEW_PAGE`. The bare sy-subrc gives no hint about which page failed or why.

The most common cause is `sy-subrc = 2` (`invalid_name`): SAP enforces the invariant `PAGEKEY = UPPERCASE(PAGENAME)`, so a repository whose page XML carries a lowercase pagekey fails here — and the old message made that practically undiagnosable.

### Change
Map sy-subrc to its exception name and include the page name, pagekey and application name in the raised message, e.g.:

```
CL_O2_API_PAGES=>CREATE_NEW_PAGE sy-subrc=2 (invalid_name) page='...' pagekey='...' applname='...'
```

No behavior change beyond the error text; `abaplint` passes clean.