### PR TITLE
DTDC: Guard deserialize against unbound io_xml (#7860)

### DIFF
--- a/src/objects/zcl_abapgit_object_dtdc.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtdc.clas.abap
@@ -316,6 +316,10 @@ CLASS zcl_abapgit_object_dtdc IMPLEMENTATION.
     ASSIGN mr_dynamic_cache->* TO <ls_dynamic_cache>.
     ASSERT sy-subrc = 0.
 
+    IF io_xml IS NOT BOUND.
+      zcx_abapgit_exception=>raise( |DTDC: JSON metadata not supported for deserialize| ).
+    ENDIF.
+
     io_xml->read(
       EXPORTING
         iv_name = 'DTDC'


### PR DESCRIPTION
## Summary
- `ZCL_ABAPGIT_OBJECT_DTDC~DESERIALIZE` called `io_xml->read(...)` without checking that `io_xml` was bound. When a DTDC object's metadata is stored as JSON, `DESERIALIZE_STEP` clears `io_xml`, causing an unhandled `CX_SY_REF_IS_INITIAL` short dump (`OBJECTS_OBJREF_NOT_ASSIGNED_NO`) instead of a normal abapGit error/log entry.
- Added an `IS BOUND` guard that raises a controlled `zcx_abapgit_exception` ("DTDC: JSON metadata not supported for deserialize") so the failure is reported via the log instead of crashing the session.

Fixes #7860. Related to the XML/JSON dual-support gap in #7768.

#### Test plan
- [x] `abaplint` passes (0 issues, 1418 files analyzed)
- [ ] Manual: deserialize a repo containing a `DTDC` object with `*.dtdc.json` metadata and confirm a controlled error is logged instead of a short dump

Generated with [Devin](https://devin.ai)