### PR TITLE
Bugfix type `LXE_PCX_S1`

### DIFF
--- a/src/objects/texts/zif_abapgit_lxe_texts.intf.abap
+++ b/src/objects/texts/zif_abapgit_lxe_texts.intf.abap
@@ -7,8 +7,8 @@ INTERFACE zif_abapgit_lxe_texts
            s_text   TYPE c LENGTH 255,
            t_text   TYPE c LENGTH 255,
            unitmlt  TYPE i,
-           uppcase  TYPE c LENGTH 4,
-           texttype TYPE c LENGTH 1,
+           uppcase  TYPE c LENGTH 1,
+           texttype TYPE c LENGTH 4,
          END OF ty_text_pair.
 
   TYPES ty_text_pairs TYPE STANDARD TABLE OF ty_text_pair WITH DEFAULT KEY.


### PR DESCRIPTION
lxe_pcx_s1 has uppcase as lxeuppcase which is char(1) and has texttype as lxetexttype which is char(4)