### PR TITLE
Do not report a browser control on the HTML GUI

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.abap
@@ -179,8 +179,13 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
     rv_version = rv_version && | - { lo_frontend_serv->get_gui_type( ) }|.
 
+    " Only SAP GUI for Windows embeds a browser control whose type is worth
+    " reporting. The HTML GUI runs in the browser of the user, and guessing the
+    " control from its user agent produced nonsense there (e.g. "IE" on Chrome).
     " Will be filled by JS method displayBrowserControlFooter
-    rv_version = rv_version && '<span id="browser-control-footer"></span>'.
+    IF lo_frontend_serv->is_sapgui_for_windows( ) = abap_true.
+      rv_version = rv_version && '<span id="browser-control-footer"></span>'.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2613,6 +2613,9 @@ function toggleBrowserControlWarning() {
 // Output type of HTML control in the abapGit footer
 function displayBrowserControlFooter() {
   var out = document.getElementById("browser-control-footer");
+  // Only rendered where there is a browser control to report on, i.e. not on
+  // the HTML GUI, which runs in the browser of the user
+  if (!out) return;
   out.innerHTML = " - " + ( navigator.userAgent.includes("Edg") ? "Edge" : "IE"  );
 }
 


### PR DESCRIPTION
Needs #7813 as prerequisite.

The footer guessed the type of the embedded browser control from the user agent, so on the HTML GUI, which runs in the browser of the user and embeds nothing, it claimed "IE" for every browser except Edge.

Render the placeholder only for SAP GUI for Windows, the one GUI that does embed a control, mirroring is_edge_control_warning_needed. The JS side now checks whether the placeholder exists at all.

Before:
<img width="381" height="60" alt="image" src="https://github.com/user-attachments/assets/2bf9a852-33fd-4050-a598-5347b660bfcc" />

After:
<img width="325" height="57" alt="image" src="https://github.com/user-attachments/assets/b807e4fb-1d78-4c1f-9733-2c325772fe66" />
