### PR TITLE
Seed the GUI environment from ABAP instead of guessing it in JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ list.txt
 /playwright/.cache/
 .DS_Store
 .claude
+.frontend

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.abap
@@ -92,7 +92,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         !ii_html TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
-    METHODS render_environment
+    CLASS-METHODS render_environment
       IMPORTING
         !ii_html TYPE REF TO zif_abapgit_html
       RAISING
@@ -118,7 +118,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
     METHODS is_edge_control_warning_needed
       RETURNING
         VALUE(rv_result) TYPE abap_bool.
-    METHODS js_bool
+    CLASS-METHODS js_bool
       IMPORTING
         !iv_value    TYPE abap_bool
       RETURNING

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.abap
@@ -92,6 +92,11 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         !ii_html TYPE REF TO zif_abapgit_html
       RAISING
         zcx_abapgit_exception .
+    METHODS render_environment
+      IMPORTING
+        !ii_html TYPE REF TO zif_abapgit_html
+      RAISING
+        zcx_abapgit_exception .
     METHODS render_hotkey_overview
       RETURNING
         VALUE(ro_html) TYPE REF TO zif_abapgit_html
@@ -113,6 +118,11 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
     METHODS is_edge_control_warning_needed
       RETURNING
         VALUE(rv_result) TYPE abap_bool.
+    METHODS js_bool
+      IMPORTING
+        !iv_value    TYPE abap_bool
+      RETURNING
+        VALUE(rv_js) TYPE string.
 ENDCLASS.
 
 
@@ -292,6 +302,17 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD js_bool.
+
+    IF iv_value = abap_true.
+      rv_js = 'true'.
+    ELSE.
+      rv_js = 'false'.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD render_back_navigation.
 
     ii_html->add( 'addHotkey({' ).
@@ -342,6 +363,29 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     LOOP AT lt_parts INTO li_part.
       ii_html->add( li_part ).
     ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD render_environment.
+
+    DATA li_frontend_services TYPE REF TO zif_abapgit_frontend_services.
+
+    li_frontend_services = zcl_abapgit_ui_factory=>get_frontend_services( ).
+
+    " Tell the frontend which GUI it is rendered into. JS can only infer that
+    " from the DOM and the user agent and has inferred it wrongly before (the
+    " footer reported "IE" for a user on Chrome), while we know it from SAP's
+    " own APIs. Whatever a browser can establish for itself - which browser
+    " control is embedded, which URL scheme its sapevents need - it still finds
+    " out on its own, see gEnv in common.js.
+    "
+    " Only the facts common.js reads are passed; extending this means extending
+    " gEnv as well.
+    ii_html->add( 'setEnvironment({' ).
+    ii_html->add( |  isWebGui: { js_bool( li_frontend_services->is_webgui( ) ) },| ).
+    ii_html->add( |  isSapGuiForWindows: { js_bool( li_frontend_services->is_sapgui_for_windows( ) ) }| ).
+    ii_html->add( '});' ).
 
   ENDMETHOD.
 
@@ -405,6 +449,9 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
   METHOD scripts.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    " First, so everything rendered below already runs in a known environment
+    render_environment( ri_html ).
 
     render_link_hints( ri_html ).
     render_command_palettes( ri_html ).

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.testclasses.abap
@@ -1,0 +1,177 @@
+CLASS ltd_frontend_services DEFINITION FINAL FOR TESTING.
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_frontend_services.
+
+    METHODS constructor
+      IMPORTING
+        !iv_is_webgui             TYPE abap_bool
+        !iv_is_sapgui_for_windows TYPE abap_bool.
+
+  PRIVATE SECTION.
+
+    DATA mv_is_webgui TYPE abap_bool.
+    DATA mv_is_sapgui_for_windows TYPE abap_bool.
+
+ENDCLASS.
+
+
+CLASS ltd_frontend_services IMPLEMENTATION.
+
+  METHOD constructor.
+    mv_is_webgui = iv_is_webgui.
+    mv_is_sapgui_for_windows = iv_is_sapgui_for_windows.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~is_webgui.
+    rv_is_webgui = mv_is_webgui.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~is_sapgui_for_windows.
+    rv_result = mv_is_sapgui_for_windows.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~is_sapgui_for_java.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~clipboard_export.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~directory_browse.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~directory_create.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~directory_exist.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~execute.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~file_download.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~file_upload.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~get_file_separator.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~get_gui_type.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~get_gui_version.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~get_system_directory.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~gui_is_available.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~open_ie_devtools.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~show_file_open_dialog.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_frontend_services~show_file_save_dialog.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltcl_render_environment DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    METHODS teardown.
+
+    METHODS sapgui_for_html FOR TESTING RAISING cx_static_check.
+    METHODS sapgui_for_windows FOR TESTING RAISING cx_static_check.
+    METHODS sapgui_for_java FOR TESTING RAISING cx_static_check.
+
+    METHODS assert_seeded
+      IMPORTING
+        !iv_is_webgui             TYPE abap_bool
+        !iv_is_sapgui_for_windows TYPE abap_bool
+        !iv_exp                   TYPE string
+      RAISING
+        cx_static_check.
+
+ENDCLASS.
+
+CLASS zcl_abapgit_gui_page DEFINITION LOCAL FRIENDS ltcl_render_environment.
+
+
+CLASS ltcl_render_environment IMPLEMENTATION.
+
+  METHOD teardown.
+
+    DATA li_frontend_services TYPE REF TO zif_abapgit_frontend_services.
+
+    " Unbound, so the factory creates the real implementation again
+    zcl_abapgit_ui_injector=>set_frontend_services( li_frontend_services ).
+
+  ENDMETHOD.
+
+  METHOD assert_seeded.
+
+    DATA li_frontend_services TYPE REF TO zif_abapgit_frontend_services.
+    DATA li_html TYPE REF TO zif_abapgit_html.
+    DATA lv_act TYPE string.
+
+    CREATE OBJECT li_frontend_services TYPE ltd_frontend_services
+      EXPORTING
+        iv_is_webgui             = iv_is_webgui
+        iv_is_sapgui_for_windows = iv_is_sapgui_for_windows.
+
+    zcl_abapgit_ui_injector=>set_frontend_services( li_frontend_services ).
+
+    CREATE OBJECT li_html TYPE zcl_abapgit_html.
+
+    zcl_abapgit_gui_page=>render_environment( li_html ).
+
+    " Layout is formatting; the contract common.js relies on is the call, the
+    " key names and the JS literals, so compare without any whitespace
+    lv_act = li_html->render( iv_no_line_breaks = abap_true ).
+    CONDENSE lv_act NO-GAPS.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_act
+      exp = iv_exp ).
+
+  ENDMETHOD.
+
+  METHOD sapgui_for_html.
+
+    assert_seeded(
+      iv_is_webgui             = abap_true
+      iv_is_sapgui_for_windows = abap_false
+      iv_exp                   = `setEnvironment({isWebGui:true,isSapGuiForWindows:false});` ).
+
+  ENDMETHOD.
+
+  METHOD sapgui_for_windows.
+
+    assert_seeded(
+      iv_is_webgui             = abap_false
+      iv_is_sapgui_for_windows = abap_true
+      iv_exp                   = `setEnvironment({isWebGui:false,isSapGuiForWindows:true});` ).
+
+  ENDMETHOD.
+
+  METHOD sapgui_for_java.
+
+    assert_seeded(
+      iv_is_webgui             = abap_false
+      iv_is_sapgui_for_windows = abap_false
+      iv_exp                   = `setEnvironment({isWebGui:false,isSapGuiForWindows:false});` ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_gui_page.clas.xml
+++ b/src/ui/lib/zcl_abapgit_gui_page.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -142,8 +142,17 @@ var gEnv = {
   isSapGuiForWindows: false
 };
 
+// Every fact seeded here has to be declared in gEnv above. An unknown key
+// would otherwise be added silently while the one it was meant to set keeps
+// its default - putting back, unnoticed, the guesswork this replaces.
 function setEnvironment(env) {
-  for (var key in env) gEnv[key] = env[key];
+  for (var key in env) {
+    if (Object.prototype.hasOwnProperty.call(gEnv, key)) {
+      gEnv[key] = env[key];
+    } else if (window.console && window.console.log) {
+      window.console.log("abapGit: unknown environment key '" + key + "'");
+    }
+  }
 }
 
 // The prefix a sapevent URL needs for the browser control in use. Probed from

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -13,6 +13,9 @@
 /* exported confirmInitialized
    -- zcl_abapgit_gui_page->zif_abapgit_gui_renderable~render */
 
+/* exported setEnvironment
+   -- zcl_abapgit_gui_page->render_environment */
+
 /* exported toggleBrowserControlWarning, displayBrowserControlFooter,
             redirectBrowserBackToSapEvent, addHotkey
    -- zcl_abapgit_gui_page->scripts */
@@ -124,6 +127,56 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 }
 
 /**********************************************************
+ * Environment
+ **********************************************************/
+
+// What kind of GUI is abapGit displayed in? None of this changes while a page
+// is up, so every fact is established once and read from here afterwards.
+//
+// The backend seeds what it knows from SAP's own APIs: render_environment is
+// the first thing zcl_abapgit_gui_page->scripts writes, so these values are in
+// place before any other script on the page runs. Everything a browser can
+// establish for itself is probed here instead of being asked for.
+var gEnv = {
+  isWebGui          : false, // SAP GUI for HTML
+  isSapGuiForWindows: false
+};
+
+function setEnvironment(env) {
+  for (var key in env) gEnv[key] = env[key];
+}
+
+// The prefix a sapevent URL needs for the browser control in use. Probed from
+// the links the backend rendered, because the user agent does not distinguish
+// the control versions - and kept, because the control cannot change under a
+// page that is already displayed.
+var gSapeventPrefix; // undefined until first probed
+
+function getSapeventPrefix() {
+  if (gSapeventPrefix === undefined) {
+    // Depending on the used browser control and its version, different URL schemes
+    // are used which we distinguish here
+    if (document.querySelector('a[href*="file:///SAPEVENT:"]')) {
+      // Prefix for old (SAPGUI <= 8.00 PL3) chromium based browser control
+      gSapeventPrefix = "file:///";
+    } else if (document.querySelector('a[href^="sap-cust"]')) {
+      // Prefix for new (SAPGUI >= 8.00 PL3 Hotfix 1) chromium based browser control
+      gSapeventPrefix = "sap-cust://sap-place-holder/";
+    } else {
+      gSapeventPrefix = ""; // No prefix for old IE control
+    }
+  }
+  return gSapeventPrefix;
+}
+
+// Is the embedded browser control the Edge (Chromium) one rather than the old
+// IE one? Only meaningful inside SAP GUI for Windows - the HTML GUI runs in the
+// browser of the user, whose user agent describes no browser control at all.
+function isEdgeControl() {
+  return navigator.userAgent.includes("Edg");
+}
+
+/**********************************************************
  * Common functions
  **********************************************************/
 
@@ -170,20 +223,6 @@ function appendParamsToAction(action, params) {
 // Use a supplied form, a pre-created form or create a hidden form
 // and submit with sapevent
 function submitSapeventForm(params, action, method, form) {
-
-  function getSapeventPrefix() {
-    // Depending on the used browser control and its version, different URL schemes
-    // are used which we distinguish here
-    if (document.querySelector('a[href*="file:///SAPEVENT:"]')) {
-      // Prefix for old (SAPGUI <= 8.00 PL3) chromium based browser control
-      return "file:///";
-    } else if (document.querySelector('a[href^="sap-cust"]')) {
-      // Prefix for new (SAPGUI >= 8.00 PL3 Hotfix 1) chromium based browser control
-      return "sap-cust://sap-place-holder/";
-    } else {
-      return ""; // No prefix for old IE control
-    }
-  }
 
   // A GET submit replaces the action URL's query string with the form fields.
   // On WebGUI that would wipe the ITS routing parameters the wired-up form
@@ -232,9 +271,17 @@ function submitSapeventForm(params, action, method, form) {
   // ~control=116&~event=OnSAPEvent&ALINK=1&frameName=&PARAMS=stage_commit
   // The event to raise sits in PARAMS, the rest of the routing has to be kept
   // exactly as ITS set it up.
-  var itsParams = form.querySelectorAll("input[name='PARAMS']");
-  var isItsForm = itsParams.length > 0 || /~control=/i.test(form_action);
+  //
+  // Nothing wires up a form anywhere else, so outside the HTML GUI there is
+  // nothing to look for.
+  var itsParams = [];
+  var isItsForm = false;
   var i;
+
+  if (gEnv.isWebGui) {
+    itsParams = form.querySelectorAll("input[name='PARAMS']");
+    isItsForm = itsParams.length > 0 || /~control=/i.test(form_action);
+  }
 
   if (itsParams.length > 0) {
     // A form can carry several of them, one per element ITS wired up (e.g. the
@@ -244,7 +291,8 @@ function submitSapeventForm(params, action, method, form) {
     for (i = 0; i < itsParams.length; i++) {
       itsParams[i].value = action;
     }
-  } else if (/~control=/i.test(form_action)) {
+  } else if (isItsForm) {
+    // The other ITS variant: no PARAMS fields, the routing sits in the action
     form.setAttribute("action", form_action.replace(/PARAMS=.*$/, "PARAMS=" + encodeItsParams(action)));
   } else if (/sapevent/i.test(action)) {
     form.setAttribute("action", action);
@@ -319,8 +367,17 @@ function setInitialFocusWithQuerySelector(sSelector, bFocusParent) {
   }
 }
 
-// Submit an existing form
+// Submit an existing, server-rendered sapevent form (its action carries the
+// event, so nothing has to be rewritten here).
+//
+// Flag the navigation as self-initiated first, so the browser-back trap ignores
+// the popstate the browser control emits while handling it (mirrors
+// submitSapeventForm / clickSapEvent). Without the flag the trap reads that
+// popstate as a user Back press and fires go_back, which supersedes the submit:
+// the page returns without saving on the Edge control, while the IE control -
+// where the trap never arms - is unaffected.
 function submitFormById(id) {
+  gSapeventNavPending = true;
   document.getElementById(id).submit();
 }
 
@@ -2632,7 +2689,11 @@ function toggleSticky() {
 // Toggle display of warning message when using Edge (based on Chromium) browser control
 // Todo: Remove once https://github.com/abapGit/abapGit/issues/4841 is fixed
 function toggleBrowserControlWarning() {
-  if (!navigator.userAgent.includes("Edg")){
+  // The warning is about the Edge control, so hide it wherever that is not what
+  // we run in: on the old IE control, and on a GUI that embeds no browser
+  // control at all, whose user agent describes the browser of the user and can
+  // report "Edg" for reasons the warning has nothing to do with.
+  if (!isEdgeControl() || !gEnv.isSapGuiForWindows) {
     var elBrowserControlWarning = document.getElementById("browser-control-warning");
     if (elBrowserControlWarning) {
       elBrowserControlWarning.style.display = "none";
@@ -2642,11 +2703,12 @@ function toggleBrowserControlWarning() {
 
 // Output type of HTML control in the abapGit footer
 function displayBrowserControlFooter() {
+  // Only report a control where there is one. The HTML GUI runs in the browser
+  // of the user, whose user agent describes no browser control at all - reading
+  // it there once reported "IE" for a user on Chrome.
   var out = document.getElementById("browser-control-footer");
-  // Only rendered where there is a browser control to report on, i.e. not on
-  // the HTML GUI, which runs in the browser of the user
-  if (!out) return;
-  out.innerHTML = " - " + ( navigator.userAgent.includes("Edg") ? "Edge" : "IE"  );
+  if (!out || !gEnv.isSapGuiForWindows) return;
+  out.innerHTML = " - " + (isEdgeControl() ? "Edge" : "IE");
 }
 
 // Redirect browser "Back" navigation to the SAPGUI back sapevent (action "go_back").

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -139,7 +139,7 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 // establish for itself is probed here instead of being asked for.
 var gEnv = {
   isWebGui          : false, // SAP GUI for HTML
-  isSapGuiForWindows: false
+  isSapGuiForWindows: false  // neither of the two: SAP GUI for Java
 };
 
 // Every fact seeded here has to be declared in gEnv above. An unknown key


### PR DESCRIPTION
common.js had no single notion of which GUI it was rendered into. Each
probe re-derived a piece of it on every call, in its own vocabulary:
getSapeventPrefix ran two document-wide querySelector calls on every
sapevent submit to rediscover something that cannot change after page
load, and two separate functions open-coded
navigator.userAgent.includes("Edg").

Reading the user agent also gets the answer wrong outside SAP GUI for
Windows, where it describes the browser of the user rather than a
browser control - the footer once reported "IE" for a user on Chrome.
That was worked around by rendering the footer element only on Windows,
which left the JS silently relying on the backend's choice of markup to
stay correct.

The backend knows the GUI from SAP's own APIs, so let it say so:
render_environment emits setEnvironment(...) as the first statement of
every page's script block. It passes booleans rather than a type code,
so no shared vocabulary has to cross the language boundary.

On the JS side gEnv holds the seeded facts, getSapeventPrefix moves to
module scope and memoizes, and a named isEdgeControl() replaces the two
user agent reads. The ITS probes in submitSapeventForm now run only on
the HTML GUI, where ITS wiring can exist at all, and the branch handling
the second ITS variant reuses isItsForm instead of re-testing the action.

No behaviour change is intended on any GUI.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>