### PR TITLE
Make JS-triggered sapevents work on WebGUI via a global form and data-sapevent marker

### DIFF
--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -347,13 +347,14 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
 
   METHOD zif_abapgit_html~a.
 
-    DATA: lv_class TYPE string,
-          lv_href  TYPE string,
-          lv_click TYPE string,
-          lv_id    TYPE string,
-          lv_act   TYPE string,
-          lv_style TYPE string,
-          lv_title TYPE string.
+    DATA: lv_class         TYPE string,
+          lv_href          TYPE string,
+          lv_click         TYPE string,
+          lv_id            TYPE string,
+          lv_act           TYPE string,
+          lv_style         TYPE string,
+          lv_title         TYPE string,
+          lv_data_sapevent TYPE string.
 
     lv_class = iv_class.
 
@@ -385,7 +386,12 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
           IF iv_query IS NOT INITIAL.
             lv_act = lv_act && `?` && iv_query.
           ENDIF.
-          lv_href  = | href="sapevent:{ lv_act }"|.
+          lv_href          = | href="sapevent:{ lv_act }"|.
+          " Stable action marker that survives ITS href rewriting on WebGUI,
+          " so JS (e.g. hotkeys) can find and click the element by its sapevent.
+          lv_data_sapevent = | data-sapevent="{ escape(
+            val    = lv_act
+            format = cl_abap_format=>e_html_attr ) }"|.
         WHEN zif_abapgit_html=>c_action_type-onclick.
           lv_href  = ' href="#"'.
           lv_click = | onclick="{ iv_act }"|.
@@ -413,7 +419,7 @@ CLASS zcl_abapgit_html IMPLEMENTATION.
         format = cl_abap_format=>e_html_attr ) }"|.
     ENDIF.
 
-    rv_str = |<a{ lv_id }{ lv_class }{ lv_href }{ lv_click }{ lv_style }{ lv_title }>|
+    rv_str = |<a{ lv_id }{ lv_class }{ lv_href }{ lv_data_sapevent }{ lv_click }{ lv_style }{ lv_title }>|
           && |{ iv_txt }</a>|.
 
   ENDMETHOD.

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -6,12 +6,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
   PUBLIC SECTION.
 
     TYPES:
-      BEGIN OF ty_event_signature,
-        method TYPE string,
-        name   TYPE string,
-      END OF  ty_event_signature .
-
-    TYPES:
       BEGIN OF ty_col_spec,
         tech_name      TYPE string,
         display_name   TYPE string,
@@ -103,11 +97,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS render_event_as_form
-      IMPORTING
-        !is_event      TYPE ty_event_signature
-      RETURNING
-        VALUE(ri_html) TYPE REF TO zif_abapgit_html .
     CLASS-METHODS render_repo_palette
       IMPORTING
         iv_action      TYPE string
@@ -565,16 +554,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     ri_html->add( |{ lv_longtext }| ).
     ri_html->add( |</div>| ).
     ri_html->add( |</div>| ).
-
-  ENDMETHOD.
-
-
-  METHOD render_event_as_form.
-
-    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
-
-    ri_html->add(
-      |<form id="form_{ is_event-name }" method="{ is_event-method }" action="sapevent:{ is_event-name }"></form>| ).
 
   ENDMETHOD.
 

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.abap
@@ -524,6 +524,15 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
       ii_html          = ri_html
       iv_part_category = c_html_parts-hidden_forms ).
 
+    " Reusable, server-rendered sapevent form. On WebGUI a sapevent only routes
+    " through a form/anchor that ITS wired up while rendering the page; a form
+    " built in JS at submit time is not wired, so the raw sapevent: scheme is
+    " rejected. submitSapeventForm reuses this form when a page provides no
+    " dedicated form_<action>, so JS-triggered sapevents work on WebGUI. On the
+    " desktop browser control its action is simply overwritten, so it is
+    " harmless there.
+    ri_html->add( |<form id="global_sapevent_form" method="post" action="sapevent:noop"></form>| ).
+
     ri_html->add( footer( lo_timer->end( ) ) ).
 
     ri_html->add( '</div>' ).

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.abap
@@ -520,6 +520,9 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     ri_html->add( render_hotkey_overview( ) ).
     ri_html->add( render_error_message_box( ) ).
 
+    " Extension point for pages that need their own hidden form. No page in
+    " abapGit uses it since the global sapevent form below replaced the
+    " per-action stub forms, but it stays available to subclasses.
     render_deferred_parts(
       ii_html          = ri_html
       iv_part_category = c_html_parts-hidden_forms ).
@@ -527,9 +530,9 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     " Reusable, server-rendered sapevent form. On WebGUI a sapevent only routes
     " through a form/anchor that ITS wired up while rendering the page; a form
     " built in JS at submit time is not wired, so the raw sapevent: scheme is
-    " rejected. submitSapeventForm reuses this form when a page provides no
-    " dedicated form_<action>, so JS-triggered sapevents work on WebGUI. On the
-    " desktop browser control its action is simply overwritten, so it is
+    " rejected. submitSapeventForm submits through this form whenever the caller
+    " does not supply one of its own, so JS-triggered sapevents work on WebGUI.
+    " On the desktop browser control its action is simply overwritten, so it is
     " harmless there.
     ri_html->add( |<form id="global_sapevent_form" method="post" action="sapevent:noop"></form>| ).
 

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -205,7 +205,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<tr>' )->add(
       '<th><a href="sapevent:sort_by:col1:dsc" data-sapevent="sort_by:col1:dsc">Col 1</a>' &&
         '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
-      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
+      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a>' &&
+        '<span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
       '</thead>' ).
@@ -273,7 +274,8 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<tr>' )->add(
       '<th><a href="sapevent:sort_by:col1:dsc" data-sapevent="sort_by:col1:dsc">Col 1</a>' &&
         '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
-      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
+      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a>'  &&
+        '<span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
       '</thead>' ).

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -203,9 +203,9 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<table id="with-sort">' )->add(
       '<thead>' )->add(
       '<tr>' )->add(
-      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a>' &&
+      '<th><a href="sapevent:sort_by:col1:dsc" data-sapevent="sort_by:col1:dsc">Col 1</a>' &&
         '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
-      '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
+      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
       '</thead>' ).
@@ -271,9 +271,9 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '</tr>' ).
     li_html_exp->add(
       '<tr>' )->add(
-      '<th><a href="sapevent:sort_by:col1:dsc">Col 1</a>' &&
+      '<th><a href="sapevent:sort_by:col1:dsc" data-sapevent="sort_by:col1:dsc">Col 1</a>' &&
         '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
-      '<th><a href="sapevent:sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
+      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a><span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(
       '</thead>' ).

--- a/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_table.clas.testclasses.abap
@@ -274,7 +274,7 @@ CLASS ltcl_test_simple_table IMPLEMENTATION.
       '<tr>' )->add(
       '<th><a href="sapevent:sort_by:col1:dsc" data-sapevent="sort_by:col1:dsc">Col 1</a>' &&
         '<span class="sort-arrow sort-active">&#x25BE;</span></th>' )->add(
-      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a>'  &&
+      '<th><a href="sapevent:sort_by:col2:asc" data-sapevent="sort_by:col2:asc">Col 2</a>' &&
         '<span class="sort-arrow">&#x25BE;</span></th>' )->add(
       '<th>Col 3</th>' )->add(
       '</tr>' )->add(

--- a/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_stage.clas.abap
@@ -118,9 +118,6 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
     METHODS count_default_files_to_commit
       RETURNING
         VALUE(rv_count) TYPE i .
-    METHODS render_deferred_hidden_events
-      RETURNING
-        VALUE(ri_html) TYPE REF TO zif_abapgit_html .
     METHODS render_scripts
       RETURNING
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
@@ -366,18 +363,6 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
     ri_html->add( '</tr>' ).
     ri_html->add( '</table>' ).
-
-  ENDMETHOD.
-
-
-  METHOD render_deferred_hidden_events.
-
-    DATA ls_event TYPE zcl_abapgit_gui_chunk_lib=>ty_event_signature.
-
-    ls_event-method = 'post'.
-    ls_event-name   = c_action-stage_commit.
-    ri_html = zcl_abapgit_gui_chunk_lib=>render_event_as_form( ls_event ).
-    ri_html->set_title( cl_abap_typedescr=>describe_by_object_ref( me )->get_relative_name( ) ).
 
   ENDMETHOD.
 
@@ -823,9 +808,6 @@ CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
     ri_html->add( '</div>' ).
 
-    gui_services( )->get_html_parts( )->add_part(
-      iv_collection = zcl_abapgit_gui_component=>c_html_parts-hidden_forms
-      ii_part       = render_deferred_hidden_events( ) ).
     register_deferred_script( render_scripts( ) ).
 
   ENDMETHOD.

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -132,11 +132,31 @@ function submitSapeventForm(params, action, method, form) {
     }
   }
 
-  var stub_form_id = "form_" + action;
+  var isGlobalForm = false;
 
-  form = form
-    || document.getElementById(stub_form_id)
-    || document.createElement("form");
+  if (!form) {
+    // Reuse the page-global, server-rendered form. On WebGUI a sapevent only
+    // routes through a form ITS wired up while rendering the page; a form
+    // created here is not wired and the raw "sapevent:" scheme is rejected.
+    // The global form is harmless on the desktop control, where its action is
+    // overwritten below.
+    form = document.getElementById("global_sapevent_form");
+    isGlobalForm = Boolean(form);
+  }
+  if (!form) {
+    // Fallback for a page not rendered through the standard scaffold
+    form = document.createElement("form");
+  }
+
+  // The global form is shared across submits; drop fields a previous submit
+  // appended so stale values do not accumulate (matters for actions that do
+  // not navigate away, e.g. filtering or clipboard yank).
+  if (isGlobalForm) {
+    var priorFields = form.querySelectorAll("input[data-sapevent-field]");
+    for (var p = 0; p < priorFields.length; p++) {
+      priorFields[p].parentNode.removeChild(priorFields[p]);
+    }
+  }
 
   form.setAttribute("method", method || "post");
   var form_action = form.getAttribute("action");
@@ -156,12 +176,13 @@ function submitSapeventForm(params, action, method, form) {
     hiddenField.setAttribute("type", "hidden");
     hiddenField.setAttribute("name", key);
     hiddenField.setAttribute("value", params[key]);
+    if (isGlobalForm) hiddenField.setAttribute("data-sapevent-field", "");
     form.appendChild(hiddenField);
   }
 
   var formExistsInDOM = form.id && Boolean(document.querySelector("#" + form.id));
 
-  if (form.id !== stub_form_id && !formExistsInDOM) {
+  if (!formExistsInDOM) {
     document.body.appendChild(form);
   }
 
@@ -169,6 +190,20 @@ function submitSapeventForm(params, action, method, form) {
   // sapevent navigation is self-initiated, not a user Back press
   gSapeventNavPending = true;
   form.submit();
+}
+
+// Trigger a server-rendered sapevent element (anchor / submit input) the way a
+// user click would. Flag the navigation as self-initiated first, so the
+// browser-back trap ignores any popstate the browser control emits while
+// handling it (mirrors submitSapeventForm). Some callers (command palette)
+// pass anchors that are not sapevents (onclick / plain links); those must not
+// arm the flag - it would never be consumed and the next genuine Back press
+// would be swallowed.
+function clickSapEvent(element) {
+  var isSapEvent = element.getAttribute("data-sapevent")
+    || /sapevent/i.test(element.hrefsav || element.href || element.formAction || "");
+  if (isSapEvent) gSapeventNavPending = true;
+  element.click();
 }
 
 // Set focus to a control
@@ -1664,7 +1699,7 @@ function Hotkeys(oKeyMap) {
     var action = this.oKeyMap[sKey];
 
     // add a tooltip/title with the hotkey, currently only sapevents are supported
-    this.getAllSapEventsForSapEventName(action).forEach(function(elAnchor) {
+    findSapEventElements(action).forEach(function(elAnchor) {
       elAnchor.title = elAnchor.title + " [" + sKey + "]";
     });
 
@@ -1693,26 +1728,14 @@ function Hotkeys(oKeyMap) {
         return;
       }
 
-      // Or a SAP event link
-      var sUiSapEventHref = this.getSapEventHref(action);
-      if (sUiSapEventHref) {
-        submitSapeventForm({}, sUiSapEventHref, "post");
-        oEvent.preventDefault();
-        return;
-      }
-
-      // Or an SAP event input
-      var sUiSapEventInputAction = this.getSapEventInputAction(action);
-      if (sUiSapEventInputAction) {
-        submitSapeventForm({}, sUiSapEventInputAction, "post");
-        oEvent.preventDefault();
-        return;
-      }
-
-      // Or an SAP event main form
-      var elForm = this.getSapEventForm(action);
-      if (elForm) {
-        elForm.submit();
+      // Or a SAP event element (anchor / submit input) rendered on the page.
+      // Click it so the browser control routes the event: on WebGUI ITS has
+      // rewritten the href/formaction, so we must trigger the real element
+      // rather than rebuild the sapevent URL. Clicking also preserves any
+      // getdata the element carries (e.g. "...?key=<repo>").
+      var elSapEvent = findSapEventElement(action);
+      if (elSapEvent) {
+        clickSapEvent(elSapEvent);
         oEvent.preventDefault();
         return;
       }
@@ -1728,69 +1751,6 @@ Hotkeys.prototype.showHotkeys = function() {
   if (elHotkeys) {
     elHotkeys.style.display = (elHotkeys.style.display) ? "" : "none";
   }
-};
-
-Hotkeys.prototype.getAllSapEventsForSapEventName = function (sSapEvent) {
-  if (/^#+$/.test(sSapEvent)){
-    // sSapEvent contains only #. Nothing sensible can be done here
-    return [];
-  }
-
-  var includesSapEvent = function(text){
-    return (text.includes("sapevent") || text.includes("SAPEVENT"));
-  };
-
-  return [].slice
-    .call(document.querySelectorAll("a[href*="+ sSapEvent +"], input[formaction*="+ sSapEvent+"]"))
-    .filter(function (elem) {
-      return (elem.nodeName === "A" && includesSapEvent(elem.href)
-          || (elem.nodeName === "INPUT" && includesSapEvent(elem.formAction)));
-    });
-};
-
-Hotkeys.prototype.getSapEventHref = function(sSapEvent) {
-  return this.getAllSapEventsForSapEventName(sSapEvent)
-    .filter(function(el) {
-      // only anchors
-      return (!!el.href);
-    })
-    .map(function(oSapEvent) {
-      return oSapEvent.href;
-    })
-    .filter(this.eliminateSapEventFalsePositives(sSapEvent))
-    .pop();
-};
-
-Hotkeys.prototype.getSapEventInputAction = function(sSapEvent) {
-  return this.getAllSapEventsForSapEventName(sSapEvent)
-    .filter(function(el) {
-      // input forms
-      return (el.type === "submit");
-    })
-    .map(function(oSapEvent) {
-      return oSapEvent.formAction;
-    })
-    .filter(this.eliminateSapEventFalsePositives(sSapEvent))
-    .pop();
-};
-
-Hotkeys.prototype.getSapEventForm = function(sSapEvent) {
-  return this.getAllSapEventsForSapEventName(sSapEvent)
-    .filter(function(el) {
-      // forms
-      var parentForm = el.parentNode.parentNode.parentNode;
-      return (el.type === "submit" && parentForm.nodeName === "FORM");
-    })
-    .map(function(oSapEvent) {
-      return oSapEvent.parentNode.parentNode.parentNode;
-    })
-    .pop();
-};
-
-Hotkeys.prototype.eliminateSapEventFalsePositives = function(sapEvent) {
-  return function(sapEventAttr) {
-    return sapEventAttr.match(new RegExp("\\b" + sapEvent + "\\b"));
-  };
 };
 
 Hotkeys.prototype.onkeydown = function(oEvent) {
@@ -2417,15 +2377,7 @@ function enumerateUiActions() {
     });
 
   items = items.map(function(item) {
-    var action;
     var anchor = item[0];
-    if (anchor.href.includes("#")) {
-      action = function() {
-        anchor.click();
-      };
-    } else {
-      action = anchor.href.replace("sapevent:", "");
-    }
     var prefix = item[1];
     // title is re-read on each palette open, some labels change dynamically
     // (e.g. commit/patch buttons on the stage page)
@@ -2433,7 +2385,10 @@ function enumerateUiActions() {
       return (prefix ? prefix + ": " : "") + anchor.innerText.trim();
     };
     return {
-      action  : action,
+      // Clicking the wired anchor routes on every browser control (desktop and
+      // WebGUI); no need to reconstruct the sapevent from the href, which ITS
+      // rewrites on WebGUI anyway.
+      action  : function() { clickSapEvent(anchor) },
       getTitle: getTitle,
       title   : getTitle()
     };
@@ -2476,7 +2431,7 @@ function enumerateUiActions() {
     }).forEach(function(anchor) {
       items.push({
         action: function() {
-          anchor.click();
+          clickSapEvent(anchor);
         },
         title: (function() {
           var result = anchor.title + anchor.text;
@@ -2623,22 +2578,40 @@ function redirectBrowserBackToSapEvent(backAction) {
   });
 }
 
-// Find the back element the backend rendered for the given sapevent action.
+// Find the server-rendered elements (anchors / submit inputs) the backend
+// rendered for a given sapevent action. Used to trigger the action by clicking
+// one, which routes on every browser control - on WebGUI ITS rewrites the href
+// and drives the submit through its own machinery, so we cannot rebuild the
+// navigation ourselves - and to annotate hotkey tooltips.
 //
-// We cannot rebuild the navigation ourselves: on WebGUI, ITS rewrites the
-// sapevent href (e.g. "sapevent:go_back" -> "#sapevent25") and drives the
-// submit through its own machinery with session context we do not have.
-// ITS preserves the original href in the "hrefsav" property though
-// (see comment in RepoOverViewHelper.updateActionLinks), so we match on
-// that on WebGUI and on href/formaction on the desktop browser control.
-function findSapEventElement(action) {
+// Matches the backend's data-sapevent marker first: it carries the original
+// action and survives ITS href rewriting on WebGUI. Falls back to
+// hrefsav/href/formaction on the desktop controls. Whole-word match so
+// "go_back" does not also match "go_back_something".
+function findSapEventElements(action) {
+  if (!action || /^#+$/.test(action)) return [];
+
+  // Escape regex metacharacters so actions like "jump?key=1" cannot break the
+  // pattern (\b still assumes word-shaped action names, which all current are)
+  var re = new RegExp("\\b" + action.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\b");
   return [].slice
-    .call(document.querySelectorAll("a[href], input[formaction]"))
+    .call(document.querySelectorAll("a, input[type='submit']"))
     .filter(function(el) {
-      var sTarget = el.hrefsav || el.href || el.formAction || "";
-      return sTarget.indexOf(action) !== -1
-        && sTarget.toLowerCase().indexOf("sapevent") !== -1;
-    })[0];
+      var target = el.getAttribute("data-sapevent");
+      if (!target) {
+        target = el.hrefsav || el.href || el.formAction || "";
+        if (!/sapevent/i.test(target)) return false;
+      }
+      return re.test(target);
+    });
+}
+
+// First matching sapevent element (anchor preferred), or undefined. Shared by
+// the browser-back trap (triggerSapEventBack) and the hotkey handler.
+function findSapEventElement(action) {
+  var elements = findSapEventElements(action);
+  var anchors  = elements.filter(function(el) { return el.nodeName === "A" });
+  return (anchors.length ? anchors : elements)[0];
 }
 
 function triggerSapEventBack(backAction) {
@@ -2654,11 +2627,8 @@ function triggerSapEventBack(backAction) {
 
   // No Back element on this page (e.g. repo list) -> submit go_back directly,
   // so browser Back mirrors F3 everywhere (e.g. leaving a top-level page).
-  // NOTE: this bare-form submit only works in the desktop browser control.
-  // On WebGUI it does not route (the ITS session context is missing), so on
-  // pages that render no Back element there, browser Back has no effect.
-  // Pages that do render a Back element use the click path above and work
-  // in both controls.
+  // This reuses the page-global sapevent form, so it routes on WebGUI as well
+  // as on the desktop browser controls.
   submitSapeventForm({}, backAction);
 }
 

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -114,6 +114,29 @@ function debugOutput(text, dstID) {
 // genuine user Back press. See that function for details.
 var gSapeventNavPending = false;
 
+// Encode a sapevent action for the ITS "PARAMS=" slot. PARAMS carries the whole
+// action including its own query string, so characters that would terminate the
+// value inside the enclosing URL have to be escaped (ITS decodes the parameter
+// again before handing it to the control). "?" and "=" are deliberately left
+// alone so single-parameter actions keep producing the exact URL they did
+// before.
+function encodeItsParams(action) {
+  return action.replace(/[%&#+]/g, function(character) {
+    return "%" + character.charCodeAt(0).toString(16).toUpperCase();
+  });
+}
+
+// Append params to a sapevent action as a query string, the way a GET form
+// submit would have appended them to the action URL
+function appendParamsToAction(action, params) {
+  var pairs = [];
+  for (var key in params) {
+    pairs.push(encodeURIComponent(key) + "=" + encodeURIComponent(params[key]));
+  }
+  if (!pairs.length) return action;
+  return action + (action.indexOf("?") === -1 ? "?" : "&") + pairs.join("&");
+}
+
 // Use a supplied form, a pre-created form or create a hidden form
 // and submit with sapevent
 function submitSapeventForm(params, action, method, form) {
@@ -130,6 +153,18 @@ function submitSapeventForm(params, action, method, form) {
     } else {
       return ""; // No prefix for old IE control
     }
+  }
+
+  // A GET submit replaces the action URL's query string with the form fields.
+  // On WebGUI that would wipe the ITS routing parameters the wired-up form
+  // action carries (~control / ~event / PARAMS), so the request no longer
+  // routes as a sapevent. Carry the params in the action instead and post: the
+  // desktop controls end up navigating to exactly the sapevent URL a GET submit
+  // produced, and WebGUI keeps its routing parameters intact.
+  if (method && method.toLowerCase() === "get") {
+    action = appendParamsToAction(action, params);
+    params = null;
+    method = "post";
   }
 
   var isGlobalForm = false;
@@ -164,7 +199,7 @@ function submitSapeventForm(params, action, method, form) {
   // SAP GUI for HTML: inside an HTML control, form actions look as follows:
   // ~control=116&~event=OnSAPEvent&ALINK=1&frameName=&PARAMS=stage_commit
   if (/~control=/i.test(form_action)) {
-    form.setAttribute("action", form_action.replace(/PARAMS=.*$/, "PARAMS=" + action));
+    form.setAttribute("action", form_action.replace(/PARAMS=.*$/, "PARAMS=" + encodeItsParams(action)));
   } else if (/sapevent/i.test(action)) {
     form.setAttribute("action", action);
   } else {
@@ -201,7 +236,7 @@ function submitSapeventForm(params, action, method, form) {
 // would be swallowed.
 function clickSapEvent(element) {
   var isSapEvent = element.getAttribute("data-sapevent")
-    || /sapevent/i.test(element.hrefsav || element.href || element.formAction || "");
+    || /sapevent/i.test(element.hrefsav || element.href || element.getAttribute("formaction") || "");
   if (isSapEvent) gSapeventNavPending = true;
   element.click();
 }
@@ -423,6 +458,13 @@ RepoOverViewHelper.prototype.updateActionLinks = function(selectedRow) {
     // see /sap/public/icmandir/its/lsgui/js/htmlviewer.js
     if (link.hrefsav) {
       link.hrefsav = link.hrefsav.replace(reKey, newKey);
+    }
+
+    // keep the backend's action marker in sync with the rewritten href, so it
+    // stays a faithful description of what clicking the link will do
+    var sapevent = link.getAttribute("data-sapevent");
+    if (sapevent) {
+      link.setAttribute("data-sapevent", sapevent.replace(reKey, newKey));
     }
 
     // toggle button visibility
@@ -2599,7 +2641,11 @@ function findSapEventElements(action) {
     .filter(function(el) {
       var target = el.getAttribute("data-sapevent");
       if (!target) {
-        target = el.hrefsav || el.href || el.formAction || "";
+        // getAttribute, not the formAction property: the property falls back to
+        // the document URL when the attribute is absent, and a WebGUI document
+        // URL can carry both "OnSAPEvent" and "PARAMS=<action>" and so match
+        // every submit button on the page.
+        target = el.hrefsav || el.href || el.getAttribute("formaction") || "";
         if (!/sapevent/i.test(target)) return false;
       }
       return re.test(target);
@@ -2608,6 +2654,11 @@ function findSapEventElements(action) {
 
 // First matching sapevent element (anchor preferred), or undefined. Shared by
 // the browser-back trap (triggerSapEventBack) and the hotkey handler.
+//
+// When a page renders the same action more than once (typically a toolbar entry
+// plus an inline link) we deliberately take the first one in document order,
+// i.e. the toolbar entry. All renderings of an action point at the same target,
+// so the choice only decides which element receives the synthetic click.
 function findSapEventElement(action) {
   var elements = findSapEventElements(action);
   var anchors  = elements.filter(function(el) { return el.nodeName === "A" });


### PR DESCRIPTION
**TL;DR fixes broken hotkeys, command palette, stage/patch buttons, browser back, link hints and more on WEBGUI + simplifications and cleanups**

Need thorough testing on:
- [x] SAPGUI for Windows Edge
- [x] SAPGUI for Windows IE
- [x] WebGUI
- [x] SAPGUI for Java

On SAP GUI for HTML (WebGUI), ITS only routes sapevents through forms and
anchors it wired up while server-rendering the page. Forms built by
JavaScript at submit time are not wired, so the raw "sapevent:" scheme is
rejected — breaking every JS-initiated action on WebGUI: hotkeys, the
command palette, and the browser-back fallback. ITS also rewrites sapevent
hrefs (e.g. "sapevent:go_back" -> "#sapevent25"), so JS cannot reliably
find an element by its action or rebuild the URL from a rewritten href.

Two server-rendered hooks fix both problems:

* zcl_abapgit_gui_page: render a single hidden
  <form id="global_sapevent_form"> in the page scaffold, so every page has
  one ITS-wired form. submitSapeventForm reuses it when the caller passes
  no form, instead of creating an unwired one (createElement remains as
  fallback for pages outside the standard scaffold). Injected hidden
  fields are tagged with data-sapevent-field and cleared on the next
  submit, since the form is shared and non-navigating actions (filter,
  clipboard yank) would otherwise accumulate stale values. On the desktop
  browser control the form's action is simply overwritten, so it is
  harmless there.

* zcl_abapgit_html->a(): emit a data-sapevent="<action>" attribute
  (HTML-escaped) on sapevent anchors. Unlike the href, this marker
  survives ITS rewriting, giving JS a stable way to locate the real wired
  element for a given action.

On top of these, the JS callers now trigger the server-rendered element
instead of reconstructing the navigation:

* findSapEventElements/findSapEventElement (new, shared): match elements
  by data-sapevent first, falling back to hrefsav/href/formaction on the
  desktop controls. Whole-word regex with metacharacters escaped, so an
  action like "jump?key=1" cannot throw or mismatch. Anchors are preferred
  over submit inputs.

* clickSapEvent (new): click a sapevent element after setting
  gSapeventNavPending, so the browser-back trap ignores the popstate the
  control emits during the navigation. Non-sapevent elements (onclick,
  plain links) do not arm the flag — it would never be consumed and the
  next genuine Back press would be swallowed.

* Hotkeys: replace the href-scraping resolution chain (getSapEventHref /
  getSapEventInputAction / getSapEventForm /
  getAllSapEventsForSapEventName / eliminateSapEventFalsePositives) with a
  single findSapEventElement + clickSapEvent. Clicking the element also
  preserves any getdata it carries (e.g. "...?key=<repo>"). Hotkey
  tooltips use the same finder.

* Command palette (enumerateUiActions): always click the wired anchor via
  clickSapEvent instead of extracting the action from the href, which is
  rewritten on WebGUI anyway.

* Browser back (triggerSapEventBack): the no-Back-element fallback now
  routes through the global form, so browser Back also works on WebGUI on
  pages that render no Back element (e.g. repo list).

The per-page hidden-form workaround is retired: the stage page's
render_deferred_hidden_events is removed along with chunk_lib's
render_event_as_form and its ty_event_signature type, and
submitSapeventForm no longer looks for form_<action> stubs.