### PR TITLE
Fix ABAP language version for newly created packages

### DIFF
--- a/src/env/zcl_abapgit_abap_language_vers.clas.abap
+++ b/src/env/zcl_abapgit_abap_language_vers.clas.abap
@@ -9,10 +9,17 @@ CLASS zcl_abapgit_abap_language_vers DEFINITION
       c_any_abap_language_version TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version VALUE '*',
       c_no_abap_language_version  TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version VALUE '-'.
 
+    CLASS-METHODS create
+      IMPORTING
+        !io_dot_abapgit  TYPE REF TO zcl_abapgit_dot_abapgit
+      RETURNING
+        VALUE(ro_result) TYPE REF TO zcl_abapgit_abap_language_vers.
+
     METHODS constructor
       IMPORTING
         !io_dot_abapgit TYPE REF TO zcl_abapgit_dot_abapgit.
 
+    "! Return the allowed ABAP language version for an object type and package
     METHODS get_abap_language_vers_by_objt
       IMPORTING
         !iv_object_type                      TYPE trobjtype
@@ -20,16 +27,24 @@ CLASS zcl_abapgit_abap_language_vers DEFINITION
       RETURNING
         VALUE(rv_allowed_abap_langu_version) TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version.
 
+    "! Returns ABAP language version (char 1) for repo objects based on .abapGit.xml setting
     METHODS get_repo_abap_language_version
       RETURNING
         VALUE(rv_abap_language_version) TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version.
 
+    "! Returns ABAP language version (char 1) for repo packages based on .abapGit.xml setting
+    METHODS get_package_abap_language_vers
+      RETURNING
+        VALUE(rv_abap_language_version) TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version.
+
+    "! Check if importing a package is allowed based on the ABAP language settings in .abapGit.xml
     METHODS is_import_allowed
       IMPORTING
         !iv_package       TYPE devclass
       RETURNING
         VALUE(rv_allowed) TYPE abap_bool.
 
+    "! Check if the expected ABAP language version matches the ABAP language version of an object
     CLASS-METHODS check_abap_language_version
       IMPORTING
         !iv_abap_language_version TYPE zif_abapgit_aff_types_v1=>ty_abap_language_version
@@ -122,6 +137,15 @@ CLASS zcl_abapgit_abap_language_vers IMPLEMENTATION.
     ELSE.
       mv_has_abap_language_vers = abap_true.
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD create.
+
+    CREATE OBJECT ro_result
+      EXPORTING
+        io_dot_abapgit = io_dot_abapgit.
 
   ENDMETHOD.
 
@@ -246,6 +270,28 @@ CLASS zcl_abapgit_abap_language_vers IMPLEMENTATION.
     ENDCASE.
 
     rv_description = |ABAP language version "{ rv_description }"|.
+
+  ENDMETHOD.
+
+
+  METHOD get_package_abap_language_vers.
+
+    DATA lv_abap_language_version TYPE string.
+
+    IF mv_has_abap_language_vers <> abap_undefined. " abap_true or abap_false
+      lv_abap_language_version = mo_dot_abapgit->get_abap_language_version( ).
+    ENDIF.
+
+    CASE lv_abap_language_version.
+      WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-standard.
+        rv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version-standard.
+      WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-key_user.
+        rv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version-key_user.
+      WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-cloud_development.
+        rv_abap_language_version = zif_abapgit_aff_types_v1=>co_abap_language_version-cloud_development.
+      WHEN OTHERS.
+        rv_abap_language_version = ''.
+    ENDCASE.
 
   ENDMETHOD.
 

--- a/src/env/zcl_abapgit_abap_language_vers.clas.testclasses.abap
+++ b/src/env/zcl_abapgit_abap_language_vers.clas.testclasses.abap
@@ -122,6 +122,8 @@ CLASS ltcl_abap_language_version DEFINITION FOR TESTING RISK LEVEL HARMLESS
       repo_setting FOR TESTING,
       object_type FOR TESTING,
       is_import_allowed FOR TESTING,
+      get_repo_abap_language_version FOR TESTING,
+      get_package_abap_language_vers FOR TESTING,
       check_abap_language_vers_same FOR TESTING RAISING zcx_abapgit_exception,
       check_abap_language_vers_diff FOR TESTING.
 
@@ -411,6 +413,87 @@ CLASS ltcl_abap_language_version IMPLEMENTATION.
     ENDLOOP.
 
   ENDMETHOD.
+
+  METHOD get_repo_abap_language_version.
+
+    DATA lv_version TYPE string.
+
+    LOOP AT mt_versions INTO lv_version.
+
+      init( lv_version ).
+
+      CASE lv_version.
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-undefined.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_repo_abap_language_version( )
+            exp = zcl_abapgit_abap_language_vers=>c_any_abap_language_version ).
+
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-ignore.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_repo_abap_language_version( )
+            exp = zcl_abapgit_abap_language_vers=>c_no_abap_language_version ).
+
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-standard.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_repo_abap_language_version( )
+            exp = zif_abapgit_aff_types_v1=>co_abap_language_version_src-standard ).
+
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-key_user.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_repo_abap_language_version( )
+            exp = zif_abapgit_aff_types_v1=>co_abap_language_version-key_user ).
+
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-cloud_development.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_repo_abap_language_version( )
+            exp = zif_abapgit_aff_types_v1=>co_abap_language_version-cloud_development ).
+
+      ENDCASE.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD get_package_abap_language_vers.
+
+    DATA lv_version TYPE string.
+
+    LOOP AT mt_versions INTO lv_version.
+
+      init( lv_version ).
+
+      CASE lv_version.
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-undefined
+          OR zif_abapgit_dot_abapgit=>c_abap_language_version-ignore
+          OR zif_abapgit_dot_abapgit=>c_abap_language_version-standard.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_package_abap_language_vers( )
+            exp = zif_abapgit_aff_types_v1=>co_abap_language_version-standard ).
+
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-key_user.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_package_abap_language_vers( )
+            exp = zif_abapgit_aff_types_v1=>co_abap_language_version-key_user ).
+
+        WHEN zif_abapgit_dot_abapgit=>c_abap_language_version-cloud_development.
+
+          cl_abap_unit_assert=>assert_equals(
+            act = mo_cut->get_package_abap_language_vers( )
+            exp = zif_abapgit_aff_types_v1=>co_abap_language_version-cloud_development ).
+
+      ENDCASE.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
 
   METHOD check_abap_language_vers_same.
 

--- a/src/objects/core/zcl_abapgit_folder_logic.clas.abap
+++ b/src/objects/core/zcl_abapgit_folder_logic.clas.abap
@@ -190,6 +190,7 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
           lv_absolute_name        TYPE string,
           lv_folder_logic         TYPE string,
           lt_unique_package_names TYPE HASHED TABLE OF devclass WITH UNIQUE KEY table_line.
+    DATA lv_abap_language_version TYPE uccheck.
 
     lv_length = strlen( io_dot->get_starting_folder( ) ).
     IF lv_length > strlen( iv_path ).
@@ -212,12 +213,14 @@ CLASS zcl_abapgit_folder_logic IMPLEMENTATION.
     " Automatically create package using minimal properties
     " Details will be updated during deserialization
     IF iv_create_if_not_exists = abap_true.
+      lv_abap_language_version = zcl_abapgit_abap_language_vers=>create( io_dot )->get_package_abap_language_vers( ).
       IF iv_top(1) = '$'.
-        zcl_abapgit_factory=>get_sap_package( iv_top )->create_local( ).
+        zcl_abapgit_factory=>get_sap_package( iv_top )->create_local( lv_abap_language_version ).
       ELSE.
         ls_package-devclass = iv_top.
-        ls_package-ctext = iv_top.
-        ls_package-as4user = sy-uname.
+        ls_package-ctext    = iv_top.
+        ls_package-as4user  = sy-uname.
+        ls_package-packkind = lv_abap_language_version.
         zcl_abapgit_factory=>get_sap_package( iv_top )->create( ls_package ).
       ENDIF.
     ENDIF.

--- a/src/objects/sap/zcl_abapgit_sap_package.clas.abap
+++ b/src/objects/sap/zcl_abapgit_sap_package.clas.abap
@@ -242,12 +242,12 @@ CLASS zcl_abapgit_sap_package IMPLEMENTATION.
 
     DATA: ls_package TYPE zif_abapgit_sap_package=>ty_create.
 
-
-    ls_package-devclass  = mv_package.
-    ls_package-ctext     = mv_package.
-    ls_package-parentcl  = '$TMP'.
-    ls_package-dlvunit   = 'LOCAL'.
-    ls_package-as4user   = sy-uname.
+    ls_package-devclass = mv_package.
+    ls_package-ctext    = mv_package.
+    ls_package-parentcl = '$TMP'.
+    ls_package-dlvunit  = 'LOCAL'.
+    ls_package-as4user  = sy-uname.
+    ls_package-packkind = iv_abap_language_version.
 
     zif_abapgit_sap_package~create( ls_package ).
 

--- a/src/objects/sap/zif_abapgit_sap_package.intf.abap
+++ b/src/objects/sap/zif_abapgit_sap_package.intf.abap
@@ -14,6 +14,7 @@ INTERFACE zif_abapgit_sap_package
            parentcl  TYPE devclass,
            pdevclass TYPE c LENGTH 4,
            as4user   TYPE usnam,
+           packkind  TYPE uccheck,
          END OF ty_create.
 
   METHODS get
@@ -30,6 +31,8 @@ INTERFACE zif_abapgit_sap_package
     RAISING
       zcx_abapgit_exception .
   METHODS create_local
+    IMPORTING
+      iv_abap_language_version TYPE uccheck
     RAISING
       zcx_abapgit_exception .
   METHODS list_subpackages


### PR DESCRIPTION
Packages created during a pull where always created with ABAP language version "Standard" even if the repository was set to "Key User" or "Cloud Development". This led to errors like shown below (from https://github.com/greltel/abap-cloud-utilities).

The ABAP language version for new packages is now set correctly in these cases.

Also added abapdocs and some more tests for `zcl_abapgit_abap_language_vers`.

<img width="1288" height="587" alt="image" src="https://github.com/user-attachments/assets/71838a6c-edc0-495c-b048-b00d363d4e79" />

fyi, @greltel
