### PR TITLE
feat(git): allow an explicit commit timestamp

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -654,7 +654,12 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
                    <ls_blob> LIKE LINE OF it_blobs.
 
 
-    lv_time = zcl_abapgit_git_time=>get_unix( ).
+* the caller can supply a timestamp, eg when replaying historic changes,
+* it is used for both the committer and the author
+    lv_time = is_comment-time.
+    IF lv_time IS INITIAL.
+      lv_time = zcl_abapgit_git_time=>get_unix( ).
+    ENDIF.
 
     READ TABLE it_trees ASSIGNING <ls_tree> WITH KEY path = '/'.
     ASSERT sy-subrc = 0.

--- a/src/git/zcl_abapgit_git_time.clas.abap
+++ b/src/git/zcl_abapgit_git_time.clas.abap
@@ -6,7 +6,7 @@ CLASS zcl_abapgit_git_time DEFINITION
   PUBLIC SECTION.
 
     TYPES:
-      ty_unixtime TYPE c LENGTH 16 .
+      ty_unixtime TYPE zif_abapgit_git_definitions=>ty_unixtime .
 
     CLASS-METHODS get_unix
       RETURNING
@@ -22,6 +22,15 @@ CLASS zcl_abapgit_git_time DEFINITION
       RAISING
         zcx_abapgit_exception .
 
+    CLASS-METHODS get_unix_from_local
+      IMPORTING
+        !iv_date       TYPE d
+        !iv_time       TYPE t
+      RETURNING
+        VALUE(rv_time) TYPE ty_unixtime
+      RAISING
+        zcx_abapgit_exception .
+
     CLASS-METHODS get_utc
       IMPORTING
         !iv_unix TYPE ty_unixtime
@@ -30,11 +39,41 @@ CLASS zcl_abapgit_git_time DEFINITION
         !ev_time TYPE sy-uzeit .
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    CLASS-METHODS get_system_timezone
+      RETURNING
+        VALUE(rv_timezone) TYPE timezone .
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_git_time IMPLEMENTATION.
+
+
+  METHOD get_system_timezone.
+* the time zone of the application server, ie the time zone of SY-DATUM and SY-UZEIT
+* and of most date and time fields on the database, like E070-AS4DATE and E070-AS4TIME
+* note SY-ZONLO is the personal time zone of the user, it can be empty,
+* eg in background jobs, so it cannot be used here
+
+    DATA lv_fm TYPE string.
+
+    lv_fm = 'GET_SYSTEM_TIMEZONE'.
+
+    TRY.
+        CALL METHOD ('CL_ABAP_TSTMP')=>get_system_timezone
+          RECEIVING
+            system_timezone = rv_timezone.
+      CATCH cx_sy_dyn_call_illegal_method.
+        CALL FUNCTION lv_fm
+          IMPORTING
+            timezone            = rv_timezone
+          EXCEPTIONS
+            customizing_missing = 1
+            OTHERS              = 2 ##FM_SUBRC_OK.
+    ENDTRY.
+
+  ENDMETHOD.
 
 
   METHOD get_unix_days_ago.
@@ -73,6 +112,43 @@ CLASS zcl_abapgit_git_time IMPLEMENTATION.
     rv_time = lv_seconds.
     CONDENSE rv_time.
     rv_time+11 = '+0000'.
+
+  ENDMETHOD.
+
+
+  METHOD get_unix_from_local.
+* returns seconds since Unix epoch, including timezone indicator
+* the input is expected to be in the time zone of the application server,
+* like SY-DATUM and SY-UZEIT, it is converted to UTC, so the timezone
+* indicator is always '+0000', the same layout as GET_UNIX returns
+
+    CONSTANTS lc_epoch TYPE timestamp VALUE '19700101000000'.
+
+    DATA lv_seconds   TYPE i.
+    DATA lv_timestamp TYPE timestamp.
+    DATA lv_timezone  TYPE timezone.
+
+    IF iv_date IS INITIAL.
+      zcx_abapgit_exception=>raise( 'Cannot determine unix time, date is initial' ).
+    ENDIF.
+
+    lv_timezone = get_system_timezone( ).
+
+    CONVERT DATE iv_date TIME iv_time
+      INTO TIME STAMP lv_timestamp TIME ZONE lv_timezone.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Unknown time zone "{ lv_timezone }"| ).
+    ENDIF.
+
+    IF lv_timestamp < lc_epoch.
+      zcx_abapgit_exception=>raise( |Date { iv_date } is before the unix epoch| ).
+    ENDIF.
+
+    lv_seconds = cl_abap_tstmp=>subtract(
+      tstmp1 = lv_timestamp
+      tstmp2 = lc_epoch ).
+
+    rv_time = |{ lv_seconds } +0000|.
 
   ENDMETHOD.
 

--- a/src/git/zcl_abapgit_git_time.clas.abap
+++ b/src/git/zcl_abapgit_git_time.clas.abap
@@ -105,7 +105,7 @@ CLASS zcl_abapgit_git_time IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Cannot determine unix time, date is initial' ).
     ENDIF.
 
-    lv_timezone = cl_abap_tstmp=>get_system_timezone( ).
+    lv_timezone = zcl_abapgit_time_date=>get_system_timezone( ).
 
     CONVERT DATE iv_date TIME iv_time
       INTO TIME STAMP lv_timestamp TIME ZONE lv_timezone.

--- a/src/git/zcl_abapgit_git_time.clas.abap
+++ b/src/git/zcl_abapgit_git_time.clas.abap
@@ -39,41 +39,11 @@ CLASS zcl_abapgit_git_time DEFINITION
         !ev_time TYPE sy-uzeit .
   PROTECTED SECTION.
   PRIVATE SECTION.
-
-    CLASS-METHODS get_system_timezone
-      RETURNING
-        VALUE(rv_timezone) TYPE timezone .
 ENDCLASS.
 
 
 
 CLASS zcl_abapgit_git_time IMPLEMENTATION.
-
-
-  METHOD get_system_timezone.
-* the time zone of the application server, ie the time zone of SY-DATUM and SY-UZEIT
-* and of most date and time fields on the database, like E070-AS4DATE and E070-AS4TIME
-* note SY-ZONLO is the personal time zone of the user, it can be empty,
-* eg in background jobs, so it cannot be used here
-
-    DATA lv_fm TYPE string.
-
-    lv_fm = 'GET_SYSTEM_TIMEZONE'.
-
-    TRY.
-        CALL METHOD ('CL_ABAP_TSTMP')=>get_system_timezone
-          RECEIVING
-            system_timezone = rv_timezone.
-      CATCH cx_sy_dyn_call_illegal_method.
-        CALL FUNCTION lv_fm
-          IMPORTING
-            timezone            = rv_timezone
-          EXCEPTIONS
-            customizing_missing = 1
-            OTHERS              = 2 ##FM_SUBRC_OK.
-    ENDTRY.
-
-  ENDMETHOD.
 
 
   METHOD get_unix_days_ago.
@@ -119,8 +89,11 @@ CLASS zcl_abapgit_git_time IMPLEMENTATION.
   METHOD get_unix_from_local.
 * returns seconds since Unix epoch, including timezone indicator
 * the input is expected to be in the time zone of the application server,
-* like SY-DATUM and SY-UZEIT, it is converted to UTC, so the timezone
-* indicator is always '+0000', the same layout as GET_UNIX returns
+* like SY-DATUM and SY-UZEIT and like most date and time fields on the
+* database, eg E070-AS4DATE and E070-AS4TIME, it is converted to UTC, so
+* the timezone indicator is always '+0000', same layout as GET_UNIX returns
+* note SY-ZONLO is the personal time zone of the user, it can be empty,
+* eg in background jobs, so it cannot be used here
 
     CONSTANTS lc_epoch TYPE timestamp VALUE '19700101000000'.
 
@@ -132,7 +105,7 @@ CLASS zcl_abapgit_git_time IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'Cannot determine unix time, date is initial' ).
     ENDIF.
 
-    lv_timezone = get_system_timezone( ).
+    lv_timezone = cl_abap_tstmp=>get_system_timezone( ).
 
     CONVERT DATE iv_date TIME iv_time
       INTO TIME STAMP lv_timestamp TIME ZONE lv_timezone.

--- a/src/git/zcl_abapgit_git_time.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_time.clas.testclasses.abap
@@ -63,7 +63,7 @@ CLASS ltcl_time_test IMPLEMENTATION.
     CONVERT DATE lv_date TIME lv_time
       INTO TIME STAMP lv_act TIME ZONE lc_utc.
 
-    lv_timezone = cl_abap_tstmp=>get_system_timezone( ).
+    lv_timezone = zcl_abapgit_time_date=>get_system_timezone( ).
 
     CONVERT DATE lc_date TIME lc_time
       INTO TIME STAMP lv_exp TIME ZONE lv_timezone.

--- a/src/git/zcl_abapgit_git_time.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_time.clas.testclasses.abap
@@ -1,6 +1,3 @@
-CLASS ltcl_time_test DEFINITION DEFERRED.
-CLASS zcl_abapgit_git_time DEFINITION LOCAL FRIENDS ltcl_time_test.
-
 CLASS ltcl_time_test DEFINITION FINAL
   FOR TESTING
   DURATION SHORT
@@ -66,7 +63,7 @@ CLASS ltcl_time_test IMPLEMENTATION.
     CONVERT DATE lv_date TIME lv_time
       INTO TIME STAMP lv_act TIME ZONE lc_utc.
 
-    lv_timezone = zcl_abapgit_git_time=>get_system_timezone( ).
+    lv_timezone = cl_abap_tstmp=>get_system_timezone( ).
 
     CONVERT DATE lc_date TIME lc_time
       INTO TIME STAMP lv_exp TIME ZONE lv_timezone.

--- a/src/git/zcl_abapgit_git_time.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_time.clas.testclasses.abap
@@ -1,3 +1,6 @@
+CLASS ltcl_time_test DEFINITION DEFERRED.
+CLASS zcl_abapgit_git_time DEFINITION LOCAL FRIENDS ltcl_time_test.
+
 CLASS ltcl_time_test DEFINITION FINAL
   FOR TESTING
   DURATION SHORT
@@ -5,6 +8,8 @@ CLASS ltcl_time_test DEFINITION FINAL
 
   PRIVATE SECTION.
     METHODS get_unix FOR TESTING RAISING cx_static_check.
+    METHODS get_unix_from_local FOR TESTING RAISING cx_static_check.
+    METHODS get_unix_from_local_now FOR TESTING RAISING cx_static_check.
     METHODS get_utc FOR TESTING.
 ENDCLASS.
 
@@ -18,6 +23,82 @@ CLASS ltcl_time_test IMPLEMENTATION.
     lv_time = zcl_abapgit_git_time=>get_unix( ).
 
     cl_abap_unit_assert=>assert_not_initial( lv_time ).
+
+  ENDMETHOD.
+
+
+  METHOD get_unix_from_local.
+
+* round trip, GET_UTC must decode the same point in time again,
+* independent of the time zone of the application server
+
+    CONSTANTS lc_utc  TYPE timezone VALUE 'UTC'.
+    CONSTANTS lc_date TYPE d VALUE '20240208'.
+    CONSTANTS lc_time TYPE t VALUE '123456'.
+
+    DATA lv_unix     TYPE zcl_abapgit_git_time=>ty_unixtime.
+    DATA lv_seconds  TYPE zcl_abapgit_git_time=>ty_unixtime.
+    DATA lv_date     TYPE sy-datum.
+    DATA lv_time     TYPE sy-uzeit.
+    DATA lv_act      TYPE timestamp.
+    DATA lv_exp      TYPE timestamp.
+    DATA lv_timezone TYPE timezone.
+
+    lv_unix = zcl_abapgit_git_time=>get_unix_from_local(
+      iv_date = lc_date
+      iv_time = lc_time ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_unix+11
+      exp = '+0000' ).
+
+* only the seconds are passed, the timezone indicator is asserted above
+* and does not shift the point in time
+    lv_seconds = lv_unix(10).
+
+    zcl_abapgit_git_time=>get_utc(
+      EXPORTING
+        iv_unix = lv_seconds
+      IMPORTING
+        ev_date = lv_date
+        ev_time = lv_time ).
+
+    CONVERT DATE lv_date TIME lv_time
+      INTO TIME STAMP lv_act TIME ZONE lc_utc.
+
+    lv_timezone = zcl_abapgit_git_time=>get_system_timezone( ).
+
+    CONVERT DATE lc_date TIME lc_time
+      INTO TIME STAMP lv_exp TIME ZONE lv_timezone.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_act
+      exp = lv_exp ).
+
+  ENDMETHOD.
+
+
+  METHOD get_unix_from_local_now.
+
+* the current time converted from local time must match GET_UNIX,
+* this fails if the wrong time zone is assumed for the input
+
+    DATA lv_unix  TYPE zcl_abapgit_git_time=>ty_unixtime.
+    DATA lv_local TYPE zcl_abapgit_git_time=>ty_unixtime.
+    DATA lv_diff  TYPE i.
+
+    GET TIME.
+
+    lv_local = zcl_abapgit_git_time=>get_unix_from_local(
+      iv_date = sy-datum
+      iv_time = sy-uzeit ).
+    lv_unix = zcl_abapgit_git_time=>get_unix( ).
+
+    lv_diff = abs( lv_unix(10) - lv_local(10) ).
+
+    IF lv_diff > 5.
+      cl_abap_unit_assert=>fail( |Off by { lv_diff } seconds, { lv_unix } vs { lv_local }| ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/git/zif_abapgit_git_definitions.intf.abap
+++ b/src/git/zif_abapgit_git_definitions.intf.abap
@@ -64,11 +64,16 @@ INTERFACE zif_abapgit_git_definitions
       name  TYPE string,
       email TYPE string,
     END OF ty_git_user .
+* seconds since the unix epoch plus timezone indicator, eg '1740000000 +0000'
+  TYPES:
+    ty_unixtime TYPE c LENGTH 16 .
+* TIME is optional, if it is initial the current time is used when committing
   TYPES:
     BEGIN OF ty_comment,
       committer TYPE ty_git_user,
       author    TYPE ty_git_user,
       comment   TYPE string,
+      time      TYPE ty_unixtime,
     END OF ty_comment .
 
   TYPES:

--- a/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -253,21 +253,7 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
   METHOD class_constructor.
 
-    DATA lv_fm TYPE string.
-    lv_fm = 'GET_SYSTEM_TIMEZONE'.
-
-    TRY.
-        CALL METHOD ('CL_ABAP_TSTMP')=>get_system_timezone
-          RECEIVING
-            system_timezone = gv_time_zone.
-      CATCH cx_sy_dyn_call_illegal_method.
-        CALL FUNCTION lv_fm
-          IMPORTING
-            timezone            = gv_time_zone
-          EXCEPTIONS
-            customizing_missing = 1
-            OTHERS              = 2 ##FM_SUBRC_OK.
-    ENDTRY.
+    gv_time_zone = zcl_abapgit_time_date=>get_system_timezone( ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_time_date.clas.abap
+++ b/src/utils/zcl_abapgit_time_date.clas.abap
@@ -1,0 +1,44 @@
+CLASS zcl_abapgit_time_date DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get_system_timezone
+      RETURNING
+        VALUE(rv_timezone) TYPE timezone .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_time_date IMPLEMENTATION.
+
+
+  METHOD get_system_timezone.
+* returns the time zone of the application server,
+* CL_ABAP_TSTMP=>GET_SYSTEM_TIMEZONE does not exist in lower releases,
+* and the function module is not released for ABAP Cloud, so call both dynamically
+
+    DATA lv_fm TYPE string.
+
+    lv_fm = 'GET_SYSTEM_TIMEZONE'.
+
+    TRY.
+        CALL METHOD ('CL_ABAP_TSTMP')=>get_system_timezone
+          RECEIVING
+            system_timezone = rv_timezone.
+      CATCH cx_sy_dyn_call_illegal_method.
+        CALL FUNCTION lv_fm
+          IMPORTING
+            timezone            = rv_timezone
+          EXCEPTIONS
+            customizing_missing = 1
+            OTHERS              = 2.
+        ASSERT sy-subrc = 0.
+    ENDTRY.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/utils/zcl_abapgit_time_date.clas.xml
+++ b/src/utils/zcl_abapgit_time_date.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_TIME_DATE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit - Time and Date Helpers</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Add ZCL_ABAPGIT_GIT_TIME=>GET_UNIX_FROM_LOCAL, the inverse of GET_UTC, which converts a date and time in the time zone of the application server, eg E070-AS4DATE and E070-AS4TIME, into unix time. The value is converted to UTC, so the timezone indicator stays '+0000' like in GET_UNIX. SY-ZONLO is not used, it is the personal time zone of the user and can be empty in background jobs.

Add an optional TIME field to ZIF_ABAPGIT_GIT_DEFINITIONS=>TY_COMMENT, so the timestamp flows through all existing push callers without signature changes. TY_UNIXTIME moved to the interface, which keeps it self contained, ZCL_ABAPGIT_GIT_TIME references it, so existing usages keep working.

RECEIVE_PACK_PUSH uses the supplied timestamp for both the committer and the author, ie history replay semantics instead of cherry pick semantics, so a tool that pushes released transports can date each commit when the change actually happened. If TIME is initial the current time is used, exactly as before, no existing call site needs changing.