### PR TITLE
Fix WebGUI keyboard actions and guard palette submissions

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -16,6 +16,7 @@ jobs:
     - run: |
         npm install
         npm run eslint
+        npm run test:ui
         npm run merge
         npm run merge.ci
     - name: Upload build artifact

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test": "npm run eslint && npm run abaplint",
+    "test": "npm run eslint && npm run test:ui && npm run abaplint",
+    "test:ui": "node --test test/ui/*.test.cjs",
     "merge": "abapmerge -f src/zabapgit.prog.abap -c zabapgit_standalone -o zabapgit.abap",
     "merge.ci": "cp zabapgit.abap ci/zabapgit_standalone.prog.abap && cd ci && abaplint --format codeframe && cd ..",
     "build": "rm -rf output && abap_transpile test/abap_transpile.json && cp -f src/ui/zabapgit_icon_font.w3mi.data.woff output/",

--- a/src/ui/lib/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.abap
@@ -576,13 +576,11 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
     IF mv_webgui = abap_true AND is_cmd-cmd_type <> zif_abapgit_html_form=>c_cmd_type-link.
       lv_action = escape( val    = is_cmd-action
                           format = cl_abap_format=>e_html_attr ).
-      lv_js = |submitSapeventForm(\{ \}, '{ lv_action }', 'post', |
+      lv_js = |submitSapeventForm(\{ \}, this.getAttribute('data-sapevent'), 'post', |
            && |document.getElementById('{ mv_form_id }'))|.
-      ii_html->add_a(
-        iv_txt   = is_cmd-label
-        iv_act   = lv_js
-        iv_typ   = zif_abapgit_html=>c_action_type-onclick
-        iv_class = lv_class ).
+      " Keep the action discoverable by hotkeys even though the link uses onclick
+      ii_html->add( |<a href="#" data-sapevent="{ lv_action }" onclick="{ lv_js }"|
+                 && | class="{ lv_class }">{ is_cmd-label }</a>| ).
       RETURN.
     ENDIF.
 
@@ -982,7 +980,8 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
         lv_side_action = escape( val    = is_field-side_action
                                  format = cl_abap_format=>e_html_attr ).
         ii_html->add( |<input type="button" value="&#x2026;" title="{ is_field-label }"|
-                   && | onclick="submitSapeventForm(\{ \}, '{ lv_side_action }', 'post', |
+                   && | data-sapevent="{ lv_side_action }"|
+                   && | onclick="submitSapeventForm(\{ \}, this.getAttribute('data-sapevent'), 'post', |
                    && |document.getElementById('{ mv_form_id }'))">| ).
       ELSE.
         ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }"|

--- a/src/ui/lib/zcl_abapgit_html_form.clas.testclasses.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.testclasses.abap
@@ -1,0 +1,71 @@
+CLASS ltcl_webgui_actions DEFINITION DEFERRED.
+CLASS zcl_abapgit_html_form DEFINITION LOCAL FRIENDS ltcl_webgui_actions.
+
+CLASS ltcl_webgui_actions DEFINITION FINAL FOR TESTING
+  DURATION SHORT RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    DATA mo_form TYPE REF TO zcl_abapgit_html_form.
+    DATA mi_html TYPE REF TO zif_abapgit_html.
+
+    METHODS setup.
+    METHODS command_marker FOR TESTING.
+    METHODS picker_marker FOR TESTING.
+
+ENDCLASS.
+
+CLASS ltcl_webgui_actions IMPLEMENTATION.
+
+  METHOD setup.
+    CREATE OBJECT mo_form.
+    mo_form->mv_webgui = abap_true.
+    mo_form->mv_form_id = 'test_form'.
+    mi_html = zcl_abapgit_html=>create( ).
+  ENDMETHOD.
+
+  METHOD command_marker.
+    DATA ls_command TYPE zif_abapgit_html_form=>ty_command.
+    DATA lv_html TYPE string.
+
+    ls_command-label = 'Save'.
+    ls_command-action = 'save?key=1&name=example'.
+    ls_command-cmd_type = zif_abapgit_html_form=>c_cmd_type-input_main.
+    mo_form->render_command(
+      ii_html = mi_html
+      is_cmd  = ls_command ).
+    lv_html = mi_html->render( ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lv_html
+      exp = '*data-sapevent="save?key=1&amp;name=example"*' ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lv_html
+      exp = |*submitSapeventForm(\{ \}, this.getAttribute('data-sapevent'), 'post', *| ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lv_html
+      exp = '*class="dialog-commands main">Save</a>*' ).
+  ENDMETHOD.
+
+  METHOD picker_marker.
+    DATA ls_field TYPE zif_abapgit_html_form=>ty_field.
+    DATA ls_attr TYPE zcl_abapgit_html_form=>ty_attr.
+    DATA lv_html TYPE string.
+
+    ls_field-name = 'package'.
+    ls_field-label = 'Package'.
+    ls_field-side_action = 'choose_package'.
+    mo_form->render_field_text(
+      ii_html  = mi_html
+      is_field = ls_field
+      is_attr  = ls_attr ).
+    lv_html = mi_html->render( ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lv_html
+      exp = '*type="button"*data-sapevent="choose_package"*' ).
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lv_html
+      exp = |*submitSapeventForm(\{ \}, this.getAttribute('data-sapevent'), 'post', *| ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/lib/zcl_abapgit_html_form.clas.xml
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.xml
@@ -10,6 +10,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -338,10 +338,7 @@ function submitSapeventForm(params, action, method, form) {
     }
   }
 
-  // Mark that the popstate the browser control may emit while handling this
-  // sapevent navigation is self-initiated, not a user Back press
-  gSapeventNavPending = true;
-  form.submit();
+  submitForm(form);
 }
 
 // Trigger a server-rendered sapevent element (anchor / submit input) the way a
@@ -352,8 +349,12 @@ function submitSapeventForm(params, action, method, form) {
 // arm the flag - it would never be consumed and the next genuine Back press
 // would be swallowed.
 function clickSapEvent(element) {
+  // Main submit inputs inherit the event from their form rather than carrying
+  // a formaction of their own.
+  var formAction = element.type === "submit" && element.form
+    ? element.form.getAttribute("action") : "";
   var isSapEvent = element.getAttribute("data-sapevent")
-    || /sapevent/i.test(element.hrefsav || element.href || element.getAttribute("formaction") || "");
+    || /sapevent/i.test(element.hrefsav || element.href || element.getAttribute("formaction") || formAction || "");
   if (isSapEvent) gSapeventNavPending = true;
   element.click();
 }
@@ -385,9 +386,13 @@ function setInitialFocusWithQuerySelector(sSelector, bFocusParent) {
 // popstate as a user Back press and fires go_back, which supersedes the submit:
 // the page returns without saving on the Edge control, while the IE control -
 // where the trap never arms - is unaffected.
-function submitFormById(id) {
+function submitForm(form) {
   gSapeventNavPending = true;
-  document.getElementById(id).submit();
+  form.submit();
+}
+
+function submitFormById(id) {
+  submitForm(document.getElementById(id));
 }
 
 // Confirm JS initialization
@@ -1784,12 +1789,12 @@ LinkHints.prototype.hintActivate = function(hint) {
     this.toggleCheckbox(hint);
   } else if (hint.parent.type === "radio") {
     this.toggleRadioButton(hint);
-  } else if (hint.parent.type === "submit") {
-    hint.parent.click();
+  } else if (hint.parent.type === "submit" || hint.parent.type === "button") {
+    clickSapEvent(hint.parent);
   } else if (hint.parent.nodeName === "INPUT" || hint.parent.nodeName === "TEXTAREA") {
     hint.parent.focus();
   } else {
-    hint.parent.click();
+    clickSapEvent(hint.parent);
     if (this.activatedDropdown) this.closeActivatedDropdown();
   }
 };
@@ -2564,12 +2569,14 @@ function enumerateUiActions() {
   });
 
   // forms
-  [].slice.call(document.querySelectorAll("input[type='submit']"))
+  [].slice.call(document.querySelectorAll("input[type='submit'], input[type='button'][data-sapevent]"))
     .forEach(function(input) {
       items.push({
         action: function() {
-          if (input.form.action.includes(input.formAction) || input.classList.contains("main")) {
-            input.form.submit();
+          if (input.type === "button") {
+            clickSapEvent(input);
+          } else if (input.form.action.includes(input.formAction) || input.classList.contains("main")) {
+            submitForm(input.form);
           } else {
             submitSapeventForm({}, input.formAction, "post", input.form);
           }
@@ -2772,7 +2779,7 @@ function findSapEventElements(action) {
   // pattern (\b still assumes word-shaped action names, which all current are)
   var re = new RegExp("\\b" + action.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\b");
   return [].slice
-    .call(document.querySelectorAll("a, input[type='submit']"))
+    .call(document.querySelectorAll("a, input[type='submit'], input[type='button'][data-sapevent]"))
     .filter(function(el) {
       var target = el.getAttribute("data-sapevent");
       if (!target) {

--- a/test/README.md
+++ b/test/README.md
@@ -20,6 +20,11 @@ Note that the integration tests are not installed on systems, edit in vscode or 
 
 ## Integration Testing - UI
 
+Run `npm run test:ui` for JavaScript action-dispatch regression tests using
+mocked DOM and browser-history objects. These run in PR CI and cover hotkeys,
+link hints, command palettes, and the submit navigation guard. They do not
+replace testing in SAP GUI for Windows, SAP GUI for Java, and WebGUI.
+
 Playwright, https://playwright.dev
 
 todo, webpack and mocked git/repos?

--- a/test/ui/sapevents.test.cjs
+++ b/test/ui/sapevents.test.cjs
@@ -1,0 +1,140 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "../../src/ui/zabapgit_js_common.w3mi.data.js"), "utf8");
+
+// Model only the DOM surface used by action discovery and dispatch. The event
+// ordering is deliberate: embedded controls can emit popstate during submit.
+function page(elements = []) {
+  const listeners = {};
+  const context = {
+    document: {
+      addEventListener() {},
+      querySelectorAll(selector) {
+        return elements.filter(element => selector.split(", ").some(part => {
+          const simple = part.match(/^([a-z]+)(\[[^\]]+\])*$/);
+          if (!simple) return false; // No toolbars or nested links in these fixtures
+          const tag = simple[1];
+          if (element.nodeName !== tag.toUpperCase()) return false;
+          const attrs = [...part.matchAll(/\[([^=\]]+)(?:='([^']*)')?\]/g)];
+          return attrs.every(([, name, value]) => value === undefined
+            ? element.getAttribute(name) !== null : element.getAttribute(name) === value);
+        }));
+      },
+      querySelector() { return null; },
+      getElementById(id) { return elements.find(element => element.id === id); }
+    },
+    history: { pushState() {} },
+    addEventListener(name, fn) { listeners[name] = fn; }
+  };
+  context.window = context;
+  vm.createContext(context);
+  vm.runInContext(source, context);
+  context.popstate = () => listeners.popstate();
+  return context;
+}
+
+function element(nodeName, attrs = {}) {
+  return {
+    nodeName,
+    type: attrs.type,
+    title: attrs.title || "",
+    value: attrs.value || "",
+    href: attrs.href,
+    getAttribute(name) { return attrs[name] === undefined ? null : attrs[name]; },
+    classList: { contains(name) { return (attrs.class || "").split(" ").includes(name); } }
+  };
+}
+
+test("Enter finds and clicks a WebGUI dialog command with a rewritten href", () => {
+  const command = element("A", { "data-sapevent": "save", href: "https://host/webgui#" });
+  const context = page([command]);
+  let clicks = 0;
+  let prevented = false;
+  command.click = () => { clicks++; assert.equal(context.gSapeventNavPending, true); };
+  const hotkeys = new context.Hotkeys({ Enter: "save" });
+  hotkeys.onkeydown({ key: "Enter", preventDefault() { prevented = true; } });
+  assert.equal(clicks, 1);
+  assert.equal(prevented, true);
+  assert.match(command.title, /\[Enter\]/);
+});
+
+test("WebGUI picker is discoverable by action and by command palette", () => {
+  const picker = element("INPUT", { type: "button", "data-sapevent": "choose_package", title: "Package" });
+  const unrelated = element("INPUT", { type: "button", title: "Unrelated" });
+  const context = page([picker, unrelated]);
+  let clicks = 0;
+  picker.click = () => { clicks++; assert.equal(context.gSapeventNavPending, true); };
+  assert.equal(context.findSapEventElement("choose_package"), picker);
+  const commands = context.enumerateUiActions();
+  assert.equal(commands.length, 1);
+  assert.match(commands[0].title, /Package/);
+  commands[0].action();
+  assert.equal(clicks, 1);
+});
+
+for (const type of ["button", "submit"]) {
+  test(`link hints activate ${type} actions with the navigation guard`, () => {
+    const input = element("INPUT", { type, "data-sapevent": "choose_package" });
+    const context = page();
+    let clicks = 0;
+    input.focus = () => assert.fail("Action must be clicked, not merely focused");
+    input.click = () => { clicks++; assert.equal(context.gSapeventNavPending, true); };
+    new context.LinkHints("f").hintActivate({ parent: input });
+    assert.equal(clicks, 1);
+  });
+}
+
+test("link hints guard main submits inheriting the form action", () => {
+  const input = element("INPUT", { type: "submit" });
+  input.form = element("FORM", { action: "SAPEVENT:save" });
+  const context = page();
+  input.click = () => assert.equal(context.gSapeventNavPending, true);
+  new context.LinkHints("f").hintActivate({ parent: input });
+});
+
+test("link hints guard sapevent links but leave ordinary links unarmed", () => {
+  for (const href of ["SAPEVENT:go_back", "https://example.org/"]) {
+    const anchor = element("A", { href });
+    const context = page();
+    context.document.location = { href: "https://host/webgui" };
+    anchor.click = () => assert.equal(context.gSapeventNavPending, href.startsWith("SAPEVENT:"));
+    new context.LinkHints("f").hintActivate({ parent: anchor });
+  }
+});
+
+test("palette main submit preserves the form and ignores submit-induced popstate", () => {
+  const input = element("INPUT", { type: "submit", class: "main", value: "Save" });
+  input.formAction = "https://host/current-page";
+  const context = page([input]);
+  let submits = 0;
+  let backs = 0;
+  const form = { action: "SAPEVENT:save", elements: [{ name: "message", value: "keep me" }] };
+  form.submit = function() {
+    assert.equal(this, form);
+    assert.equal(this.elements[0].value, "keep me");
+    assert.equal(context.gSapeventNavPending, true);
+    submits++;
+    context.popstate();
+  };
+  input.form = form;
+  context.redirectBrowserBackToSapEvent();
+  context.triggerSapEventBack = () => backs++;
+  context.enumerateUiActions()[0].action();
+  assert.equal(submits, 1);
+  assert.equal(backs, 0);
+  context.popstate();
+  assert.equal(backs, 1);
+});
+
+test("submitFormById keeps guarding server-rendered forms", () => {
+  const form = { id: "edit_form" };
+  const context = page([form]);
+  let submits = 0;
+  form.submit = () => { submits++; assert.equal(context.gSapeventNavPending, true); };
+  context.submitFormById(form.id);
+  assert.equal(submits, 1);
+});


### PR DESCRIPTION
 Fix WebGUI dialog hotkeys, picker keyboard actions, and palette submission navigation.

The recent WebGUI improvements fixed form submission, but some keyboard paths did not recognize the updated controls. Command-palette submissions also bypassed the navigation guard added in #7830.

  This PR fixes three related issues:

  - Dialog hotkeys: Preserve data-sapevent on WebGUI dialog commands so hotkey lookup can find the action and annotate its tooltip.
  - Picker buttons: Include WebGUI side-action buttons, such as package and branch pickers, in the command palette. Selecting their link hint now activates the picker instead of only focusing it.
  - Submission navigation: Route palette submissions through a shared navigation guard. Guard link-hint activation as well, including submit inputs that inherit their action from the form. This prevents a submission-induced popstate
    from incorrectly triggering Back.

  Adds eight JavaScript regression tests and two ABAP rendering tests, with JavaScript tests included in PR CI.

Successfully Tested with latest versions of:
- [x] SAP GUI for HTML
- [x] SAP GUI for Windows
- [x] SAP GUI for Java