### PR TITLE
WDYN: Fix CX_SY_REGEX_TOO_COMPLEX in method name regex

### DIFF
--- a/src/objects/zcl_abapgit_object_wdyn.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdyn.clas.abap
@@ -422,7 +422,7 @@ CLASS zcl_abapgit_object_wdyn IMPLEMENTATION.
       lt_abap = mo_files->read_abap( iv_extra = lv_extra ).
       LOOP AT lt_abap INTO ls_abap.
         " Start of method
-        FIND REGEX '\s*method\s+(.*)\s*\.' IN ls_abap-line IGNORING CASE SUBMATCHES lv_cmpname ##REGEX_POSIX.
+        FIND REGEX '^\s*method\s+([\w~/]+)' IN ls_abap-line IGNORING CASE SUBMATCHES lv_cmpname ##REGEX_POSIX.
         IF sy-subrc = 0.
           lv_line = 1.
         ENDIF.


### PR DESCRIPTION
The current regex captures with (.*) followed by \s*, so both can match the same trailing whitespace. This makes the submatch boundaries ambiguous and the kernel raises CX_SY_REGEX_TOO_COMPLEX when resolving leftmost-longest. Restricting the capture to [\w~/]+ makes the split unambiguous. Anchoring with ^ additionally prevents matching METHOD inside identifiers such as the following line which caused a dump on my system: 
`    PO_METHOD          = l_po_method`

<img width="1016" height="504" alt="image" src="https://github.com/user-attachments/assets/e138c9e8-4c08-461f-ab14-10e8a083f669" />
