### PR TITLE
Fix HTML truncation with non-ASCII content in SAPGUI for Java

### DIFF
--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -202,10 +202,19 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
 
   METHOD cache_html.
 
-    rv_url = zif_abapgit_gui_services~cache_asset(
-      iv_text    = iv_text
-      iv_type    = 'text'
-      iv_subtype = 'html' ).
+    IF zcl_abapgit_ui_factory=>get_frontend_services( )->is_sapgui_for_java( ) = abap_true.
+      "Java GUI needs the UTF-8 payload length in bytes for non-ASCII HTML.
+      rv_url = zif_abapgit_gui_services~cache_asset(
+        iv_xdata   = zcl_abapgit_convert=>string_to_xstring_utf8( iv_text )
+        iv_type    = 'text'
+        iv_subtype = 'html' ).
+    ELSE.
+      "Keep the character-based HTML processing for WebGUI and Windows.
+      rv_url = zif_abapgit_gui_services~cache_asset(
+        iv_text    = iv_text
+        iv_type    = 'text'
+        iv_subtype = 'html' ).
+    ENDIF.
 
   ENDMETHOD.
 


### PR DESCRIPTION
HTML pages containing non-ASCII characters can be truncated in SAP GUI for Java because the transferred UTF-8 byte length exceeds the character-based size. This can cut off the final JavaScript block and prevent page initialization.

For example, a document containing 961,441 characters encoded as 961,542 UTF-8 bytes returned only 961,441 bytes, losing the final 101 bytes.

This change loads HTML as UTF-8 binary data for SAP GUI for  Java, using the encoded byte length. Windows and WebGUI retain the existing character-based loading path. WebGUI requires that path for SAP event-link conversion; applying binary loading there broke navigation.

fixes #7867