### PR TITLE
Prevent diff filter clicks from triggering browser Back

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1115,6 +1115,9 @@ CheckListWrapper.prototype.onClick = function(e) {
   var option   = nodeA.innerText;
   var oldState = nodeLi.getAttribute("data-check");
   if (oldState === null) return; // no data-check attribute - non-checkbox
+  // These links only toggle a filter. Following href="#" would emit a
+  // popstate which the browser-back trap interprets as a request to go back.
+  e.preventDefault();
   var newState = oldState !== "X";
 
   if (newState) {

--- a/test/ui/checklist.test.cjs
+++ b/test/ui/checklist.test.cjs
@@ -1,0 +1,67 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const loadUi = require("./load-ui.cjs");
+
+function page({ option = "abap", checked = "X", aux = "extension" } = {}) {
+  const listeners = {};
+  const menu = {};
+  const classes = new Set(["icon", "icon-check", checked === "X" ? "blue" : "grey"]);
+  const icon = { tagName: "I", classList: {
+    contains(name) { return classes.has(name); },
+    add(name) { classes.add(name); }, remove(name) { classes.delete(name); }
+  } };
+  const attrs = { "data-check": checked, "data-aux": aux };
+  const li = { tagName: "LI", getAttribute(name) { return attrs[name] ?? null; },
+    setAttribute(name, value) { attrs[name] = value; } };
+  const anchor = { tagName: "A", parentNode: li, children: [icon], innerText: option };
+  icon.parentNode = anchor;
+  const context = loadUi({ document: { addEventListener() {}, getElementById() { return menu; } },
+    history: { pushState() {} }, addEventListener(name, fn) { listeners[name] = fn; } });
+  const calls = [];
+  let backs = 0;
+  context.redirectBrowserBackToSapEvent();
+  context.triggerSapEventBack = () => backs++;
+  new context.CheckListWrapper("diff-filter",
+    (...args) => calls.push(["filter", ...args]), (...args) => calls.push(["mine", ...args]));
+  function click(target, legacy = false) {
+    const event = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+    event[legacy ? "srcElement" : "target"] = target;
+    menu.onclick(event);
+    // Model the default fragment navigation after bubbling. A cancelled click
+    // must never reach the same popstate listener used for genuine Back.
+    if (!event.defaultPrevented) listeners.popstate();
+    return event.defaultPrevented;
+  }
+  return { anchor, icon, li, calls, classes, click, back() { listeners.popstate(); }, get backs() { return backs; } };
+}
+
+for (const target of ["anchor", "icon"]) {
+  for (const legacy of [false, true]) {
+    test(`filter ${target} click cancels navigation and toggles both ways (${legacy ? "srcElement" : "target"})`, () => {
+      const p = page();
+      assert.equal(p.click(p[target], legacy), true);
+      assert.equal(p.li.getAttribute("data-check"), "");
+      assert.equal(p.classes.has("grey"), true);
+      assert.equal(p.click(p[target], legacy), true);
+      assert.equal(p.li.getAttribute("data-check"), "X");
+      assert.equal(p.classes.has("blue"), true);
+      assert.deepEqual(p.calls, [["filter", "extension", "abap", false], ["filter", "extension", "abap", true]]);
+      assert.equal(p.backs, 0);
+      p.back();
+      assert.equal(p.backs, 1);
+    });
+  }
+}
+
+test("Only my changes cancels navigation and dispatches its own callback", () => {
+  const p = page({ option: "Only my changes", checked: "", aux: "DEVELOPER" });
+  assert.equal(p.click(p.icon), true);
+  assert.deepEqual(p.calls, [["mine", "DEVELOPER", true]]);
+  assert.equal(p.backs, 0);
+});
+
+test("ordinary links without a checkbox retain their default navigation", () => {
+  const p = page({ checked: null });
+  assert.equal(p.click(p.anchor), false);
+  assert.deepEqual(p.calls, []);
+});


### PR DESCRIPTION
Diff filter links use href="#" but did not cancel the default navigation.
The resulting popstate was interpreted as browser Back and triggered go_back, returning the user to the previous page.

This regression was introduced on 23 July 2026 by
a51687c22ebadc0101d1c9beb6d78c789c1c43ad
(Enable browser back navigation in SAPGUI + WebGui, #7782). The missing cancellation predates that commit, but its browser-back trap turned the fragment navigation into an unintended SAP back action.

Cancel default navigation for checklist filter clicks. Add regression coverage for link and icon clicks, legacy srcElement events, Only my changes, and preservation of genuine Back navigation.