### PR TITLE
Page Commit: Fix misleading max-length placeholder

### DIFF
--- a/src/ui/pages/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_commit.clas.abap
@@ -303,7 +303,6 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
     DATA lv_commitmsg_comment_length TYPE i.
     DATA lv_button_text TYPE string.
     CONSTANTS lc_commitmsg_comment_min_len TYPE i VALUE 1.
-    CONSTANTS lc_commitmsg_comment_max_len TYPE i VALUE 255.
 
     ro_form = zcl_abapgit_html_form=>create(
       iv_form_id   = 'commit-form'
@@ -317,7 +316,7 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
       iv_required    = abap_true
       iv_min         = lc_commitmsg_comment_min_len
       iv_max         = lv_commitmsg_comment_length
-      iv_placeholder = |Add a mandatory comment with max { lc_commitmsg_comment_max_len } characters|
+      iv_placeholder = |Add a mandatory comment with max { lv_commitmsg_comment_length } characters|
     )->textarea(
       iv_name        = c_id-body
       iv_label       = 'Body'


### PR DESCRIPTION
Max length setting is 50
<img width="574" height="202" alt="image" src="https://github.com/user-attachments/assets/52db3ee6-1d7f-4d7c-95bb-bf9adf3252a8" />

Before
<img width="1530" height="432" alt="image" src="https://github.com/user-attachments/assets/6e87ff1c-d8ed-4469-ac53-4902b79984d6" />

After
<img width="1247" height="292" alt="image" src="https://github.com/user-attachments/assets/97611ecf-2b12-4d72-9dd5-4d299d181f85" />

