### PR TITLE
Fix SAPGUI for Windows determination

### DIFF
--- a/src/ui/zcl_abapgit_frontend_services.clas.abap
+++ b/src/ui/zcl_abapgit_frontend_services.clas.abap
@@ -403,9 +403,13 @@ CLASS zcl_abapgit_frontend_services IMPLEMENTATION.
   METHOD zif_abapgit_frontend_services~is_sapgui_for_windows.
 
     TRY.
-        CALL FUNCTION 'GUI_HAS_ACTIVEX'
-          IMPORTING
-            return = rv_result.
+        " Sole ActiveX check is not sufficient as it is also TRUE for WebGUI
+        IF zif_abapgit_frontend_services~is_webgui( ) = abap_false.
+          CALL FUNCTION 'GUI_HAS_ACTIVEX'
+            IMPORTING
+              return = rv_result.
+        ENDIF.
+
       CATCH cx_sy_dyn_call_illegal_func.
 * when running on open-abap
         RETURN.


### PR DESCRIPTION
fixes #7810 
| Check | SAP GUI for Windows | SAP GUI for Java | WebGUI |
|-------|:-------------------:|:----------------:|:-------:|
| **zcl_abapgit_frontend_services** ||||
| `is_sapgui_for_windows` | ✅ | ❌ | ❌ |
| `is_webgui` | ❌ | ❌ | ✅ |
| `is_sapgui_for_java` | ❌ | ✅ | ❌ |
| **Function Modules** ||||
| `GUI_IS_AVAILABLE` | ✅ | ✅ | ✅ |
| `GUI_HAS_ACTIVEX` | ✅ | ❌ | ✅ |
| `GUI_HAS_JAVABEANS` | ❌ | ✅ | ❌ |
| `GUI_IS_ITS` | ❌ | ❌ | ✅ |
| `GUI_IS_WEBGUI` | ❌ | ❌ | ✅ |
| **cl_gui_object** ||||
| `gui_is_running` | ✅ | ✅ | ✅ |
| `activex` | ✅ | ❌ | ✅ |
| `javabean` | ❌ | ✅ | ❌ |
| `www_active` | ❌ | ❌ | ✅ |

<details>
<summary>For the records check report</summary>



```
REPORT ztest_gui.

CLASS report DEFINITION.

  PUBLIC SECTION.
    CLASS-METHODS run.

  PRIVATE SECTION.
    CLASS-METHODS gui_is_available
      RETURNING VALUE(result) TYPE abap_bool.

    CLASS-METHODS gui_has_activex
      RETURNING VALUE(result) TYPE abap_bool.

    CLASS-METHODS gui_has_javabeans
      RETURNING VALUE(result) TYPE abap_bool.

    CLASS-METHODS gui_is_its
      RETURNING VALUE(result) TYPE abap_bool.

    CLASS-METHODS gui_is_webgui
      RETURNING VALUE(result) TYPE abap_bool.

ENDCLASS.


CLASS report IMPLEMENTATION.
  METHOD run.
    WRITE / |===========-zcl_abapgit_frontend_services-===========|.
    WRITE / |is_sapgui_for_windows: { zcl_abapgit_ui_factory=>get_frontend_services( )->is_sapgui_for_windows( ) }|.
    WRITE / |is_webgui: { zcl_abapgit_ui_factory=>get_frontend_services( )->is_webgui( ) }|.
    WRITE / |is_sapgui_for_java: { zcl_abapgit_ui_factory=>get_frontend_services( )->is_sapgui_for_java( ) }|.
    WRITE / |===========-Function Modules-===========|.
    WRITE / |GUI_IS_AVAILABLE: { gui_is_available( ) }|.
    WRITE / |GUI_HAS_ACTIVEX: { gui_has_activex( ) }|.
    WRITE / |GUI_HAS_JAVABEANS: { gui_has_javabeans( ) }|.
    WRITE / |GUI_IS_ITS: { gui_is_its( ) }|.
    WRITE / |GUI_IS_WEBGUI: { gui_is_webgui( ) }|.
    WRITE / |===========-cl_gui_object-===========|.
    WRITE / |gui_is_running: { cl_gui_object=>gui_is_running }|.
    WRITE / |activex: { cl_gui_object=>activex }|.
    WRITE / |javabean: { cl_gui_object=>javabean }|.
    WRITE / |www_active: { cl_gui_object=>www_active }|.
  ENDMETHOD.

  METHOD gui_is_available.
    CALL FUNCTION 'GUI_IS_AVAILABLE'
      IMPORTING return = result.
  ENDMETHOD.

  METHOD gui_has_activex.
    CALL FUNCTION 'GUI_HAS_ACTIVEX'
      IMPORTING return = result.
  ENDMETHOD.

  METHOD gui_has_javabeans.
    CALL FUNCTION 'GUI_HAS_JAVABEANS'
      IMPORTING return = result.
  ENDMETHOD.

  METHOD gui_is_its.
    CALL FUNCTION 'GUI_IS_ITS'
      IMPORTING return = result.
  ENDMETHOD.

  METHOD gui_is_webgui.
    CALL FUNCTION 'GUI_IS_WEBGUI'
      IMPORTING is_webgui = result.
  ENDMETHOD.
ENDCLASS.

START-OF-SELECTION.
  report=>run( ).
```

</details>