### PR TITLE
Avoid empty data config

### DIFF
--- a/src/data/zcl_abapgit_data_config.clas.abap
+++ b/src/data/zcl_abapgit_data_config.clas.abap
@@ -173,6 +173,11 @@ CLASS zcl_abapgit_data_config IMPLEMENTATION.
     DATA lx_ajson TYPE REF TO zcx_abapgit_ajson_error.
     DATA lv_json  TYPE string.
 
+    IF mt_config IS INITIAL.
+      zcl_abapgit_persist_factory=>get_repo_data( )->delete( iv_repo_key ).
+      RETURN.
+    ENDIF.
+
     TRY.
         lo_ajson = zcl_abapgit_ajson=>create_empty( ).
         lo_ajson->zif_abapgit_ajson~set(


### PR DESCRIPTION
Remove data config entry from DB if no tables are maintained.