### PR TITLE
MSAG: Add missing message translations

### DIFF
--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -252,7 +252,15 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
       AND sprsl <> mv_language
       ORDER BY langu.                    "#EC CI_BYPASS "#EC CI_GENBUFF
 
+    SELECT DISTINCT sprsl AS langu APPENDING TABLE lt_i18n_langs
+      FROM t100
+      WHERE arbgb = lv_msg_id
+      AND sprsl IN lt_language_filter
+      AND sprsl <> mv_language
+      ORDER BY langu.                    "#EC CI_BYPASS "#EC CI_GENBUFF
+
     SORT lt_i18n_langs ASCENDING.
+    DELETE ADJACENT DUPLICATES FROM lt_i18n_langs.
 
     IF lines( lt_i18n_langs ) > 0.
 


### PR DESCRIPTION
Add missing translations, if the message class does *not* have any translations but some individual messages are translated.

Closes #7853