### PR TITLE
Return created package to new repository page

### DIFF
--- a/src/ui/pages/dlg/zcl_abapgit_gui_page_addofflin.clas.abap
+++ b/src/ui/pages/dlg/zcl_abapgit_gui_page_addofflin.clas.abap
@@ -243,7 +243,10 @@ CLASS zcl_abapgit_gui_page_addofflin IMPLEMENTATION.
             AND zcl_abapgit_factory=>get_sap_package( lv_package )->exists( ) = abap_true.
           zcx_abapgit_exception=>raise( |Package { lv_package } already exists| ).
         ENDIF.
-        rs_handled-page  = zcl_abapgit_gui_page_cpackage=>create( lv_package ).
+        rs_handled-page  = zcl_abapgit_gui_page_cpackage=>create(
+          iv_name         = lv_package
+          io_caller_form  = mo_form_data
+          iv_caller_field = c_id-package ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN c_event-choose_package.

--- a/src/ui/pages/dlg/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/pages/dlg/zcl_abapgit_gui_page_addonline.clas.abap
@@ -350,7 +350,10 @@ CLASS zcl_abapgit_gui_page_addonline IMPLEMENTATION.
             AND zcl_abapgit_factory=>get_sap_package( lv_package )->exists( ) = abap_true.
           zcx_abapgit_exception=>raise( |Package { lv_package } already exists| ).
         ENDIF.
-        rs_handled-page  = zcl_abapgit_gui_page_cpackage=>create( lv_package ).
+        rs_handled-page  = zcl_abapgit_gui_page_cpackage=>create(
+          iv_name         = lv_package
+          io_caller_form  = mo_form_data
+          iv_caller_field = c_id-package ).
         rs_handled-state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN c_event-create_repo.

--- a/src/ui/pages/zcl_abapgit_gui_page_cpackage.clas.abap
+++ b/src/ui/pages/zcl_abapgit_gui_page_cpackage.clas.abap
@@ -13,9 +13,11 @@ CLASS zcl_abapgit_gui_page_cpackage DEFINITION
 
     CLASS-METHODS create
       IMPORTING
-        iv_name        TYPE devclass
+        iv_name         TYPE devclass
+        io_caller_form  TYPE REF TO zcl_abapgit_string_map OPTIONAL
+        iv_caller_field TYPE string DEFAULT 'package'
       RETURNING
-        VALUE(ri_page) TYPE REF TO zif_abapgit_gui_renderable
+        VALUE(ri_page)  TYPE REF TO zif_abapgit_gui_renderable
       RAISING
         zcx_abapgit_exception.
 
@@ -32,6 +34,8 @@ CLASS zcl_abapgit_gui_page_cpackage DEFINITION
     DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map.
     DATA mo_form_util      TYPE REF TO zcl_abapgit_html_form_utils.
     DATA mv_default_name   TYPE devclass.
+    DATA mo_caller_form    TYPE REF TO zcl_abapgit_string_map.
+    DATA mv_caller_field   TYPE string.
 
     CONSTANTS:
       BEGIN OF c_id,
@@ -132,6 +136,8 @@ CLASS zcl_abapgit_gui_page_cpackage IMPLEMENTATION.
 
     CREATE OBJECT lo_component.
     lo_component->mv_default_name = iv_name.
+    lo_component->mo_caller_form = io_caller_form.
+    lo_component->mv_caller_field = iv_caller_field.
 
     ri_page = zcl_abapgit_gui_page_hoc=>create(
       iv_page_title         = 'Create Package'
@@ -163,6 +169,14 @@ CLASS zcl_abapgit_gui_page_cpackage IMPLEMENTATION.
 
           zcl_abapgit_factory=>get_sap_package( ls_create-devclass )->create( ls_create ).
           MESSAGE 'Package created' TYPE 'S'.
+
+          " Hand the new package back to the page that opened this one
+          IF mo_caller_form IS BOUND AND mv_caller_field IS NOT INITIAL.
+            mo_caller_form->set(
+              iv_key = mv_caller_field
+              iv_val = |{ ls_create-devclass }| ).
+          ENDIF.
+
           rs_handled-state = zcl_abapgit_gui=>c_event_state-go_back.
         ELSE.
           rs_handled-state = zcl_abapgit_gui=>c_event_state-re_render.


### PR DESCRIPTION
Closes #7643

Creating a package from the New Offline/Online Repository page left the Package field empty after returning, so the user had to type or pick the package again.

ZCL_ABAPGIT_GUI_PAGE_CPACKAGE=>CREATE now optionally accepts the calling page's form data and the field to fill. On successful creation the new package name is written back before navigating back, so the caller re-renders with the package already filled in.

Both parameters are optional, existing callers are unaffected.