### PR TITLE
fix(ui): arm back-trap flag in submitFormById

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -319,8 +319,17 @@ function setInitialFocusWithQuerySelector(sSelector, bFocusParent) {
   }
 }
 
-// Submit an existing form
+// Submit an existing, server-rendered sapevent form (its action carries the
+// event, so nothing has to be rewritten here).
+//
+// Flag the navigation as self-initiated first, so the browser-back trap ignores
+// the popstate the browser control emits while handling it (mirrors
+// submitSapeventForm / clickSapEvent). Without the flag the trap reads that
+// popstate as a user Back press and fires go_back, which supersedes the submit:
+// the page returns without saving on the Edge control, while the IE control -
+// where the trap never arms - is unaffected.
 function submitFormById(id) {
+  gSapeventNavPending = true;
   document.getElementById(id).submit();
 }
 


### PR DESCRIPTION
The browser-back trap ignores popstate events that our own sapevent navigations cause, by way of the gSapeventNavPending flag. Every sapevent entry point set it except submitFormById, which submits a server-rendered sapevent form directly.

On the Edge control the popstate emitted while handling such a submit was therefore read as a genuine Back press and fired go_back, which superseded the pending request. Saving a config entry in the Database Utility returned to the previous page without persisting; the three Apply buttons on the merge resolution page were broken the same way. The IE control is unaffected because the trap never arms there (no pushState support).

Closes #7826