### PR TITLE
SHMA: bugfix GUI popup

### DIFF
--- a/src/objects/zcl_abapgit_object_shma.clas.abap
+++ b/src/objects/zcl_abapgit_object_shma.clas.abap
@@ -144,12 +144,13 @@ CLASS zcl_abapgit_object_shma IMPLEMENTATION.
     tadir_insert( iv_package ).
 
     TRY.
+        " dont generate the classes, it will cause a GUI popup to show
         CALL METHOD ('\PROGRAM=SAPLSHMA\CLASS=LCL_SHMA_HELPER')=>('INSERT_AREA')
           EXPORTING
             area_name           = lv_area_name
             attributes          = ls_area_attributes
             force_overwrite     = abap_true
-            no_class_generation = abap_false
+            no_class_generation = abap_true
             silent_mode         = abap_true.
 
       CATCH cx_root INTO lx_root.

--- a/src/objects/zcl_abapgit_object_shma.clas.abap
+++ b/src/objects/zcl_abapgit_object_shma.clas.abap
@@ -155,7 +155,7 @@ CLASS zcl_abapgit_object_shma IMPLEMENTATION.
 
       CATCH cx_root INTO lx_root.
         zcx_abapgit_exception=>raise(
-          iv_text     = |Error deserializing SHMA { ms_item-obj_name }|
+          iv_text     = |Error deserializing SHMA { ms_item-obj_name }, { lx_root->get_text( ) }|
           ix_previous = lx_root ).
     ENDTRY.
 

--- a/src/objects/zcl_abapgit_object_shma.clas.abap
+++ b/src/objects/zcl_abapgit_object_shma.clas.abap
@@ -145,6 +145,7 @@ CLASS zcl_abapgit_object_shma IMPLEMENTATION.
 
     TRY.
         " dont generate the classes, it will cause a GUI popup to show
+        " the CLAS must be deserialized before SHMA
         CALL METHOD ('\PROGRAM=SAPLSHMA\CLASS=LCL_SHMA_HELPER')=>('INSERT_AREA')
           EXPORTING
             area_name           = lv_area_name

--- a/src/objects/zcl_abapgit_object_shma.clas.abap
+++ b/src/objects/zcl_abapgit_object_shma.clas.abap
@@ -141,11 +141,17 @@ CLASS zcl_abapgit_object_shma IMPLEMENTATION.
       CHANGING
         cg_data = ls_area_attributes ).
 
+    IF ls_area_attributes-root IS INITIAL.
+      zcx_abapgit_exception=>raise( |Error deserializing SHMA { ms_item-obj_name }, root class is empty| ).
+    ELSEIF zcl_abapgit_oo_factory=>get_by_type( 'CLAS' )->exists( ls_area_attributes-root ) = abap_false.
+      zcx_abapgit_exception=>raise( |Error deserializing SHMA { ms_item-obj_name }, root class {
+        ls_area_attributes-root } does not exist| ).
+    ENDIF.
+
     tadir_insert( iv_package ).
 
     TRY.
         " dont generate the classes, it will cause a GUI popup to show
-        " the CLAS must be deserialized before SHMA
         CALL METHOD ('\PROGRAM=SAPLSHMA\CLASS=LCL_SHMA_HELPER')=>('INSERT_AREA')
           EXPORTING
             area_name           = lv_area_name


### PR DESCRIPTION
if deserializing only a SHMA, it will show a popup when trying to generate the classes, test with https://github.com/abapGit-tests/SHMA/tree/hvam/onlytheshma

it will now show an error that the root class doesn't exist. For on-stack development it will generate it along with the area, for off-stack the class must be created at the same time