### PR TITLE
Fix palette title escaping and repository selection guards

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -520,14 +520,16 @@ RepoOverViewHelper.prototype.registerKeyboardShortcuts = function() {
 };
 
 RepoOverViewHelper.prototype.openSelectedRepo = function() {
-  this.selectedRepoKey = document.querySelector(".repo-overview tr.selected").dataset.key;
+  var selectedRow = document.querySelector(".repo-overview tr.selected");
+  if (!selectedRow) return;
+  this.selectedRepoKey = selectedRow.dataset.key;
   this.saveLocalStorage();
   document.querySelector(".repo-overview tr.selected td.ro-go a").click();
 };
 
 RepoOverViewHelper.prototype.selectRowByIndex = function(index) {
   var rows = this.getVisibleRows();
-  if (rows.length >= index) {
+  if (index >= 0 && index < rows.length) {
     var selectedRow = rows[index];
     if (selectedRow.classList.contains("selected")) {
       return;
@@ -544,6 +546,7 @@ RepoOverViewHelper.prototype.selectRowByIndex = function(index) {
 RepoOverViewHelper.prototype.selectRowByRepoKey = function(key) {
   var attributeQuery = "[data-key='" + key + "']";
   var row            = document.querySelector(".repo-overview tbody tr" + attributeQuery);
+  if (!row) return;
   // navigation to already selected repo
   if (row.dataset.key === key && row.classList.contains("selected")) {
     return;
@@ -2245,6 +2248,10 @@ function registerStagePatch() {
 // return non empty marked string in case it fits the filter
 // abc + b = a<mark>b</mark>c
 function fuzzyMatchAndMark(str, filter) {
+  function escapeText(text) {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
   var markedStr   = "";
   var filterLower = filter.toLowerCase();
   var strLower    = str.toLowerCase();
@@ -2252,15 +2259,15 @@ function fuzzyMatchAndMark(str, filter) {
 
   for (var i = 0; i < filter.length; i++) {
     while (filterLower[i] !== strLower[cur] && cur < str.length) {
-      markedStr += str[cur++];
+      markedStr += escapeText(str[cur++]);
     }
     if (cur === str.length) break;
-    markedStr += "<mark>" + str[cur++] + "</mark>";
+    markedStr += "<mark>" + escapeText(str[cur++]) + "</mark>";
   }
 
   var matched = i === filter.length;
 
-  if (matched && cur < str.length) markedStr += str.substring(cur);
+  if (matched && cur < str.length) markedStr += escapeText(str.substring(cur));
   return matched ? markedStr: null;
 }
 

--- a/test/ui/palette.test.cjs
+++ b/test/ui/palette.test.cjs
@@ -136,3 +136,23 @@ for (const [title, filter, expected] of [
     assert.equal(loadUi().fuzzyMatchAndMark(title, filter), expected);
   });
 }
+
+test("filtering escapes title markup while preserving generated highlights", () => {
+  const title = "Repo <img src=x onerror=alert(1)> & Docs";
+  const { palette, filter, key, actions } = page([title]);
+  filter("repo");
+  assert.equal(palette.commands[0].titleSpan.innerHTML,
+    "<mark>R</mark><mark>e</mark><mark>p</mark><mark>o</mark> &lt;img src=x onerror=alert(1)&gt; &amp; Docs");
+  key("Enter");
+  assert.deepEqual(actions, [title]);
+});
+
+test("matching special characters uses the original title, escaping every output segment", () => {
+  const { palette, filter } = page(["<A & B>"]);
+  filter("&");
+  assert.equal(palette.commands[0].titleSpan.innerHTML, "&lt;A <mark>&amp;</mark> B&gt;");
+  filter("<>");
+  assert.equal(palette.commands[0].titleSpan.innerHTML, "<mark>&lt;</mark>A &amp; B<mark>&gt;</mark>");
+  filter("");
+  assert.equal(palette.commands[0].titleSpan.innerText, "<A & B>");
+});

--- a/test/ui/repo-overview.test.cjs
+++ b/test/ui/repo-overview.test.cjs
@@ -1,0 +1,75 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const loadUi = require("./load-ui.cjs");
+
+function page(keys = []) {
+  const rows = keys.map(key => {
+    const classes = new Set();
+    return { dataset: { key }, classList: {
+      add(name) { classes.add(name); },
+      remove(name) { classes.delete(name); },
+      contains(name) { return classes.has(name); }
+    } };
+  });
+  const listeners = {};
+  const opened = [];
+  const saved = [];
+  const context = loadUi({ document: {
+    activeElement: { id: "", tagName: "BODY" },
+    addEventListener(name, handler) { listeners[name] = handler; },
+    querySelectorAll() { return rows; },
+    querySelector(selector) {
+      const selected = rows.find(row => row.classList.contains("selected"));
+      if (selector === ".repo-overview tr.selected") return selected || null;
+      if (selector === ".repo-overview tr.selected td.ro-go a") {
+        return selected ? { click() { opened.push(selected.dataset.key); } } : null;
+      }
+      const key = selector.match(/\[data-key='([^']+)'\]/);
+      assert.ok(key, selector);
+      return rows.find(row => row.dataset.key === key[1]) || null;
+    }
+  } });
+  // Exercise selection and keyboard handling without constructing toolbar DOM.
+  const helper = Object.create(context.RepoOverViewHelper.prototype);
+  helper.updateActionLinks = () => {};
+  helper.saveLocalStorage = () => saved.push(helper.selectedRepoKey);
+  helper.registerKeyboardShortcuts();
+  return { helper, rows, opened, saved, enter() { listeners.keypress({ keyCode: 13 }); } };
+}
+
+test("empty repository lists tolerate initial selection and Enter", () => {
+  const { helper, enter, opened, saved } = page();
+  helper.selectRowByIndex(0);
+  enter();
+  assert.deepEqual(opened, []);
+  assert.deepEqual(saved, []);
+});
+
+test("out-of-range indexes preserve the selected repository", () => {
+  const { helper, rows, saved } = page(["1", "2"]);
+  helper.selectRowByIndex(0);
+  for (const index of [-1, 2, 3]) helper.selectRowByIndex(index);
+  assert.equal(rows[0].classList.contains("selected"), true);
+  assert.equal(helper.selectedRepoKey, "1");
+  assert.deepEqual(saved, ["1"]);
+});
+
+test("Enter without selection does nothing; selecting the last row opens it", () => {
+  const { helper, enter, opened } = page(["1", "2"]);
+  enter();
+  assert.deepEqual(opened, []);
+  helper.selectRowByIndex(0);
+  helper.selectRowByIndex(1);
+  enter();
+  assert.deepEqual(opened, ["2"]);
+});
+
+test("restoring a removed repository key leaves the current selection intact", () => {
+  const { helper, saved } = page(["1"]);
+  helper.selectRowByRepoKey("missing");
+  assert.deepEqual(saved, []);
+  helper.selectRowByRepoKey("1");
+  helper.selectRowByRepoKey("missing");
+  assert.equal(helper.selectedRepoKey, "1");
+  assert.deepEqual(saved, ["1"]);
+});


### PR DESCRIPTION
Command palette filtering now escapes title text before adding match highlights, so characters such as <, > and & remain literal text.

Repository navigation now safely handles empty lists, out-of-range indexes, Enter without a selection, and restoring a saved selection for a removed repository.