### PR TITLE
Expand UI tests and fix command palette filtering

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -2393,9 +2393,11 @@ CommandPalette.prototype.applySelectIndex = function(newIndex) {
   if (newIndex !== this.selectIndex) {
     if (this.selectIndex >= 0) this.commands[this.selectIndex].element.classList.remove("selected");
     var newCmd = this.commands[newIndex];
-    newCmd.element.classList.add("selected");
     this.selectIndex = newIndex;
-    this.adjustScrollPosition(newCmd.element);
+    if (newCmd) {
+      newCmd.element.classList.add("selected");
+      this.adjustScrollPosition(newCmd.element);
+    }
   }
 };
 
@@ -2403,8 +2405,9 @@ CommandPalette.prototype.selectFirst = function() {
   for (var i = 0; i < this.commands.length; i++) {
     if (this.commands[i].element.style.display === "none") continue; // skip hidden
     this.applySelectIndex(i);
-    break;
+    return;
   }
+  this.applySelectIndex(-1);
 };
 
 CommandPalette.prototype.selectNext = function() {
@@ -2462,6 +2465,7 @@ CommandPalette.prototype.toggleDisplay = function(forceState) {
       if (cmd.getTitle) cmd.title = cmd.getTitle();
     });
     this.elements.input.value = "";
+    this.filter = "";
     this.elements.input.focus();
     this.applyFilter();
     this.selectFirst();

--- a/test/ui/README.md
+++ b/test/ui/README.md
@@ -1,0 +1,55 @@
+# JavaScript UI tests
+
+These tests use Node's built-in test runner and require no SAP system or browser.
+Run them from the repository root:
+
+```sh
+npm run test:ui
+```
+
+To show individual test results on Node versions that support disabling test
+isolation:
+
+```sh
+node --test --test-isolation=none --test-reporter=spec test/ui/*.test.cjs
+```
+
+`npm test` runs ESLint, these UI tests, and ABAP lint. ABAP lint may need network
+access to fetch its configured dependency.
+
+## Test setup
+
+[`load-ui.cjs`](load-ui.cjs) evaluates the shipped
+[`zabapgit_js_common.w3mi.data.js`](../../src/ui/zabapgit_js_common.w3mi.data.js)
+in a fresh VM context for each call. The context supplies a browser-like `window`
+global; each test provides the DOM methods and other globals it needs.
+
+Add tests in `*.test.cjs` files using `node:test` and `node:assert/strict`. Keep DOM
+fixtures small and specific to the behavior under test. Assert observable results
+such as dispatched actions, submitted fields, visible commands, and selection.
+Exercise the shipped functions rather than copying their implementation into tests.
+Avoid expanding the fixtures into a general-purpose browser emulator.
+
+## Coverage
+
+| File | Behavior covered |
+| --- | --- |
+| [`sapevents.test.cjs`](sapevents.test.cjs) | Action discovery, keyboard and link-hint activation, and navigation guards |
+| [`forms.test.cjs`](forms.test.cjs) | Desktop and WebGUI form routing, parameter encoding, repeated submissions, and preservation of existing fields |
+| [`stage.test.cjs`](stage.test.cjs) | Commit and patch actions, selection/filter precedence, visible-file staging, and selection counts |
+| [`palette.test.cjs`](palette.test.cjs) | Filtering, keyboard navigation, command execution, reopening, and fuzzy matching |
+
+Important regression expectations:
+
+- Explicit staging selections take precedence over filters, even when selected
+  files are hidden by the filter.
+- A staging filter with no matches must not fall back to committing everything.
+- A command palette with no matches must clear its selection so Enter does nothing.
+- Reopening the palette must reset both the search field and the active filter.
+
+## Limits
+
+The fixtures model only the DOM operations needed by each test. They do not verify
+browser layout, scrolling geometry, native event ordering, or actual SAP GUI/WebGUI
+integration. Changes that depend on those behaviors still need testing in the
+relevant browser control.

--- a/test/ui/forms.test.cjs
+++ b/test/ui/forms.test.cjs
@@ -1,0 +1,130 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const loadUi = require("./load-ui.cjs");
+
+function field(attrs = {}) {
+  return {
+    attrs: { ...attrs },
+    value: attrs.value,
+    setAttribute(name, value) {
+      this.attrs[name] = String(value);
+      if (name === "value") this.value = String(value);
+    }
+  };
+}
+
+// Only the form/field operations used by submitSapeventForm are modeled here.
+function page({ action = "SAPEVENT:old", fields = [], webgui = false, global = true, prefix = "" } = {}) {
+  const submissions = [];
+  const form = {
+    id: "global_sapevent_form",
+    attrs: { action },
+    elements: fields,
+    getAttribute(name) { return this.attrs[name] ?? null; },
+    setAttribute(name, value) { this.attrs[name] = value; },
+    querySelectorAll(selector) {
+      if (selector === "input[name='PARAMS']") return this.elements.filter(f => f.attrs.name === "PARAMS");
+      assert.equal(selector, "input[data-sapevent-field]");
+      return this.elements.filter(f => "data-sapevent-field" in f.attrs);
+    },
+    appendChild(input) { input.parentNode = this; this.elements.push(input); },
+    removeChild(input) { this.elements.splice(this.elements.indexOf(input), 1); },
+    submit() {
+      assert.equal(context.gSapeventNavPending, true);
+      submissions.push({
+        action: this.attrs.action,
+        method: this.attrs.method,
+        fields: this.elements.map(f => ({ name: f.attrs.name, value: f.value }))
+      });
+    }
+  };
+  fields.forEach(f => { f.parentNode = form; });
+  const context = loadUi({ document: {
+    addEventListener() {},
+    getElementById(id) { return global && id === form.id ? form : null; },
+    querySelector() { return null; },
+    createElement(tag) {
+      assert.equal(tag, "input");
+      return field();
+    },
+    body: { appendChild(node) { assert.equal(node, form); } }
+  } });
+  context.setEnvironment({ isWebGui: webgui });
+  context.gSapeventPrefix = prefix;
+  return { context, form, submissions };
+}
+
+for (const prefix of ["", "file:///", "sap-cust://sap-place-holder/"]) {
+  test(`desktop submission uses the configured prefix ${JSON.stringify(prefix)}`, () => {
+    const { context, submissions } = page({ prefix });
+    context.submitSapeventForm({ message: "a & b" }, "save");
+    assert.deepEqual(submissions, [{
+      action: prefix + "SAPEVENT:save", method: "post",
+      fields: [{ name: "message", value: "a & b" }]
+    }]);
+  });
+}
+
+test("an explicit desktop sapevent URL is preserved", () => {
+  const { context, submissions } = page({ prefix: "file:///" });
+  context.submitSapeventForm({}, "sap-cust://sap-place-holder/SAPEVENT:save?key=1");
+  assert.equal(submissions[0].action, "sap-cust://sap-place-holder/SAPEVENT:save?key=1");
+});
+
+test("WebGUI updates every PARAMS field and preserves ITS routing fields and action", () => {
+  const fields = [field({ name: "PARAMS", value: "old" }), field({ name: "PARAMS", value: "other" }),
+    field({ name: "~control", value: "116" }), field({ name: "~event", value: "OnSAPEvent" })];
+  const { context, submissions } = page({ webgui: true, action: "https://host/webgui", fields });
+  context.submitSapeventForm({ message: "keep me" }, "save?key=a&other=b");
+  assert.deepEqual(submissions[0], {
+    action: "https://host/webgui", method: "post",
+    fields: [
+      { name: "PARAMS", value: "save?key=a&other=b" },
+      { name: "PARAMS", value: "save?key=a&other=b" },
+      { name: "~control", value: "116" }, { name: "~event", value: "OnSAPEvent" },
+      { name: "message", value: "keep me" }
+    ]
+  });
+});
+
+test("WebGUI action routing encodes the event without changing the routing prefix", () => {
+  const routing = "https://host/webgui?~control=116&~event=OnSAPEvent&ALINK=1&frameName=&PARAMS=";
+  const { context, submissions } = page({ webgui: true, action: routing + "old" });
+  context.submitSapeventForm({}, "save?key=100%&value=a+b#c");
+  assert.equal(submissions[0].action, routing + "save?key=100%25%26value=a%2Bb%23c");
+});
+
+for (const action of ["search", "search?repo=1"]) {
+  test(`GET parameters survive WebGUI POST conversion for ${action}`, () => {
+    const { context, submissions } = page({ webgui: true, fields: [field({ name: "PARAMS", value: "old" })] });
+    context.submitSapeventForm({ "search term": "a &+#%ä" }, action, "GET");
+    assert.deepEqual(submissions[0].fields, [{
+      name: "PARAMS", value: action + (action.includes("?") ? "&" : "?") + "search%20term=a%20%26%2B%23%25%C3%A4"
+    }]);
+    assert.equal(submissions[0].method, "post");
+  });
+}
+
+test("reusing the global form removes only previously generated fields", () => {
+  const { context, submissions } = page({ webgui: true, fields: [
+    field({ name: "PARAMS", value: "old" }), field({ name: "token", value: "keep" })
+  ] });
+  context.submitSapeventForm({ filterValue: "first" }, "stage_filter");
+  context.submitSapeventForm({ filterValue: "second" }, "stage_filter");
+  context.submitSapeventForm({}, "go_back");
+  assert.deepEqual(submissions.map(s => s.fields), [
+    [{ name: "PARAMS", value: "stage_filter" }, { name: "token", value: "keep" }, { name: "filterValue", value: "first" }],
+    [{ name: "PARAMS", value: "stage_filter" }, { name: "token", value: "keep" }, { name: "filterValue", value: "second" }],
+    [{ name: "PARAMS", value: "go_back" }, { name: "token", value: "keep" }]
+  ]);
+});
+
+test("an explicitly supplied ITS form keeps user fields and normalizes valueless elements", () => {
+  const { context, form, submissions } = page({ webgui: true, global: false, fields: [
+    field({ name: "PARAMS", value: "old" }), field({ name: "message", value: "keep me" }), field()
+  ] });
+  context.submitSapeventForm({}, "save", "post", form);
+  assert.deepEqual(submissions[0].fields, [
+    { name: "PARAMS", value: "save" }, { name: "message", value: "keep me" }, { name: undefined, value: "" }
+  ]);
+});

--- a/test/ui/forms.test.cjs
+++ b/test/ui/forms.test.cjs
@@ -30,7 +30,10 @@ function page({ action = "SAPEVENT:old", fields = [], webgui = false, global = t
     appendChild(input) { input.parentNode = this; this.elements.push(input); },
     removeChild(input) { this.elements.splice(this.elements.indexOf(input), 1); },
     submit() {
+      // Every submit has to arm the browser-back guard, not just the first one:
+      // consume the flag so a later submit that forgot to set it is caught too.
       assert.equal(context.gSapeventNavPending, true);
+      context.gSapeventNavPending = false;
       submissions.push({
         action: this.attrs.action,
         method: this.attrs.method,

--- a/test/ui/load-ui.cjs
+++ b/test/ui/load-ui.cjs
@@ -1,0 +1,18 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "../../src/ui/zabapgit_js_common.w3mi.data.js"), "utf8");
+
+// Evaluate the shipped script in a fresh browser global for every test.
+module.exports = function loadUi(overrides = {}) {
+  const context = {
+    document: { addEventListener() {} },
+    addEventListener() {},
+    ...overrides
+  };
+  context.window = context;
+  vm.createContext(context);
+  vm.runInContext(source, context);
+  return context;
+};

--- a/test/ui/palette.test.cjs
+++ b/test/ui/palette.test.cjs
@@ -1,0 +1,138 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const loadUi = require("./load-ui.cjs");
+
+function page(titles = ["Open Repo", "Save", "Open Settings"]) {
+  // Model construction and event dispatch, with fixed geometry: these tests
+  // exercise selection and actions, not browser layout or scrolling.
+  function element(tag) {
+    const classes = new Set();
+    return {
+      nodeName: tag.toUpperCase(), style: {}, children: [], listeners: {},
+      value: "", scrollTop: 0,
+      classList: {
+        add(name) { classes.add(name); },
+        remove(name) { classes.delete(name); },
+        contains(name) { return classes.has(name); }
+      },
+      appendChild(child) { child.parentNode = this; this.children.push(child); },
+      addEventListener(name, fn) { this.listeners[name] = fn; },
+      focus() {},
+      getBoundingClientRect() { return { top: 0, bottom: 100, height: 100 }; }
+    };
+  }
+  const context = loadUi({ document: {
+    addEventListener() {}, querySelector() { return null; },
+    createElement: element, body: element("body")
+  } });
+  const actions = [];
+  const palette = new context.CommandPalette(() => titles.map(title => ({
+    title, action() { actions.push(title); }
+  })), { toggleKey: "F1", hotkeyDescription: "Commands" });
+  palette.toggleDisplay(true);
+  function key(key) {
+    let prevented = false;
+    palette.elements.input.listeners.keyup({ key, preventDefault() { prevented = true; } });
+    assert.equal(prevented, true);
+  }
+  function filter(value) {
+    palette.elements.input.value = value;
+    key("x");
+  }
+  function selected() {
+    return palette.commands.filter(cmd => cmd.element.classList.contains("selected")).map(cmd => cmd.title);
+  }
+  return { palette, actions, key, filter, selected };
+}
+
+test("Enter after a filter with no matches does not execute the previous selection", () => {
+  const { palette, actions, key, filter, selected } = page();
+  key("ArrowDown");
+  filter("no such command");
+  key("Enter");
+  assert.deepEqual(actions, []);
+  assert.deepEqual(selected(), []);
+  assert.equal(palette.getSelected(), undefined);
+  assert.equal(palette.elements.palette.style.display, "");
+});
+
+for (const [up, down] of [["ArrowUp", "ArrowDown"], ["Up", "Down"]]) {
+  test(`${up}/${down} skip hidden commands and stop at list boundaries`, () => {
+    const { filter, key, selected } = page();
+    filter("open");
+    key(up);
+    assert.deepEqual(selected(), ["Open Repo"]);
+    key(down);
+    assert.deepEqual(selected(), ["Open Settings"]);
+    key(down);
+    assert.deepEqual(selected(), ["Open Settings"]);
+    key(up);
+    assert.deepEqual(selected(), ["Open Repo"]);
+  });
+}
+
+test("changing the filter selects the first matching command and Enter executes it once", () => {
+  const { palette, actions, key, filter, selected } = page();
+  key("ArrowDown");
+  key("ArrowDown");
+  filter("save");
+  assert.deepEqual(selected(), ["Save"]);
+  key("Enter");
+  assert.deepEqual(actions, ["Save"]);
+  assert.equal(palette.elements.palette.style.display, "none");
+});
+
+test("clearing a filter restores all titles and selects the first command", () => {
+  const { palette, filter, selected } = page();
+  filter("save");
+  filter("");
+  assert.deepEqual(selected(), ["Open Repo"]);
+  for (const cmd of palette.commands) {
+    assert.equal(cmd.element.style.display, "");
+    assert.equal(cmd.titleSpan.innerText, cmd.title);
+  }
+});
+
+test("selection recovers when a no-match filter is replaced with a match", () => {
+  const { filter, selected, key, actions } = page();
+  filter("zzzz");
+  filter("settings");
+  assert.deepEqual(selected(), ["Open Settings"]);
+  key("Enter");
+  assert.deepEqual(actions, ["Open Settings"]);
+});
+
+test("an empty command list tolerates navigation and Enter", () => {
+  const { key, actions, selected } = page([]);
+  key("ArrowDown");
+  key("ArrowUp");
+  key("Enter");
+  assert.deepEqual(actions, []);
+  assert.deepEqual(selected(), []);
+});
+
+test("reopening a filtered palette resets both the search field and visible results", () => {
+  const { palette, filter, selected } = page();
+  filter("save");
+  palette.toggleDisplay(false);
+  palette.toggleDisplay(true);
+  assert.equal(palette.elements.input.value, "");
+  assert.deepEqual(palette.commands.map(cmd => cmd.element.style.display), ["", "", ""]);
+  assert.deepEqual(selected(), ["Open Repo"]);
+});
+
+for (const [title, filter, expected] of [
+  ["Open Repo", "or", "<mark>O</mark>pen <mark>R</mark>epo"],
+  ["Open Repo", "oR", "<mark>O</mark>pen <mark>R</mark>epo"],
+  ["Save", "save", "<mark>S</mark><mark>a</mark><mark>v</mark><mark>e</mark>"],
+  ["Open Repo", "", "Open Repo"],
+  ["", "", ""],
+  ["", "a", null],
+  ["Save", "saved", null],
+  ["abc", "ca", null],
+  ["aba", "aa", "<mark>a</mark>b<mark>a</mark>"]
+]) {
+  test(`fuzzy matching ${JSON.stringify(title)} with ${JSON.stringify(filter)}`, () => {
+    assert.equal(loadUi().fuzzyMatchAndMark(title, filter), expected);
+  });
+}

--- a/test/ui/palette.test.cjs
+++ b/test/ui/palette.test.cjs
@@ -30,10 +30,10 @@ function page(titles = ["Open Repo", "Save", "Open Settings"]) {
     title, action() { actions.push(title); }
   })), { toggleKey: "F1", hotkeyDescription: "Commands" });
   palette.toggleDisplay(true);
+  // Invoke the registered keyup handler; this fixture does not simulate
+  // browser default actions or the preceding keydown/keypress events.
   function key(key) {
-    let prevented = false;
-    palette.elements.input.listeners.keyup({ key, preventDefault() { prevented = true; } });
-    assert.equal(prevented, true);
+    palette.elements.input.listeners.keyup({ key, preventDefault() {} });
   }
   function filter(value) {
     palette.elements.input.value = value;

--- a/test/ui/sapevents.test.cjs
+++ b/test/ui/sapevents.test.cjs
@@ -1,16 +1,13 @@
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const path = require("node:path");
 const test = require("node:test");
-const vm = require("node:vm");
 
-const source = fs.readFileSync(path.join(__dirname, "../../src/ui/zabapgit_js_common.w3mi.data.js"), "utf8");
+const loadUi = require("./load-ui.cjs");
 
 // Model only the DOM surface used by action discovery and dispatch. The event
 // ordering is deliberate: embedded controls can emit popstate during submit.
 function page(elements = []) {
   const listeners = {};
-  const context = {
+  const context = loadUi({
     document: {
       addEventListener() {},
       querySelectorAll(selector) {
@@ -29,10 +26,7 @@ function page(elements = []) {
     },
     history: { pushState() {} },
     addEventListener(name, fn) { listeners[name] = fn; }
-  };
-  context.window = context;
-  vm.createContext(context);
-  vm.runInContext(source, context);
+  });
   context.popstate = () => listeners.popstate();
   return context;
 }

--- a/test/ui/stage.test.cjs
+++ b/test/ui/stage.test.cjs
@@ -1,0 +1,124 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const loadUi = require("./load-ui.cjs");
+
+function cell(className, text) {
+  return {
+    className, innerText: text, innerHTML: text, children: [],
+    classList: { add() {}, remove() {} },
+    // These fixtures contain plain cells, with no links or link hints.
+    getElementsByTagName() { return []; },
+    cloneNode() { return { textContent: text, querySelectorAll() { return []; } }; }
+  };
+}
+
+function page() {
+  const rows = [
+    { className: "local", name: "zcl_keep.clas.abap" },
+    { className: "remote", name: "zcl_keep_old.clas.abap" },
+    { className: "local", name: "zcl_hidden.clas.abap" }
+  ].map(({ className, name }) => ({
+    className, style: { display: "" },
+    cells: [cell("name", name), cell("user", "CHRIS"), cell("transport", "DEVK900001"), cell("status", "?"), cell("cmd", "")]
+  }));
+  const nodes = {
+    table: { tBodies: [{ rows }], style: { display: "" } },
+    commit: { innerHTML: "Add All and Commit (3)" },
+    patch: { innerHTML: "Patch All (3)" },
+    search: { value: "" }
+  };
+  const context = loadUi({
+    document: {
+      addEventListener() {},
+      getElementById(id) { return nodes[id]; },
+      querySelector() { return null; }
+    },
+    scrollTo() {},
+    alert(message) { assert.fail(message); }
+  });
+  const submissions = [];
+  // Observe the staging-to-form boundary; forms.test.cjs exercises transport.
+  context.submitSapeventForm = (params, action) => submissions.push({ params: { ...params }, action });
+  const helper = new context.StageHelper({
+    seed: "stage", formAction: "stage_commit", patchAction: "stage_patch", stageAllAction: "stage_all",
+    ids: { stageTab: "table", commitBtn: "commit", patchBtn: "patch", objectSearch: "search" }
+  });
+  return { helper, rows, nodes, submissions };
+}
+
+test("commit without selection or filter uses the stage-all action", () => {
+  const { nodes, submissions } = page();
+  nodes.commit.onclick();
+  assert.deepEqual(submissions, [{ params: {}, action: "stage_all" }]);
+});
+
+test("filtering then committing adds matching local files and removes matching remote files", () => {
+  const { helper, rows, nodes, submissions } = page();
+  helper.applyFilterValue("KEEP");
+  assert.deepEqual(rows.map(row => row.style.display), ["", "", "none"]);
+  assert.equal(nodes.commit.innerHTML, "Add <b>Filtered</b> and Commit (2)");
+  nodes.commit.onclick();
+  assert.deepEqual(submissions, [{ action: "stage_commit", params: {
+    "zcl_keep.clas.abap": "A", "zcl_keep_old.clas.abap": "R", "zcl_hidden.clas.abap": "?"
+  } }]);
+  assert.equal(helper.selectedCount, 2);
+});
+
+for (const button of ["commit", "patch"]) {
+  test(`explicit selection takes precedence over the filter for ${button}`, () => {
+    const { helper, rows, nodes, submissions } = page();
+    helper.updateRow(rows[2], helper.STATUS.add);
+    helper.applyFilterValue("keep");
+    assert.equal(nodes[button].innerHTML, (button === "commit" ? "Commit" : "Patch") + " <b>Selected</b> (1)");
+    nodes[button].onclick();
+    assert.deepEqual(submissions, [{ action: button === "commit" ? "stage_commit" : "stage_patch", params: {
+      "zcl_keep.clas.abap": "?", "zcl_keep_old.clas.abap": "?", "zcl_hidden.clas.abap": "A"
+    } }]);
+  });
+}
+
+test("filtered patch submission includes only matching files", () => {
+  const { helper, nodes, submissions } = page();
+  helper.applyFilterValue("keep");
+  assert.equal(nodes.patch.innerHTML, "Patch <b>Filtered</b> (2)");
+  nodes.patch.onclick();
+  assert.deepEqual(submissions, [{ action: "stage_patch", params: {
+    "zcl_keep.clas.abap": "A", "zcl_keep_old.clas.abap": "R", "zcl_hidden.clas.abap": "?"
+  } }]);
+});
+
+test("clearing a filter restores all rows and the default commit action", () => {
+  const { helper, rows, nodes, submissions } = page();
+  helper.applyFilterValue("keep");
+  helper.applyFilterValue("");
+  assert.deepEqual(rows.map(row => row.style.display), ["", "", ""]);
+  assert.equal(nodes.commit.innerHTML, "Add All and Commit (3)");
+  assert.equal(nodes.patch.innerHTML, "Patch All (3)");
+  nodes.commit.onclick();
+  assert.deepEqual(submissions, [{ action: "stage_all", params: {} }]);
+});
+
+test("a filter with no matches does not fall back to committing everything", () => {
+  const { helper, nodes, submissions } = page();
+  helper.applyFilterValue("no_such_file");
+  assert.equal(nodes.commit.innerHTML, "Add <b>Filtered</b> and Commit (0)");
+  nodes.commit.onclick();
+  assert.deepEqual(submissions, [{ action: "stage_commit", params: {
+    "zcl_keep.clas.abap": "?", "zcl_keep_old.clas.abap": "?", "zcl_hidden.clas.abap": "?"
+  } }]);
+});
+
+test("changing a selected status does not double-count and resetting restores filtered mode", () => {
+  const { helper, rows, nodes } = page();
+  helper.applyFilterValue("keep");
+  helper.updateRow(rows[1], helper.STATUS.ignore);
+  helper.updateRow(rows[1], helper.STATUS.remove);
+  helper.updateRow(rows[1], helper.STATUS.remove);
+  helper.updateMenu();
+  assert.equal(helper.selectedCount, 1);
+  assert.equal(nodes.commit.innerHTML, "Commit <b>Selected</b> (1)");
+  helper.updateRow(rows[1], helper.STATUS.reset);
+  helper.updateMenu();
+  assert.equal(helper.selectedCount, 0);
+  assert.equal(nodes.commit.innerHTML, "Add <b>Filtered</b> and Commit (2)");
+});


### PR DESCRIPTION
Adds JavaScript tests for form submission, staging, and command palette behavior using the existing Node/VM test setup.

  The palette tests exposed two bugs, fixed in this PR:

  - Pressing Enter after filtering to zero matches executed the previously selected, hidden command. The selection is now cleared.
  - Reopening the palette cleared the search field but retained the old filter. Both now reset together.

  Coverage includes WebGUI routing and parameter encoding, repeated form submissions, staging selection/filter precedence, keyboard navigation, and fuzzy matching. A shared VM loader keeps the test setup reusable without adding
  dependencies.

Adds test/ui/README.md documenting how to run and extend the tests, covered behaviors, regression expectations, and limitations of the DOM fixtures.