### PR TITLE
Fix styling of radio options in HTML forms

### DIFF
--- a/src/ui/lib/zcl_abapgit_gui_picklist.clas.abap
+++ b/src/ui/lib/zcl_abapgit_gui_picklist.clas.abap
@@ -129,11 +129,13 @@ CLASS zcl_abapgit_gui_picklist IMPLEMENTATION.
 
     ro_form = zcl_abapgit_html_form=>create( ).
 
+    ASSIGN mr_list->* TO <lt_list>.
+
     ro_form->radio(
       iv_name     = c_radio_name
-      iv_label    = mv_title ).
+      iv_label    = mv_title
+      iv_condense = boolc( lines( <lt_list> ) <= 15 ) ).
 
-    ASSIGN mr_list->* TO <lt_list>.
     LOOP AT <lt_list> ASSIGNING <ls_row>.
       lv_index = sy-tabix.
 

--- a/src/ui/lib/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/lib/zcl_abapgit_html_form.clas.abap
@@ -817,7 +817,11 @@ CLASS zcl_abapgit_html_form IMPLEMENTATION.
       ii_html->add( is_attr-error ).
     ENDIF.
 
-    ii_html->add( |<div class="radio-container">| ).
+    IF is_field-condense = abap_true.
+      ii_html->add( |<div class="radio-container">| ).
+    ELSE.
+      ii_html->add( |<div class="radio-container with-border">| ).
+    ENDIF.
 
     LOOP AT is_field-subitems ASSIGNING <ls_opt>.
 

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1489,8 +1489,16 @@ table.unit_tests {
   border-radius: 2px;
   display: inline-block;
 }
+.dialog .radio-container.with-border input[type="radio"] + label {
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  margin-bottom: 2px;
+}
 .dialog .radio-container input[type="radio"]:checked + label {
   border: 1px solid transparent;
+}
+.dialog .radio-container label:hover {
+  background-color: rgba(0, 0, 0, 0.1);
 }
 .dialog table {
   width: 100%;
@@ -1643,16 +1651,6 @@ table.unit_tests {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.3);
-}
-
-.modal .radio-container label {
-  /* hacky, improve later, get rid of !important, hook it to a named style instead */
-  border-radius: 3px !important;
-  border: 1px solid rgba(0, 0, 0, 0.3) !important;
-  margin-bottom: 2px !important;
-}
-.modal .radio-container label:hover {
-  background-color: rgba(0, 0, 0, 0.1);
 }
 
 /* WHERE USED PAGE */


### PR DESCRIPTION
- Up to 15 options will show in single column, more will show side-by-side
- Fixed options border and hover effect
- Replaced "hacky" CSS

Short list:

<img width="663" height="361" alt="image" src="https://github.com/user-attachments/assets/e281b0e3-f8c6-4a93-b4ee-e6b0c2c4dee3" />

Long list:

<img width="662" height="309" alt="image" src="https://github.com/user-attachments/assets/18058fd4-967f-4ed3-9a13-9185bfdf9c1c" />
